### PR TITLE
In trades replace BID / ASK with BUY / SELL.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 ## Changelog
 
+### 0.20.1 (2019-02-10)
+  * Feature: Trades sides are now labeled as Buy / Sell instead of Bid / Ask.
+
 ### 0.20.0 (2019-02-04)
   * Feature #57: Write updates directly to MongoDB via new backend support
   * Feature #56: Experimental support for fine grained configuration per exchange

--- a/cryptofeed/binance/binance.py
+++ b/cryptofeed/binance/binance.py
@@ -12,7 +12,7 @@ import time
 from sortedcontainers import SortedDict as sd
 
 from cryptofeed.feed import Feed
-from cryptofeed.defines import TICKER, TRADES, BUY, SELL, BID, ASK, L2_BOOK, UND, BINANCE
+from cryptofeed.defines import TICKER, TRADES, BUY, SELL, BID, ASK, L2_BOOK, BINANCE
 from cryptofeed.standards import pair_exchange_to_std
 
 

--- a/cryptofeed/binance/binance.py
+++ b/cryptofeed/binance/binance.py
@@ -12,7 +12,7 @@ import time
 from sortedcontainers import SortedDict as sd
 
 from cryptofeed.feed import Feed
-from cryptofeed.defines import TICKER, TRADES, BID, ASK, L2_BOOK, UND, BINANCE
+from cryptofeed.defines import TICKER, TRADES, BUY, SELL, BID, ASK, L2_BOOK, UND, BINANCE
 from cryptofeed.standards import pair_exchange_to_std
 
 
@@ -60,7 +60,7 @@ class Binance(Feed):
         await self.callbacks[TRADES](feed=self.id,
                                      order_id=msg['t'],
                                      pair=pair_exchange_to_std(msg['s']),
-                                     side=UND,
+                                     side=SELL if msg['m'] else BUY,
                                      amount=amount,
                                      price=price,
                                      timestamp=msg['E'])

--- a/cryptofeed/bitfinex/bitfinex.py
+++ b/cryptofeed/bitfinex/bitfinex.py
@@ -14,7 +14,7 @@ from sortedcontainers import SortedDict as sd
 
 from cryptofeed.exceptions import MissingSequenceNumber
 from cryptofeed.feed import Feed
-from cryptofeed.defines import TICKER, TRADES, L3_BOOK, BID, ASK, L2_BOOK, FUNDING, DEL, UPD, BITFINEX
+from cryptofeed.defines import TICKER, TRADES, L3_BOOK, BUY, SELL, BID, ASK, L2_BOOK, FUNDING, DEL, UPD, BITFINEX
 from cryptofeed.standards import pair_exchange_to_std
 
 
@@ -85,10 +85,7 @@ class Bitfinex(Feed):
             else:
                 order_id, timestamp, amount, price = trade
                 period = None
-            if amount < 0:
-                side = ASK
-            else:
-                side = BID
+            side = SELL if amount < 0 else BUY
             amount = abs(amount)
             if period:
                 await self.callbacks[FUNDING](feed=self.id,

--- a/cryptofeed/bitmex/bitmex.py
+++ b/cryptofeed/bitmex/bitmex.py
@@ -14,7 +14,7 @@ import requests
 from sortedcontainers import SortedDict as sd
 
 from cryptofeed.feed import Feed
-from cryptofeed.defines import L2_BOOK, BID, ASK, TRADES, UPD, DEL, FUNDING, L3_BOOK, BITMEX
+from cryptofeed.defines import L2_BOOK, BUY, SELL, BID, ASK, TRADES, UPD, DEL, FUNDING, L3_BOOK, BITMEX
 
 
 LOG = logging.getLogger('feedhandler')
@@ -76,7 +76,7 @@ class Bitmex(Feed):
         for data in msg['data']:
             await self.callbacks[TRADES](feed=self.id,
                                          pair=data['symbol'],
-                                         side=BID if data['side'] == 'Buy' else ASK,
+                                         side=BUY if data['side'] == 'Buy' else SELL,
                                          amount=Decimal(data['size']),
                                          price=Decimal(data['price']),
                                          order_id=data['trdMatchID'],

--- a/cryptofeed/bitstamp/bitstamp.py
+++ b/cryptofeed/bitstamp/bitstamp.py
@@ -11,7 +11,7 @@ from decimal import Decimal
 from sortedcontainers import SortedDict as sd
 
 from cryptofeed.feed import Feed
-from cryptofeed.defines import BID, ASK, TRADES, L2_BOOK, BITSTAMP
+from cryptofeed.defines import BUY, SELL, BID, ASK, TRADES, L2_BOOK, BITSTAMP
 from cryptofeed.standards import pair_exchange_to_std
 
 
@@ -54,7 +54,7 @@ class Bitstamp(Feed):
         else:
             pair = pair_exchange_to_std(chan.split('_')[-1])
 
-        side = BID if data['type'] == 0 else ASK
+        side = BUY if data['type'] == 0 else SELL
         amount = Decimal(data['amount'])
         price = Decimal(data['price'])
         timestamp = data['timestamp']

--- a/cryptofeed/coinbase/coinbase.py
+++ b/cryptofeed/coinbase/coinbase.py
@@ -15,7 +15,7 @@ import requests
 from sortedcontainers import SortedDict as sd
 
 from cryptofeed.feed import Feed
-from cryptofeed.defines import L2_BOOK, L3_BOOK, BID, ASK, TRADES, TICKER, DEL, UPD, COINBASE
+from cryptofeed.defines import L2_BOOK, L3_BOOK, BUY, SELL, BID, ASK, TRADES, TICKER, DEL, UPD, COINBASE
 
 
 LOG = logging.getLogger('feedhandler')
@@ -117,7 +117,7 @@ class Coinbase(Feed):
             feed=self.id,
             pair=msg['product_id'],
             order_id=msg['trade_id'],
-            side=BID if msg['side'] == 'buy' else ASK,
+            side=BUY if msg['side'] == 'buy' else SELL,
             amount=Decimal(msg['size']),
             price=Decimal(msg['price']),
             timestamp=msg['time']

--- a/cryptofeed/defines.py
+++ b/cryptofeed/defines.py
@@ -29,6 +29,9 @@ VOLUME = 'volume'
 FUNDING = 'funding'
 UNSUPPORTED = 'unsupported'
 
+BUY = 'buy'
+SELL = 'sell'
+
 BID = 'bid'
 ASK = 'ask'
 UND = 'undefined'

--- a/cryptofeed/exx/exx.py
+++ b/cryptofeed/exx/exx.py
@@ -13,7 +13,7 @@ from sortedcontainers import SortedDict as sd
 from cryptofeed.feed import Feed
 from cryptofeed.standards import pair_exchange_to_std
 from cryptofeed.defines import EXX as EXX_id
-from cryptofeed.defines import L2_BOOK, BID, ASK, TRADES
+from cryptofeed.defines import L2_BOOK, BUY, SELL, BID, ASK, TRADES
 
 
 LOG = logging.getLogger('feedhandler')
@@ -123,7 +123,7 @@ class EXX(Feed):
         """
         timestamp = msg[2]
         pair = pair_exchange_to_std(msg[3])
-        side = msg[4]
+        side = BUY if msg[4] == 'bid' else SELL
         price = Decimal(msg[5])
         amount = Decimal(msg[6])
         trade_id = msg[7]

--- a/cryptofeed/gemini/gemini.py
+++ b/cryptofeed/gemini/gemini.py
@@ -11,7 +11,7 @@ from decimal import Decimal
 from sortedcontainers import SortedDict as sd
 
 from cryptofeed.feed import Feed
-from cryptofeed.defines import L2_BOOK, BID, ASK, TRADES, UPD, DEL, GEMINI
+from cryptofeed.defines import L2_BOOK, BUY, SELL, BID, ASK, TRADES, UPD, DEL, GEMINI
 from cryptofeed.standards import pair_std_to_exchange
 from cryptofeed.exceptions import MissingSequenceNumber
 
@@ -60,7 +60,7 @@ class Gemini(Feed):
 
     async def _trade(self, msg, timestamp):
         price = Decimal(msg['price'])
-        side = BID if msg['makerSide'] == 'bid' else ASK
+        side = BUY if msg['makerSide'] == 'bid' else SELL
         amount = Decimal(msg['amount'])
         await self.callbacks[TRADES](feed=self.id,
                                      order_id=msg['tid'],

--- a/cryptofeed/hitbtc/hitbtc.py
+++ b/cryptofeed/hitbtc/hitbtc.py
@@ -13,7 +13,7 @@ import time
 from sortedcontainers import SortedDict as sd
 
 from cryptofeed.feed import Feed
-from cryptofeed.defines import TICKER, L2_BOOK, TRADES, BID, ASK, UPD, DEL, HITBTC
+from cryptofeed.defines import TICKER, L2_BOOK, TRADES, BUY, SELL, BID, ASK, UPD, DEL, HITBTC
 from cryptofeed.standards import pair_exchange_to_std
 
 
@@ -68,7 +68,7 @@ class HitBTC(Feed):
         for update in msg['data']:
             price = Decimal(update['price'])
             quantity = Decimal(update['quantity'])
-            side = update['side']
+            side = BUY if update['side'] == 'buy' else SELL
             order_id = update['id']
             timestamp = update['timestamp']
             await self.callbacks[TRADES](feed=self.id,

--- a/cryptofeed/kraken/_kraken.py
+++ b/cryptofeed/kraken/_kraken.py
@@ -21,7 +21,7 @@ import time
 from sortedcontainers import SortedDict as sd
 
 from cryptofeed.feed import RestFeed
-from cryptofeed.defines import TRADES, BID, ASK, TICKER, L2_BOOK, KRAKEN
+from cryptofeed.defines import TRADES, BUY, SELL, BID, ASK, TICKER, L2_BOOK, KRAKEN
 from cryptofeed.standards import pair_exchange_to_std
 
 import aiohttp
@@ -53,7 +53,7 @@ class Kraken(RestFeed):
                         price, amount, timestamp, side, _, _ = trade
                         await self.callbacks[TRADES](feed=self.id,
                                                      pair=pair_exchange_to_std(pair),
-                                                     side=BID if side == 'b' else ASK,
+                                                     side=BUY if side == 'b' else SELL,
                                                      amount=Decimal(amount),
                                                      price=Decimal(price),
                                                      order_id=None,

--- a/cryptofeed/kraken/kraken.py
+++ b/cryptofeed/kraken/kraken.py
@@ -6,7 +6,7 @@ import time
 from sortedcontainers import SortedDict as sd
 
 from cryptofeed.feed import Feed
-from cryptofeed.defines import TRADES, BID, ASK, TICKER, L2_BOOK, KRAKEN
+from cryptofeed.defines import TRADES, BUY, SELL, BID, ASK, TICKER, L2_BOOK, KRAKEN
 from cryptofeed.standards import pair_exchange_to_std
 
 
@@ -51,7 +51,7 @@ class Kraken(Feed):
             price, amount, timestamp, side, _, _ = trade
             await self.callbacks[TRADES](feed=self.id,
                                         pair=pair,
-                                        side=BID if side == 'b' else ASK,
+                                        side=BUY if side == 'b' else SELL,
                                         amount=Decimal(amount),
                                         price=Decimal(price),
                                         order_id=None,

--- a/cryptofeed/poloniex/poloniex.py
+++ b/cryptofeed/poloniex/poloniex.py
@@ -14,7 +14,7 @@ from sortedcontainers import SortedDict as sd
 
 from cryptofeed.exceptions import MissingSequenceNumber
 from cryptofeed.feed import Feed
-from cryptofeed.defines import BID, ASK, TRADES, TICKER, L2_BOOK, VOLUME, UPD, DEL, POLONIEX
+from cryptofeed.defines import BUY, SELL, BID, ASK, TRADES, TICKER, L2_BOOK, VOLUME, UPD, DEL, POLONIEX
 from cryptofeed.standards import pair_exchange_to_std
 from cryptofeed.pairs import poloniex_id_pair_mapping
 
@@ -104,7 +104,7 @@ class Poloniex(Feed):
                     _, order_id, _, price, amount, timestamp = update
                     price = Decimal(price)
                     amount = Decimal(amount)
-                    side = ASK if update[2] == 0 else BID
+                    side = BUY if update[2] == 1 else SELL
                     await self.callbacks[TRADES](feed=self.id,
                                                  pair=pair,
                                                  side=side,


### PR DESCRIPTION
Primarily semantics changes, but I feel like trades side should either be BUY or SELL instead of BID / ASK, which is used when describing the order book. 
Also, side on Binance can be had from side if buyer is maker.