### PR TITLE
Add futures to OKEX

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Cryptofeed supports the following channels:
 * FUNDING
 * BOOK_DELTA - Subscribed to with L2 or L3 books, receive book deltas rather than the entire book on updates. Full updates will be periodically sent on the L2 or L3 channel. If BOOK_DELTA is enabled, only L2 or L3 book can be enabled, not both. To receive both create two `feedhandler` objects. Not all exchanges are supported, as some exchanges send complete books on every update.
 * *_SWAP (L2/L3 Books, Trades, Ticker) - Swap data on supporting exchanges
+* *_FUTURES (L2/L3 Books, Trades, Ticker) - Futures data on supporting exchanges
 * INSTRUMENT - Exchange specific instrument information
 
 ## Backends

--- a/cryptofeed/defines.py
+++ b/cryptofeed/defines.py
@@ -44,6 +44,10 @@ L2_BOOK_SWAP = 'l2_book_swap'
 TRADES_SWAP = 'trades_swap'
 TICKER_SWAP = 'ticker_swap'
 
+L2_BOOK_FUTURES = 'l2_book_futures'
+TRADES_FUTURES = 'trades_futures'
+TICKER_FUTURES = 'ticker_futures'
+
 BUY = 'buy'
 SELL = 'sell'
 

--- a/cryptofeed/exchange/okcoin.py
+++ b/cryptofeed/exchange/okcoin.py
@@ -62,12 +62,16 @@ class OKCoin(Feed):
         {'table': 'spot/trade', 'data': [{'instrument_id': 'BTC-USD', 'price': '3977.44', 'side': 'buy', 'size': '0.0096', 'timestamp': '2019-03-22T22:45:44.578Z', 'trade_id': '486519521'}]}
         """
         for trade in msg['data']:
+            if msg['table'] == 'futures/trade':
+                amount_sym = 'qty'
+            else:
+                amount_sym = 'size'
             await self.callback(TRADES,
                 feed=self.id,
                 pair=pair_exchange_to_std(trade['instrument_id']),
                 order_id=trade['trade_id'],
                 side=BUY if trade['side'] == 'buy' else SELL,
-                amount=Decimal(trade['size']),
+                amount=Decimal(trade[amount_sym]),
                 price=Decimal(trade['price']),
                 timestamp=timestamp_normalize(self.id, trade['timestamp'])
             )

--- a/cryptofeed/exchange/okex.py
+++ b/cryptofeed/exchange/okex.py
@@ -7,15 +7,32 @@ associated with this software.
 from cryptofeed.defines import OKEX
 from cryptofeed.exchange.okcoin import OKCoin
 
+import requests
+
 
 class OKEx(OKCoin):
     """
     OKEx has the same api as OKCoin, just a different websocket endpoint
     """
     id = OKEX
-    table_prefixs = ['swap', "spot"]
+    api = 'https://www.okex.com/api/'
+    table_prefixs = ['futures', 'swap', "spot"]
 
     def __init__(self, pairs=None, channels=None, callbacks=None, **kwargs):
         super().__init__(pairs=pairs, channels=channels, callbacks=callbacks, **kwargs)
         self.address = 'wss://real.okex.com:10442/ws/v3'
         self.book_depth = 200
+
+
+    @staticmethod
+    def get_active_symbols_info():
+        return requests.get(OKEx.api + 'futures/v3/instruments').json()
+
+
+    @staticmethod
+    def get_active_symbols():
+        symbols = []
+        for data in OKEx.get_active_symbols_info():
+            #print(data)
+            symbols.append(data['instrument_id'])
+        return symbols

--- a/cryptofeed/pairs.py
+++ b/cryptofeed/pairs.py
@@ -184,6 +184,10 @@ def okex_pairs():
     r = requests.get('https://www.okex.com/api/swap/v3/instruments/ticker').json()
     for update in r:
         data[update['instrument_id']] = update['instrument_id']
+    # futures
+    r = requests.get('https://www.okex.com/api/futures/v3/instruments/ticker').json()
+    for update in r:
+        data[update['instrument_id']] = update['instrument_id']
     return data
 
 

--- a/cryptofeed/standards.py
+++ b/cryptofeed/standards.py
@@ -14,7 +14,8 @@ import pandas as pd
 
 from cryptofeed.defines import (L2_BOOK, L3_BOOK, TRADES, TICKER, VOLUME, FUNDING, UNSUPPORTED, BITFINEX, GEMINI,
                                 POLONIEX, HITBTC, BITSTAMP, COINBASE, BITMEX, KRAKEN, KRAKEN_FUTURES, BINANCE, EXX, HUOBI, HUOBI_US, HUOBI_DM, OKCOIN,
-                                OKEX, COINBENE, BYBIT, FTX, TRADES_SWAP, TICKER_SWAP, L2_BOOK_SWAP, LIMIT, MARKET, FILL_OR_KILL, IMMEDIATE_OR_CANCEL, MAKER_OR_CANCEL, DERIBIT, INSTRUMENT)
+                                OKEX, COINBENE, BYBIT, FTX, TRADES_SWAP, TICKER_SWAP, L2_BOOK_SWAP, TRADES_FUTURES, TICKER_FUTURES, L2_BOOK_FUTURES,
+                                LIMIT, MARKET, FILL_OR_KILL, IMMEDIATE_OR_CANCEL, MAKER_OR_CANCEL, DERIBIT, INSTRUMENT)
 from cryptofeed.pairs import gen_pairs
 from cryptofeed.exceptions import UnsupportedTradingPair, UnsupportedDataFeed, UnsupportedTradingOption
 
@@ -174,6 +175,15 @@ _feed_to_exchange_map = {
     },
     L2_BOOK_SWAP: {
         OKEX: 'swap/depth'
+    },
+    TRADES_FUTURES: {
+        OKEX: 'futures/trade'
+    },
+    TICKER_FUTURES: {
+        OKEX: 'futures/ticker'
+    },
+    L2_BOOK_FUTURES: {
+        OKEX: 'futures/depth'
     },
     INSTRUMENT: {
         BITMEX: 'instrument'

--- a/examples/demo_okex_futures.py
+++ b/examples/demo_okex_futures.py
@@ -1,0 +1,37 @@
+'''
+Copyright (C) 2017-2019  Bryant Moscon - bmoscon@gmail.com
+
+Please see the LICENSE file for the terms and conditions
+associated with this software.
+'''
+from cryptofeed.callback import TickerCallback, TradeCallback, BookCallback
+from cryptofeed import FeedHandler
+from cryptofeed.exchanges import OKEx
+from cryptofeed.defines import L2_BOOK_FUTURES, L2_BOOK, BID, ASK, TRADES, TRADES_FUTURES, TICKER, TICKER_FUTURES
+
+
+
+
+async def trade(feed, pair, order_id, timestamp, side, amount, price):
+    print(f"Timestamp: {timestamp} Feed: {feed} Pair: {pair} ID: {order_id} Side: {side} Amount: {amount} Price: {price}")
+
+
+async def book(feed, pair, book, timestamp):
+    print(f'Timestamp: {timestamp} Feed: {feed} Pair: {pair} Book Bid Size is {len(book[BID])} Ask Size is {len(book[ASK])}')
+
+
+async def ticker(feed, pair, bid, ask):
+    print(f'Feed: {feed} Pair: {pair} Bid: {bid} Ask: {ask}')
+
+def main():
+    fh = FeedHandler()
+
+    callbacks = {TRADES: TradeCallback(trade), L2_BOOK: BookCallback(book), TICKER: TickerCallback(ticker)}
+    pairs = OKEx.get_active_symbols()
+    fh.add_feed(OKEx(pairs=pairs, channels=[TRADES_FUTURES, L2_BOOK_FUTURES, TICKER_FUTURES], callbacks=callbacks))
+
+    fh.run()
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Swaps were already added, but futures are in a different channel, so added futures.

So added new channels:
- TICKER_FUTURES
- TRADES_FUTURES
- L2_BOOK_FUTURES

Also added `get_active_symbols()`, similar to Bitmex, as the contracts will change as expiries are delete and added.