### PR TITLE
Improve the unit tests

### DIFF
--- a/tests/integration/rest/test_rest.py
+++ b/tests/integration/rest/test_rest.py
@@ -60,5 +60,5 @@ def test_rest_ftx():
     try:
         assert ret[0] == expected
     except AssertionError as ex:
-        print('test_rest_ftx failed: AssertionError')
+        print(f'test_rest_ftx failed: {ex!r}')
         print('Please check the start_date, because FTX only saves 4 months worth of funding data')

--- a/tests/unit/rest_apis/test_gemini.py
+++ b/tests/unit/rest_apis/test_gemini.py
@@ -1,3 +1,4 @@
+from cryptofeed.defines import BID, ASK
 from cryptofeed.rest import Rest
 
 import pytest
@@ -10,15 +11,15 @@ sandbox = Rest('config.yaml', sandbox=True).Gemini
 def test_ticker():
     ticker = public.ticker('BTC-USD')
 
-    assert 'bid' in ticker
-    assert 'ask' in ticker
+    assert BID in ticker
+    assert ASK in ticker
 
 
 def test_order_book():
     current_order_book = public.l2_book('BTC-USD')
 
-    assert 'bid'in current_order_book
-    assert len(current_order_book['bid']) > 0
+    assert BID in current_order_book
+    assert len(current_order_book[BID]) > 0
 
 
 def test_trade_history():

--- a/tests/unit/test_exchange_integration.py
+++ b/tests/unit/test_exchange_integration.py
@@ -10,4 +10,5 @@ def test_exchanges_fh():
     path = os.path.dirname(os.path.abspath(__file__))
     files = os.listdir(f"{path}/../../cryptofeed/exchange")
     files = [f for f in files if '__' not in f]
-    assert(len(files) == len(_EXCHANGES))
+    files = [f[:-3].upper() for f in files]  # Drop extension .py and uppercase
+    assert(sorted(files) == sorted(_EXCHANGES))


### PR DESCRIPTION
One unit test fails:

```
$ python3 -m pytest tests

__ test_rest_bitmex __

    def test_rest_bitmex():
        r = Rest()
        ret = []
        end = pd.Timestamp.now()
        start = end - pd.Timedelta(minutes=2)
        for data in r.bitmex.trades('XBTUSD', start=start, end=end):
            ret.extend(data)

>       assert len(ret) > 0
E       assert 0 > 0
E        +  where 0 = len([])

tests/integration/rest/test_rest.py:15: AssertionError
```