### PR TITLE
#60 Fix system crash if Bitstamp not available

### DIFF
--- a/cryptofeed/bitstamp/pairs.py
+++ b/cryptofeed/bitstamp/pairs.py
@@ -5,7 +5,9 @@ Please see the LICENSE file for the terms and conditions
 associated with this software.
 '''
 import requests
+import logging
 
+LOG = logging.getLogger('bitstamp.pairs')
 
 def gen_pairs():
     ret = {}
@@ -16,5 +18,8 @@ def gen_pairs():
         ret[normalized] = pair
     return ret
 
-
-bitstamp_pair_mapping = gen_pairs()
+try:
+    bitstamp_pair_mapping = gen_pairs()
+except:
+    LOG.exception("Unable to get pairs from Bitstamp")
+    bitstamp_pair_mapping = None

--- a/cryptofeed/standards.py
+++ b/cryptofeed/standards.py
@@ -45,12 +45,15 @@ mappings = {
 }
 
 for exchange, mapping in mappings.items():
-    for std, exch in mapping.items():
-        _exchange_to_std[exch] = std
-        if std in _std_trading_pairs:
-            _std_trading_pairs[std][exchange] = exch
-        else:
-            _std_trading_pairs[std] = {exchange: exch}
+    if mapping:
+        for std, exch in mapping.items():
+            _exchange_to_std[exch] = std
+            if std in _std_trading_pairs:
+                _std_trading_pairs[std][exchange] = exch
+            else:
+                _std_trading_pairs[std] = {exchange: exch}
+    else:
+        LOG.warning("No mapping for {}".format(exchange))
 
 
 def pair_std_to_exchange(pair, exchange):


### PR DESCRIPTION
This PR to address the problem when app crashes when Bitstamp is not available (e.g. banned by provider).
Please review. Probably it's not good idea to patch for Bitstamp only.