### PR TITLE
Throw exception if bid and ask are overlapping

### DIFF
--- a/cryptofeed/exceptions.py
+++ b/cryptofeed/exceptions.py
@@ -32,3 +32,7 @@ class UnsupportedType(Exception):
 
 class ExhaustedRetries(Exception):
     pass
+
+
+class BidAskOverlapping(Exception):
+    pass

--- a/cryptofeed/feed.py
+++ b/cryptofeed/feed.py
@@ -6,8 +6,6 @@ associated with this software.
 '''
 import uuid
 from collections import defaultdict
-from sortedcontainers import SortedDict as sd
-
 
 from cryptofeed.callback import Callback
 from cryptofeed.standards import pair_std_to_exchange, feed_to_exchange, load_exchange_pair_mapping
@@ -115,7 +113,6 @@ class Feed:
 
     def check_bid_ask_overlapping(self, book, pair):
         bid, ask = book[BID], book[ASK]
-        assert isinstance(bid, sd) and isinstance(ask, sd)
         if len(bid) > 0 and len(ask) > 0:
             best_bid, best_ask = bid.keys()[-1], ask.keys()[0]
             if best_bid >= best_ask:


### PR DESCRIPTION
See https://github.com/bmoscon/cryptofeed/issues/232 for discussion
This will completely break the Upbit feed if L2_BOOK is enabled (most likely since either the implementation is wrong or the exchange notifications are insufficient).