### PR TITLE
Fixing issue with bitstamp order book message parsing

### DIFF
--- a/cryptofeed/bitstamp/bitstamp.py
+++ b/cryptofeed/bitstamp/bitstamp.py
@@ -43,7 +43,7 @@ class Bitstamp(Feed):
 
         book = {}
         for side in (BID, ASK):
-            book[side] = sd({price: size for price, size in data[side+'s']})
+            book[side] = sd({Decimal(price): Decimal(size) for price, size in data[side+'s']})
         await self.callbacks[L2_BOOK](feed=self.id, pair=pair, book=book, timestamp=timestamp)
 
     async def _trades(self, msg):


### PR DESCRIPTION
I think we need to convert price and size strings in order book messages to Decimal objects