### PR TITLE
Cache retrieved pairs to reduce HTTP requests

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -4,3 +4,4 @@ Cryptofeed was originally created by Bryant Moscon, but many others have contrib
 * [Archie Norman](https://github.com/archienorman11) - <archie@mercuryassets.io>
 * [Quantfiction](https://github.com/quantfiction)
 * [Cody Jacques](https://github.com/PandaXcentric) - <jacques.co@northeastern.edu>
+* [O. Libre](https://github.com/olibre) - <olibre@Lmap.org>

--- a/cryptofeed/pairs.py
+++ b/cryptofeed/pairs.py
@@ -7,7 +7,7 @@ associated with this software.
 
 Pair generation code for exchanges
 '''
-import collections
+
 import logging
 
 import requests
@@ -19,7 +19,7 @@ LOG = logging.getLogger('feedhandler')
 PAIR_SEP = '-'
 
 
-_pairs_retrieval_cache = collections.defaultdict(dict)
+_pairs_retrieval_cache = dict()
 
 
 def set_pair_separator(symbol: str):
@@ -108,12 +108,6 @@ def ftx_us_pairs():
 def coinbase_pairs():
     r = requests.get('https://api.pro.coinbase.com/products').json()
     return {data['id'].replace("-", PAIR_SEP): data['id'] for data in r}
-
-
-def dsx_pairs():
-    r = requests.get('https://dsxglobal.com/mapi/v2/info').json()
-    data = r['pairs']
-    return {f"{data[symbol]['base_currency']}{PAIR_SEP}{data[symbol]['quoted_currency']}": symbol for symbol in data}
 
 
 def gemini_pairs():

--- a/cryptofeed/pairs.py
+++ b/cryptofeed/pairs.py
@@ -7,12 +7,19 @@ associated with this software.
 
 Pair generation code for exchanges
 '''
+import collections
+import logging
+
 import requests
 
 from cryptofeed.defines import BITSTAMP, BITFINEX, COINBASE, GEMINI, HITBTC, POLONIEX, KRAKEN, BINANCE, BINANCE_US, BINANCE_JERSEY, BINANCE_FUTURES, EXX, HUOBI, HUOBI_DM, HUOBI_SWAP, OKCOIN, OKEX, COINBENE, BYBIT, FTX, FTX_US, BITTREX, BITCOINCOM, BITMAX, UPBIT, BLOCKCHAIN
 
+LOG = logging.getLogger('feedhandler')
 
 PAIR_SEP = '-'
+
+
+_pairs_retrieval_cache = collections.defaultdict(dict)
 
 
 def set_pair_separator(symbol: str):
@@ -21,7 +28,12 @@ def set_pair_separator(symbol: str):
 
 
 def gen_pairs(exchange):
-    return _exchange_function_map[exchange]()
+    if exchange not in _pairs_retrieval_cache:
+        LOG.info("%s: Getting list of pairs", exchange)
+        pairs = _exchange_function_map[exchange]()
+        LOG.info("%s: %s pairs", exchange, len(pairs))
+        _pairs_retrieval_cache[exchange] = pairs
+    return _pairs_retrieval_cache[exchange]
 
 
 def _binance_pairs(endpoint: str):
@@ -57,11 +69,9 @@ def bitfinex_pairs():
         pair = data[0]
         if pair[0] == 'f':
             continue
-        else:
-            normalized = pair[1:-3] + PAIR_SEP + pair[-3:]
-            normalized = normalized.replace('UST', 'USDT')
-            ret[normalized] = pair
-
+        normalized = pair[1:-3] + PAIR_SEP + pair[-3:]
+        normalized = normalized.replace('UST', 'USDT')
+        ret[normalized] = pair
     return ret
 
 
@@ -113,7 +123,6 @@ def gemini_pairs():
     for pair in r:
         std = f"{pair[:-3]}{PAIR_SEP}{pair[-3:]}"
         std = std.upper()
-        ret[std] = pair
         ret[std] = pair.upper()
 
     return ret
@@ -193,7 +202,7 @@ def exx_pairs():
 
     exchange = [key.upper() for key in r.keys()]
     pairs = [key.replace("_", PAIR_SEP) for key in exchange]
-    return {pair: exchange for pair, exchange in zip(pairs, exchange)}
+    return dict(zip(pairs, exchange))
 
 
 def huobi_common_pairs(url: str):


### PR DESCRIPTION
I have written a script with Cryptofeed, and my script calls the function `pairs.gen_pairs()` to list the currency pairs. I do this for multiple exchanges. But the function `pairs.gen_pairs()` is also called by `standards.load_exchange_pair_mapping()` with the result that the same HTTP request is sent twice to the exchanges. This double cryptocurrencies pairs retrieval is time-consuming, and some exchanges may not respond to the second consecutive request.

Therefore I have added a cache in 'pairs.py'. I share this feature in this PR in the hope that this may help someone else.

Note: My script does not use the variable 'standards._std_trading_pairs', because this variable is not designed to list the pairs for each exchange in a simple way.

In this PR I have also cleaned up the 'pairs.py' file and added myself to the AUTHORS.md file.