### PR TITLE
add rate limit to trades

### DIFF
--- a/cryptofeed/rest/bitfinex.py
+++ b/cryptofeed/rest/bitfinex.py
@@ -22,6 +22,7 @@ from cryptofeed.standards import pair_std_to_exchange, pair_exchange_to_std, tim
 
 
 REQUEST_LIMIT = 5000
+RATE_LIMIT_SLEEP = 3
 LOG = logging.getLogger('rest')
 
 
@@ -128,6 +129,8 @@ class Bitfinex(API):
                 continue
             elif r.status_code != 200:
                 self._handle_error(r, LOG)
+            else:
+                sleep(RATE_LIMIT_SLEEP)
 
             data = r.json()
             if data == []:

--- a/cryptofeed/rest/bitmex.py
+++ b/cryptofeed/rest/bitmex.py
@@ -24,6 +24,7 @@ from cryptofeed.standards import timestamp_normalize
 
 
 S3_ENDPOINT = 'https://s3-eu-west-1.amazonaws.com/public.bitmex.com/data/trade/{}.csv.gz'
+RATE_LIMIT_SLEEP = 2
 API_MAX = 500
 API_REFRESH = 300
 
@@ -103,6 +104,8 @@ class Bitmex(API):
                     continue
                 elif r.status_code != 200:
                     self._handle_error(r, LOG)
+                else r.status_code != 200:
+                    sleep(RATE_LIMIT_SLEEP)
 
                 limit = int(r.headers['X-RateLimit-Remaining'])
                 data = r.json()

--- a/cryptofeed/rest/bitmex.py
+++ b/cryptofeed/rest/bitmex.py
@@ -104,7 +104,7 @@ class Bitmex(API):
                     continue
                 elif r.status_code != 200:
                     self._handle_error(r, LOG)
-                else r.status_code != 200:
+                else:
                     sleep(RATE_LIMIT_SLEEP)
 
                 limit = int(r.headers['X-RateLimit-Remaining'])

--- a/cryptofeed/rest/coinbase.py
+++ b/cryptofeed/rest/coinbase.py
@@ -24,6 +24,7 @@ from cryptofeed.standards import normalize_trading_options, timestamp_normalize
 
 
 REQUEST_LIMIT = 10
+RATE_LIMIT_SLEEP = 0.2
 LOG = logging.getLogger('rest')
 
 
@@ -132,7 +133,7 @@ class Coinbase(API):
                 else:
                     upper = bound
                     bound = (upper + lower) // 2
-            time.sleep(0.2)
+            time.sleep(RATE_LIMIT_SLEEP)
 
     def _trade_normalize(self, symbol: str, data: dict) -> dict:
         return {

--- a/cryptofeed/rest/deribit.py
+++ b/cryptofeed/rest/deribit.py
@@ -10,6 +10,7 @@ from sortedcontainers import SortedDict as sd
 
 
 REQUEST_LIMIT = 1000
+RATE_LIMIT_SLEEP = 0.2
 LOG = logging.getLogger('rest')
 
 
@@ -54,6 +55,8 @@ class Deribit(API):
                 continue
             elif r.status_code != 200:
                 self._handle_error(r, LOG)
+            else:
+                sleep(RATE_LIMIT_SLEEP)
 
             data = r.json()["result"]["trades"]
             if data == []:

--- a/cryptofeed/rest/gemini.py
+++ b/cryptofeed/rest/gemini.py
@@ -16,6 +16,7 @@ from cryptofeed.standards import pair_std_to_exchange, pair_exchange_to_std, nor
 
 
 LOG = logging.getLogger('rest')
+RATE_LIMIT_SLEEP = 0.5
 
 
 # https://docs.gemini.com/rest-api/#introduction
@@ -145,7 +146,7 @@ class Gemini(API):
             if not start and not end:
                 break
             # GEMINI rate limits to 120 requests a minute
-            sleep(0.5)
+            sleep(RATE_LIMIT_SLEEP)
 
     # Trading APIs
     def place_order(self, symbol: str, side: str, order_type: str, amount: Decimal, price=None, client_order_id=None, options=None):

--- a/cryptofeed/rest/kraken.py
+++ b/cryptofeed/rest/kraken.py
@@ -22,6 +22,7 @@ from cryptofeed.standards import pair_std_to_exchange, normalize_trading_options
 
 
 LOG = logging.getLogger('rest')
+RATE_LIMIT_SLEEP = 1
 
 
 class Kraken(API):
@@ -170,6 +171,8 @@ class Kraken(API):
                 continue
             elif r.status_code != 200:
                 self._handle_error(r, LOG)
+            else:
+                time.sleep(RATE_LIMIT_SLEEP)
 
             data = r.json()
             if 'error' in data and data['error']:


### PR DESCRIPTION
Seems like `rest` module of cryptofeed does not implement rate limiting for most exchanges. Exchanges ban for exceeding rate limits for increasing amounts of time if requests keep coming