### PR TITLE
Handle binance None pair

### DIFF
--- a/cryptofeed/binance/binance.py
+++ b/cryptofeed/binance/binance.py
@@ -31,9 +31,10 @@ class Binance(Feed):
         address = "wss://stream.binance.com:9443/stream?streams="
         for chan in self.channels if not self.config else self.config:
             for pair in self.pairs if not self.config else self.config[chan]:
-                pair = pair.lower()
-                stream = f"{pair}@{chan}/"
-                address += stream
+                if pair:
+                    pair = pair.lower()
+                    stream = f"{pair}@{chan}/"
+                    address += stream
         return address[:-1]
 
     def __reset(self):


### PR DESCRIPTION
Fix exception raised on binance when a symbol specified in channel is not found.  

 File "/home/werdor/.local/lib/python3.7/site-packages/cryptofeed/binance/binance.py", line 27, in __init__
    self.address = self.__address()
  File "/home/werdor/.local/lib/python3.7/site-packages/cryptofeed/binance/binance.py", line 34, in __address
    pair = pair.lower()
NoneType: None
2019-04-10 00:09:26 ERROR  root                 start.py:49       <class 'AttributeError'>: 'NoneType' object has no attribute 'lower'
NoneType: None