### PR TITLE
explicit error message on unmapped pair

### DIFF
--- a/cryptofeed/standards.py
+++ b/cryptofeed/standards.py
@@ -2348,7 +2348,13 @@ _exchange_to_std = {
 
 def pair_std_to_exchange(pair, exchange):
     if pair in _std_trading_pairs:
-        return _std_trading_pairs[pair][exchange]
+        try:
+            return _std_trading_pairs[pair][exchange]
+        except KeyError as e:
+            raise KeyError("{} is not configured/availble for {}".format(
+                pair,
+                exchange
+            ))
     else:
         return None
 


### PR DESCRIPTION
Hi, while trying to use your lib I hit the following exception:

```
Traceback (most recent call last):
....
    return _std_trading_pairs[pair][exchange]
KeyError: 'BITFINEX'
```

Even though I was using only pairs pulled from:  https://api.bitfinex.com/v1/symbols"

So I modified the code a bit to figure out which pair was causing the problem. 

The pairs:
    #- [fun,usd]
    #- [fun,btc]
    #- [fun,eth]
    #- [zrx,usd]
    #- [zrx,btc]
    #- [zrx,eth]

Cheers