### PR TITLE
Removed non perpetuals from funding feed

### DIFF
--- a/cryptofeed/exchange/ftx.py
+++ b/cryptofeed/exchange/ftx.py
@@ -67,6 +67,8 @@ class FTX(Feed):
         async with aiohttp.ClientSession() as session:
             while True:
                 for pair in pairs:
+                    if '-PERP' not in pair:
+                        continue
                     async with session.get(f"https://ftx.com/api/funding_rates?future={pair}") as response:
                         data = await response.text()
                         data = json.loads(data, parse_float=Decimal)


### PR DESCRIPTION
Because only perpetuals have funding, pairs that are not perpetuals must be filtered out of the funding API request, because otherwise exceptions are thrown.