### PR TITLE
Cast FTX timestamp to float

### DIFF
--- a/cryptofeed/exchange/ftx.py
+++ b/cryptofeed/exchange/ftx.py
@@ -92,7 +92,7 @@ class FTX(Feed):
                     Decimal(price) : Decimal(amount) for price, amount in msg['data']['asks']
                 })
             }
-            await self.book_callback(pair, L2_BOOK, True, None, msg['data']['time'])
+            await self.book_callback(pair, L2_BOOK, True, None, float(msg['data']['time']))
         else:
             # update
             delta = {BID: [], ASK: []}
@@ -108,7 +108,7 @@ class FTX(Feed):
                     else:
                         delta[s].append((price, amount))
                         self.l2_book[pair][s][price] = amount
-            await self.book_callback(pair, L2_BOOK, False, delta, msg['data']['time'])
+            await self.book_callback(pair, L2_BOOK, False, delta, float(msg['data']['time']))
 
     async def message_handler(self, msg: str, timestamp: float):
         msg = json.loads(msg, parse_float=Decimal)


### PR DESCRIPTION
Fixes an issue where FTX books are unable to be json serialized, due to the book timestamp being returned as decimal.