### PR TITLE
Trade side update

### DIFF
--- a/cryptofeed/coinbase/coinbase.py
+++ b/cryptofeed/coinbase/coinbase.py
@@ -117,7 +117,7 @@ class Coinbase(Feed):
             feed=self.id,
             pair=msg['product_id'],
             order_id=msg['trade_id'],
-            side=BUY if msg['side'] == 'buy' else SELL,
+            side=SELL if msg['side'] == 'buy' else BUY,
             amount=Decimal(msg['size']),
             price=Decimal(msg['price']),
             timestamp=msg['time']

--- a/cryptofeed/gemini/gemini.py
+++ b/cryptofeed/gemini/gemini.py
@@ -60,7 +60,7 @@ class Gemini(Feed):
 
     async def _trade(self, msg, timestamp):
         price = Decimal(msg['price'])
-        side = SELL if msg['makerSide'] == 'bid' else BUY:
+        side = SELL if msg['makerSide'] == 'bid' else BUY
         amount = Decimal(msg['amount'])
         await self.callbacks[TRADES](feed=self.id,
                                      order_id=msg['tid'],

--- a/cryptofeed/gemini/gemini.py
+++ b/cryptofeed/gemini/gemini.py
@@ -60,7 +60,7 @@ class Gemini(Feed):
 
     async def _trade(self, msg, timestamp):
         price = Decimal(msg['price'])
-        side = BUY if msg['makerSide'] == 'bid' else SELL
+        side = SELL if msg['makerSide'] == 'bid' else BUY:
         amount = Decimal(msg['amount'])
         await self.callbacks[TRADES](feed=self.id,
                                      order_id=msg['tid'],

--- a/cryptofeed/rest/bitfinex.py
+++ b/cryptofeed/rest/bitfinex.py
@@ -11,7 +11,7 @@ import pandas as pd
 import requests
 
 from cryptofeed.rest.api import API, request_retry
-from cryptofeed.defines import BITFINEX
+from cryptofeed.defines import BITFINEX, SELL, BUY
 from cryptofeed.standards import pair_std_to_exchange, pair_exchange_to_std
 
 
@@ -53,7 +53,7 @@ class Bitfinex(API):
             'pair': pair_exchange_to_std(symbol),
             'id': trade_id,
             'feed': 'BITFINEX',
-            'side': 'Sell' if amount < 0 else 'Buy',
+            'side': SELL if amount < 0 else BUY,
             'amount': abs(amount),
             'price': price,
         }

--- a/cryptofeed/rest/bitmex.py
+++ b/cryptofeed/rest/bitmex.py
@@ -9,7 +9,7 @@ import requests
 import pandas as pd
 
 from cryptofeed.rest.api import API, request_retry
-from cryptofeed.defines import BITMEX
+from cryptofeed.defines import BITMEX, SELL, BUY
 
 
 API_MAX = 500
@@ -105,7 +105,7 @@ class Bitmex(API):
             'pair': trade['symbol'],
             'id': trade['trdMatchID'],
             'feed': self.ID,
-            'side': trade['side'],
+            'side': BUY if trade['side'] == 'Buy' else SELL,
             'amount': trade['size'],
             'price': trade['price']
         }

--- a/cryptofeed/rest/coinbase.py
+++ b/cryptofeed/rest/coinbase.py
@@ -11,7 +11,7 @@ import logging
 import pandas as pd
 
 from cryptofeed.rest.api import API
-from cryptofeed.defines import COINBASE
+from cryptofeed.defines import COINBASE, BUY, SELL
 from cryptofeed.standards import pair_std_to_exchange
 
 
@@ -362,7 +362,7 @@ class Coinbase(API):
             'timestamp': trade['created_at'],
             'pair': trade['product_id'],
             'feed': self.ID,
-            'side': trade['side'],
+            'side': BUY if trade['side'] == 'sell' else SELL,
             'amount': trade['size'],
             "settled": trade["settled"]
         }

--- a/cryptofeed/rest/kraken.py
+++ b/cryptofeed/rest/kraken.py
@@ -10,7 +10,7 @@ import calendar
 import pandas as pd
 
 from cryptofeed.rest.api import API, request_retry
-from cryptofeed.defines import KRAKEN, BID, ASK
+from cryptofeed.defines import KRAKEN, SELL, BUY
 from cryptofeed.standards import pair_std_to_exchange
 
 
@@ -157,7 +157,7 @@ class Kraken(API):
             'pair': symbol,
             'id': None,
             'feed': self.ID,
-            'side': ASK if trade[3] == 's' else BID,
+            'side': SELL if trade[3] == 's' else BUY,
             'amount': trade[1],
             'price': trade[0]
         }

--- a/cryptofeed/rest/poloniex.py
+++ b/cryptofeed/rest/poloniex.py
@@ -10,7 +10,7 @@ import logging
 import pandas as pd
 
 from cryptofeed.rest.api import API, request_retry
-from cryptofeed.defines import POLONIEX
+from cryptofeed.defines import POLONIEX, BUY, SELL
 from cryptofeed.standards import pair_std_to_exchange, pair_exchange_to_std
 
 
@@ -73,7 +73,7 @@ class Poloniex(API):
             'pair': pair_exchange_to_std(symbol),
             'id': trade['tradeID'],
             'feed': self.ID,
-            'side': trade['type'],
+            'side': BUY if trade['type'] == 'buy' else SELL,
             'amount': Decimal(trade['amount']),
             'price': Decimal(trade['rate'])
         }

--- a/tests/integration/rest/test_rest.py
+++ b/tests/integration/rest/test_rest.py
@@ -1,4 +1,5 @@
 from cryptofeed.rest import Rest
+from cryptofeed.defines import BUY, SELL
 
 
 def test_rest_bitmex():
@@ -6,7 +7,7 @@ def test_rest_bitmex():
                 'pair': 'XBTUSD',
                 'id': '58db4844-82b2-40e9-de90-c4d1672af7cc',
                 'feed': 'BITMEX',
-                'side': 'Sell',
+                'side': SELL,
                 'amount': 265,
                 'price': 6620}
 
@@ -24,7 +25,7 @@ def test_rest_bitfinex():
                 'pair': 'BTC-USD',
                 'id': 25291508,
                 'feed': 'BITFINEX',
-                'side': 'Sell',
+                'side': SELL,
                 'amount': 1.65,
                 'price': 966.61}
     r = Rest()


### PR DESCRIPTION
Some exchanges report trade side based on the maker order, others based on the taker's order. This PR ensures all exchanges report the trade side based on the taker. (Some exchanges even use maker for WS and taker for REST!)