### PR TITLE
Support InfluxDB 2.0 by adding token authentication headers (Issue #194)

### DIFF
--- a/cryptofeed/backends/influxdb.py
+++ b/cryptofeed/backends/influxdb.py
@@ -63,7 +63,7 @@ class InfluxCallback(HTTPCallback):
           Precision level among (s, ms, us, ns) 
         """
         super().__init__(addr, **kwargs)
-        if (org and bucket and token):
+        if org and bucket and token:
             self.addr = f"{addr}/api/v2/write?org={org}&bucket={bucket}&precision={precision}"
             self.headers = {"Authorization": f"Token {token}"}
         else:

--- a/cryptofeed/backends/influxdb.py
+++ b/cryptofeed/backends/influxdb.py
@@ -18,7 +18,7 @@ LOG = logging.getLogger('feedhandler')
 
 
 class InfluxCallback(HTTPCallback):
-    def __init__(self, addr: str, db: str, key=None, create_db=True, numeric_type=str, **kwargs):
+    def __init__(self, addr: str, db=None, key=None, create_db=True, numeric_type=str, org=None, bucket=None, token=None, precision='ns', **kwargs):
         """
         Parent class for InfluxDB callbacks
 
@@ -53,16 +53,30 @@ class InfluxCallback(HTTPCallback):
           Create database if not exists
         numeric_type: str/float
           Convert types before writing (amount and price)
+        org: str (For InfluxDB 2.0 compatibility)
+          Orgnaization name for authentication
+        bucket: str (For InfluxDB 2.0 compatibility)
+          Bucket name for authentication
+        token: str (For InfluxDB 2.0 compatibility)
+          Token string for authentication
+        precision: str (For InfluxDB 2.0 compatibility)
+          Precision level among (s, ms, us, ns) 
         """
         super().__init__(addr, **kwargs)
-        self.addr = f"{addr}/write?db={db}"
+        if (org and bucket and token):
+            self.addr = f"{addr}/api/v2/write?org={org}&bucket={bucket}&precision={precision}"
+            self.headers = {"Authorization": f"Token {token}"}
+
+        else:
+            if create_db:
+                r = requests.post(f'{addr}/query', data={'q': f'CREATE DATABASE {db}'})
+                r.raise_for_status()
+            self.addr = f"{addr}/write?db={db}"
+            self.headers = {}
+            
         self.session = None
         self.numeric_type = numeric_type
         self.key = key if key else self.default_key
-
-        if create_db:
-            r = requests.post(f'{addr}/query', data={'q': f'CREATE DATABASE {db}'})
-            r.raise_for_status()
 
     async def write(self, feed, pair, timestamp, data):
         d = ''
@@ -77,7 +91,7 @@ class InfluxCallback(HTTPCallback):
         d = d[:-1]
 
         update = f'{self.key}-{feed},pair={pair} {d},timestamp={timestamp}'
-        await self.http_write('POST', update)
+        await self.http_write('POST', update, self.headers)
 
 
 class TradeInflux(InfluxCallback, BackendTradeCallback):
@@ -113,7 +127,7 @@ class InfluxBookCallback(InfluxCallback):
                     else:
                         raise UnsupportedType(f"Type {self.numeric_type} not supported")
                     ts += 1
-        await self.http_write('POST', '\n'.join(msg))
+        await self.http_write('POST', '\n'.join(msg), self.headers)
 
 
 class BookInflux(InfluxBookCallback, BackendBookCallback):

--- a/cryptofeed/backends/influxdb.py
+++ b/cryptofeed/backends/influxdb.py
@@ -66,7 +66,6 @@ class InfluxCallback(HTTPCallback):
         if (org and bucket and token):
             self.addr = f"{addr}/api/v2/write?org={org}&bucket={bucket}&precision={precision}"
             self.headers = {"Authorization": f"Token {token}"}
-
         else:
             if create_db:
                 r = requests.post(f'{addr}/query', data={'q': f'CREATE DATABASE {db}'})

--- a/examples/demo_influxdb.py
+++ b/examples/demo_influxdb.py
@@ -11,12 +11,36 @@ from cryptofeed.exchanges import Bitmex, Coinbase
 from cryptofeed.defines import TRADES, FUNDING, L2_BOOK, BOOK_DELTA, TICKER
 
 
+
 def main():
+    
     f = FeedHandler()
     f.add_feed(Bitmex(channels=[FUNDING, L2_BOOK],pairs=['XBTUSD'], callbacks={FUNDING: FundingInflux('http://localhost:8086', 'example'), L2_BOOK: BookInflux('http://localhost:8086', 'example', numeric_type=float), BOOK_DELTA: BookDeltaInflux('http://localhost:8086', 'example', numeric_type=float)}))
     f.add_feed(Coinbase(channels=[TRADES], pairs=['BTC-USD'], callbacks={TRADES: TradeInflux('http://localhost:8086', 'example')}))
     f.add_feed(Coinbase(channels=[L2_BOOK], pairs=['BTC-USD'], callbacks={L2_BOOK: BookInflux('http://localhost:8086', 'example', numeric_type=float), BOOK_DELTA: BookDeltaInflux('http://localhost:8086', 'example', numeric_type=float)}))
     f.add_feed(Coinbase(channels=[TICKER], pairs=['BTC-USD'], callbacks={TICKER: TickerInflux('http://localhost:8086', 'example', numeric_type=float)}))
+    
+    """
+    # For InfluxDB 2.0, provide additional org, bucket(instead of db), token and precision(optional) 
+    # [Note] In order to use visualization and aggregation, numeric_type with float is strongly recommended. 
+    
+    ADDR = 'https://localhost:9999'
+    ORG='my-org'
+    BUCKET = 'my-bucket'
+    TOKEN = 'token-something-like-end-with-=='
+    
+    f = FeedHandler()
+    funding_influx = FundingInflux(ADDR, org=ORG, bucket=BUCKET, token=TOKEN, numeric_type=float) 
+    trade_influx = TradeInflux(ADDR, org=ORG, bucket=BUCKET, token=TOKEN, numeric_type=float) 
+    book_influx = BookInflux(ADDR, org=ORG, bucket=BUCKET, token=TOKEN, numeric_type=float) 
+    bookdelta_influx = BookDeltaInflux(ADDR, org=ORG, bucket=BUCKET, token=TOKEN, numeric_type=float) 
+    ticker_influx = TickerInflux(ADDR, org=ORG, bucket=BUCKET, token=TOKEN, numeric_type=float) 
+    
+    f.add_feed(Bitmex(channels=[FUNDING, L2_BOOK],pairs=['XBTUSD'], callbacks={FUNDING: funding_influx, L2_BOOK: book_influx, BOOK_DELTA: bookdelta_influx}))
+    f.add_feed(Coinbase(channels=[TRADES], pairs=['BTC-USD'], callbacks={TRADES: trade_influx}))
+    f.add_feed(Coinbase(channels=[L2_BOOK], pairs=['BTC-USD'], callbacks={L2_BOOK: book_influx, BOOK_DELTA: bookdelta_influx}))
+    f.add_feed(Coinbase(channels=[TICKER], pairs=['BTC-USD'], callbacks={TICKER: ticker_influx}))
+    """
 
     f.run()
 

--- a/examples/demo_influxdb.py
+++ b/examples/demo_influxdb.py
@@ -20,7 +20,8 @@ def main():
     f.add_feed(Coinbase(channels=[L2_BOOK], pairs=['BTC-USD'], callbacks={L2_BOOK: BookInflux('http://localhost:8086', 'example', numeric_type=float), BOOK_DELTA: BookDeltaInflux('http://localhost:8086', 'example', numeric_type=float)}))
     f.add_feed(Coinbase(channels=[TICKER], pairs=['BTC-USD'], callbacks={TICKER: TickerInflux('http://localhost:8086', 'example', numeric_type=float)}))
     
-    """
+    """ 
+    # Uncomment Here When Using InfluxDB 2.0
     # For InfluxDB 2.0, provide additional org, bucket(instead of db), token and precision(optional) 
     # [Note] In order to use visualization and aggregation, numeric_type with float is strongly recommended. 
     


### PR DESCRIPTION
I am trying to construct my own crypto database, I choose to use InfluxDB 2.0 for several reasons. In order to solve #194, I made a few changes to your awesome code. 

### 1) Four additional parameter for InfluxCallback  
Since InfluxDB 2.0 always requires an authentication token when using the rest API method, I added four additional input arguments to `InfluxCallback`.

- org: str 
        Organization name for authentication  

- bucket: str  
Bucket name for authentication  

- token: str 
          Token string for authentication  

- precision: str 
          Precision level among (s, ms, us, ns)   

### 2) Change with `self.addr`.
Also, `self.addr` could be constructed in two ways.  
If the user provides all `org`, `bucket`, `token` arguments, then the address should be like below 
```
self.addr = f"{addr}/api/v2/write?org={org}&bucket={bucket}&precision={precision}"
``` 

Otherwise, the original style.  
```
self.addr = f"{addr}/write?db={db}"
```
 
### 3) Newly added `self.headers` containing authentication token  

I also created `self.headers` object in order to pass the authentication token.
This header sends to the http request method.   
```
self.headers = {"Authorization": f"Token {token}"}
```

### 4) Add brief demo with `demo_inflxudb.py` 
I also demonstrated how to deal with InfluxDB 2.0 by adding supplementary example code in the `demo_influxdb.py`  

### 5) Testing  
I tested the mentioned demo code and observed works well with InfluxDB Cloud 2.0 service. However, sometimes the Influx refuses connection due to a high request rate (so I need to work with cryptostore library). 

For summary, I hope you merge my pull request!  

 


