### PR TITLE
Rewrite book delta demo using DeltaBook class.

### DIFF
--- a/examples/demo_book_delta.py
+++ b/examples/demo_book_delta.py
@@ -12,77 +12,76 @@ from cryptofeed.exchanges import Bitmex, Coinbase, Bitfinex, Gemini, HitBTC, Pol
 from cryptofeed.defines import L2_BOOK, L3_BOOK, BID, ASK, BOOK_DELTA
 
 
-BOOK = None
+class DeltaBook(object):
+    def __init__(self, name):
+        self.book = None
+        self.name = name
+        self.L2 = {L2_BOOK: BookCallback(self.handle_book),
+                   BOOK_DELTA: BookUpdateCallback(self.handle_l2_delta)}
+        self.L3 = {L3_BOOK: BookCallback(self.handle_book),
+                   BOOK_DELTA: BookUpdateCallback(self.handle_l3_delta)}
 
-
-def check_books(master, delta):
-    """
-    check that master is equal to delta
-    """
-    for side in (BID, ASK):
-        if len(master[side]) != len(delta[side]):
-            return False
-
-        for price in master[side]:
-            if price not in delta[side]:
+    def check_books(self, master):
+        """Check that master is equal to self.book."""
+        for side in (BID, ASK):
+            if len(master[side]) != len(self.book[side]):
                 return False
 
-        for price in delta[side]:
-            if price not in master[side]:
-                return False
-    return True
+            for price in master[side]:
+                if price not in self.book[side]:
+                    return False
 
+            for price in self.book[side]:
+                if price not in master[side]:
+                    return False
+        return True
 
-async def book(feed, pair, book, timestamp):
-    global BOOK
-    if not BOOK:
-        BOOK = deepcopy(book)
-        print("Book Set")
-    else:
-        assert(check_books(book, BOOK))
-        print("Books match!")
+    async def handle_book(self, feed, pair, book, timestamp):
+        """Handle full book updates."""
+        if not self.book:
+            self.book = deepcopy(book)
+            print("%s: Book Set" % self.name)
+        else:
+            assert(self.check_books(book))
+            print("%s: Books match!" % self.name)
 
-
-async def delta(feed, pair, update, timestamp):
-    # handle updates for L2 books
-    global BOOK
-    for side in (BID, ASK):
-        for price, size in update[side]:
-            if size == 0:
-                del BOOK[side][price]
-            else:
-                BOOK[side][price] = size
-
-
-async def l3_delta(feed, pair, update, timestamp):
-    global BOOK
-    for side in (BID, ASK):
-        for order, price, size in update[side]:
-            if size == 0:
-                del BOOK[side][price][order]
-                if len(BOOK[side][price]) == 0:
-                    del BOOK[side][price]
-            else:
-                if price in BOOK[side]:
-                    BOOK[side][price][order] = size
+    async def handle_l2_delta(self, feed, pair, update, timestamp):
+        """Handle L2 delta updates."""
+        # handle updates for L2 books
+        for side in (BID, ASK):
+            for price, size in update[side]:
+                if size == 0:
+                    del self.book[side][price]
                 else:
-                    BOOK[side][price] = {order: size}
+                    self.book[side][price] = size
+
+    async def handle_l3_delta(self, feed, pair, update, timestamp):
+        """Handle L3 delta updates."""
+        for side in (BID, ASK):
+            for order, price, size in update[side]:
+                if size == 0:
+                    del self.book[side][price][order]
+                    if len(self.book[side][price]) == 0:
+                        del self.book[side][price]
+                else:
+                    if price in self.book[side]:
+                        self.book[side][price][order] = size
+                    else:
+                        self.book[side][price] = {order: size}
 
 
 def main():
     f = FeedHandler()
-    # due to the way the test verification works, you can only run one for the test
-    #f.add_feed(Bitmex(pairs=['XBTUSD'], channels=[L3_BOOK], callbacks={L3_BOOK: BookCallback(book), BOOK_DELTA: BookUpdateCallback(l3_delta)}))
-    # f.add_feed(Bitfinex(pairs=['BTC-USD'], channels=[L3_BOOK], callbacks={L3_BOOK: BookCallback(book), BOOK_DELTA: BookUpdateCallback(l3_delta)}))
-    # f.add_feed(Bitfinex(pairs=['BTC-USD'], channels=[L2_BOOK], callbacks={L2_BOOK: BookCallback(book), BOOK_DELTA: BookUpdateCallback(delta)}))
-    # f.add_feed(Coinbase(pairs=['BTC-USD'], channels=[L3_BOOK], callbacks={L3_BOOK: BookCallback(book), BOOK_DELTA: BookUpdateCallback(l3_delta)}))
-    # f.add_feed(Coinbase(pairs=['BTC-USD'], channels=[L2_BOOK], callbacks={L2_BOOK: BookCallback(book), BOOK_DELTA: BookUpdateCallback(delta)}))
-    # f.add_feed(Gemini(book_interval=100, pairs=['BTC-USD'], callbacks={L2_BOOK: BookCallback(book), BOOK_DELTA: BookUpdateCallback(delta)}))
-    # f.add_feed(HitBTC(book_interval=100, pairs=['BTC-USD'], channels=[L2_BOOK], callbacks={L2_BOOK: BookCallback(book), BOOK_DELTA: BookUpdateCallback(delta)}))
-    # f.add_feed(Poloniex(book_interval=100, channels=['BTC-USDT'], callbacks={L2_BOOK: BookCallback(book), BOOK_DELTA: BookUpdateCallback(delta)}))
-    # f.add_feed(Kraken(book_interval=100, pairs=['BTC-USD'], channels=[L2_BOOK], callbacks={L2_BOOK: BookCallback(book), BOOK_DELTA: BookUpdateCallback(delta)}))
-    f.add_feed(OKCoin(book_interval=100, pairs=['BTC-USD'], channels=[L2_BOOK], callbacks={L2_BOOK: BookCallback(book), BOOK_DELTA: BookUpdateCallback(delta)}))
-
+    f.add_feed(Bitmex(pairs=['XBTUSD'], channels=[L3_BOOK], callbacks=DeltaBook("Bitmex").L3))
+    f.add_feed(Bitfinex(pairs=['BTC-USD'], channels=[L3_BOOK], callbacks=DeltaBook("Bitfinex-L3").L3))
+    f.add_feed(Bitfinex(pairs=['BTC-USD'], channels=[L2_BOOK], callbacks=DeltaBook("Bitfinex-L2").L2))
+    f.add_feed(Coinbase(pairs=['BTC-USD'], channels=[L3_BOOK], callbacks=DeltaBook("Coinbase-L3").L3))
+    f.add_feed(Coinbase(pairs=['BTC-USD'], channels=[L2_BOOK], callbacks=DeltaBook("Coinbase-L2").L2))
+    f.add_feed(Gemini(book_interval=100, pairs=['BTC-USD'], callbacks=DeltaBook("Gemini").L2))
+    f.add_feed(HitBTC(book_interval=100, pairs=['BTC-USD'], channels=[L2_BOOK], callbacks=DeltaBook("HitBTC").L2))
+    f.add_feed(Poloniex(book_interval=100, channels=['BTC-USDT'], callbacks=DeltaBook("Poloniex").L2))
+    f.add_feed(Kraken(book_interval=100, pairs=['BTC-USD'], channels=[L2_BOOK], callbacks=DeltaBook("Kraken").L2))
+    f.add_feed(OKCoin(book_interval=100, pairs=['BTC-USD'], channels=[L2_BOOK], callbacks=DeltaBook("OKCoin").L2))
     f.run()
 
 


### PR DESCRIPTION
This rewrites the demo_book_delta.py example to a Class to handle multiple feed checkings at the same time. I do think that there is value in promoting DeltaBook to a more generic place in the codebase, potentially in cryptofeed/callbacks.py, but that would require giving the interface a bit more thought, in particular what to do when the book equality check fails. I'll send a follow-up PR to discuss this, after I played around with some variants.

(Also I do think that the check_books function is incomplete in checking book equality)