### PR TITLE
Format "import" section in folder "examples" only

### DIFF
--- a/examples/demo.py
+++ b/examples/demo.py
@@ -6,11 +6,45 @@ associated with this software.
 '''
 from decimal import Decimal
 
-from cryptofeed.callback import TickerCallback, TradeCallback, BookCallback, FundingCallback
 from cryptofeed import FeedHandler
-from cryptofeed.exchanges import Bitmex, Coinbase, Bitfinex, Poloniex, Gemini, HitBTC, Bitstamp, Kraken, Binance, EXX, Huobi, OKCoin, OKEx, HuobiDM, HuobiSwap, Bittrex, FTX
-from cryptofeed.defines import L2_BOOK, BID, ASK, TRADES, TICKER, FUNDING, COINBASE, OPEN_INTEREST, \
-    GEMINI, VOLUME, BLOCKCHAIN
+from cryptofeed.callback import (
+    BookCallback,
+    FundingCallback,
+    TickerCallback,
+    TradeCallback,
+)
+from cryptofeed.defines import (
+    ASK,
+    BID,
+    BLOCKCHAIN,
+    COINBASE,
+    FUNDING,
+    GEMINI,
+    L2_BOOK,
+    OPEN_INTEREST,
+    TICKER,
+    TRADES,
+    VOLUME,
+)
+from cryptofeed.exchanges import (
+    EXX,
+    FTX,
+    Binance,
+    Bitfinex,
+    Bitmex,
+    Bitstamp,
+    Bittrex,
+    Coinbase,
+    Gemini,
+    HitBTC,
+    Huobi,
+    HuobiDM,
+    HuobiSwap,
+    Kraken,
+    OKCoin,
+    OKEx,
+    Poloniex,
+)
 
 
 # Examples of some handlers for different updates. These currently don't do much.

--- a/examples/demo.py
+++ b/examples/demo.py
@@ -7,12 +7,7 @@ associated with this software.
 from decimal import Decimal
 
 from cryptofeed import FeedHandler
-from cryptofeed.callback import (
-    BookCallback,
-    FundingCallback,
-    TickerCallback,
-    TradeCallback,
-)
+from cryptofeed.callback import BookCallback, FundingCallback, TickerCallback, TradeCallback
 from cryptofeed.defines import (
     ASK,
     BID,

--- a/examples/demo.py
+++ b/examples/demo.py
@@ -9,9 +9,9 @@ from decimal import Decimal
 from cryptofeed import FeedHandler
 from cryptofeed.callback import BookCallback, FundingCallback, TickerCallback, TradeCallback
 from cryptofeed.defines import (ASK, BID, BLOCKCHAIN, COINBASE, FUNDING, GEMINI, L2_BOOK, OPEN_INTEREST, TICKER, TRADES,
-                                VOLUME,)
+                                VOLUME)
 from cryptofeed.exchanges import (EXX, FTX, Binance, Bitfinex, Bitmex, Bitstamp, Bittrex, Coinbase, Gemini, HitBTC,
-                                  Huobi, HuobiDM, HuobiSwap, Kraken, OKCoin, OKEx, Poloniex,)
+                                  Huobi, HuobiDM, HuobiSwap, Kraken, OKCoin, OKEx, Poloniex)
 
 
 # Examples of some handlers for different updates. These currently don't do much.

--- a/examples/demo.py
+++ b/examples/demo.py
@@ -8,38 +8,10 @@ from decimal import Decimal
 
 from cryptofeed import FeedHandler
 from cryptofeed.callback import BookCallback, FundingCallback, TickerCallback, TradeCallback
-from cryptofeed.defines import (
-    ASK,
-    BID,
-    BLOCKCHAIN,
-    COINBASE,
-    FUNDING,
-    GEMINI,
-    L2_BOOK,
-    OPEN_INTEREST,
-    TICKER,
-    TRADES,
-    VOLUME,
-)
-from cryptofeed.exchanges import (
-    EXX,
-    FTX,
-    Binance,
-    Bitfinex,
-    Bitmex,
-    Bitstamp,
-    Bittrex,
-    Coinbase,
-    Gemini,
-    HitBTC,
-    Huobi,
-    HuobiDM,
-    HuobiSwap,
-    Kraken,
-    OKCoin,
-    OKEx,
-    Poloniex,
-)
+from cryptofeed.defines import (ASK, BID, BLOCKCHAIN, COINBASE, FUNDING, GEMINI, L2_BOOK, OPEN_INTEREST, TICKER, TRADES,
+                                VOLUME,)
+from cryptofeed.exchanges import (EXX, FTX, Binance, Bitfinex, Bitmex, Bitstamp, Bittrex, Coinbase, Gemini, HitBTC,
+                                  Huobi, HuobiDM, HuobiSwap, Kraken, OKCoin, OKEx, Poloniex,)
 
 
 # Examples of some handlers for different updates. These currently don't do much.

--- a/examples/demo_arctic.py
+++ b/examples/demo_arctic.py
@@ -4,11 +4,10 @@ Copyright (C) 2018-2020  Bryant Moscon - bmoscon@gmail.com
 Please see the LICENSE file for the terms and conditions
 associated with this software.
 '''
-from cryptofeed.backends.arctic import TradeArctic, FundingArctic, TickerArctic
 from cryptofeed import FeedHandler
-from cryptofeed.exchanges import Bitmex, Bitfinex, Coinbase
-
-from cryptofeed.defines import TRADES, FUNDING, TICKER
+from cryptofeed.backends.arctic import FundingArctic, TickerArctic, TradeArctic
+from cryptofeed.defines import FUNDING, TICKER, TRADES
+from cryptofeed.exchanges import Bitfinex, Bitmex, Coinbase
 
 
 def main():

--- a/examples/demo_book_delta.py
+++ b/examples/demo_book_delta.py
@@ -11,7 +11,7 @@ from cryptofeed.callback import BookCallback, BookUpdateCallback
 from cryptofeed.defines import ASK, BID, BOOK_DELTA, L2_BOOK, L3_BOOK
 from cryptofeed.exchange.blockchain import Blockchain
 from cryptofeed.exchanges import (EXX, Binance, Bitfinex, Bitmex, Bitstamp, Bittrex, Bybit, Coinbase, Gemini, HitBTC,
-                                  Kraken, OKCoin, Poloniex, Upbit,)
+                                  Kraken, OKCoin, Poloniex, Upbit)
 
 
 class DeltaBook(object):

--- a/examples/demo_book_delta.py
+++ b/examples/demo_book_delta.py
@@ -10,22 +10,8 @@ from cryptofeed import FeedHandler
 from cryptofeed.callback import BookCallback, BookUpdateCallback
 from cryptofeed.defines import ASK, BID, BOOK_DELTA, L2_BOOK, L3_BOOK
 from cryptofeed.exchange.blockchain import Blockchain
-from cryptofeed.exchanges import (
-    EXX,
-    Binance,
-    Bitfinex,
-    Bitmex,
-    Bitstamp,
-    Bittrex,
-    Bybit,
-    Coinbase,
-    Gemini,
-    HitBTC,
-    Kraken,
-    OKCoin,
-    Poloniex,
-    Upbit,
-)
+from cryptofeed.exchanges import (EXX, Binance, Bitfinex, Bitmex, Bitstamp, Bittrex, Bybit, Coinbase, Gemini, HitBTC,
+                                  Kraken, OKCoin, Poloniex, Upbit,)
 
 
 class DeltaBook(object):

--- a/examples/demo_book_delta.py
+++ b/examples/demo_book_delta.py
@@ -6,11 +6,26 @@ associated with this software.
 '''
 from copy import deepcopy
 
-from cryptofeed.callback import BookCallback, BookUpdateCallback
 from cryptofeed import FeedHandler
+from cryptofeed.callback import BookCallback, BookUpdateCallback
+from cryptofeed.defines import ASK, BID, BOOK_DELTA, L2_BOOK, L3_BOOK
 from cryptofeed.exchange.blockchain import Blockchain
-from cryptofeed.exchanges import Bitmex, Coinbase, Bitfinex, Gemini, HitBTC, Poloniex, Kraken, OKCoin, Bybit, Binance, Bitstamp, EXX, Bittrex, Upbit
-from cryptofeed.defines import L2_BOOK, L3_BOOK, BID, ASK, BOOK_DELTA
+from cryptofeed.exchanges import (
+    EXX,
+    Binance,
+    Bitfinex,
+    Bitmex,
+    Bitstamp,
+    Bittrex,
+    Bybit,
+    Coinbase,
+    Gemini,
+    HitBTC,
+    Kraken,
+    OKCoin,
+    Poloniex,
+    Upbit,
+)
 
 
 class DeltaBook(object):

--- a/examples/demo_book_delta_simple.py
+++ b/examples/demo_book_delta_simple.py
@@ -5,8 +5,8 @@ Please see the LICENSE file for the terms and conditions
 associated with this software.
 '''
 from cryptofeed import FeedHandler
+from cryptofeed.defines import BOOK_DELTA, L2_BOOK
 from cryptofeed.exchanges import Coinbase
-from cryptofeed.defines import L2_BOOK, BOOK_DELTA
 
 
 async def book(feed, pair, book, timestamp, receipt_timestamp):

--- a/examples/demo_bybit.py
+++ b/examples/demo_bybit.py
@@ -5,11 +5,10 @@ Please see the LICENSE file for the terms and conditions
 associated with this software.
 '''
 
-from cryptofeed.callback import TradeCallback, BookCallback
 from cryptofeed import FeedHandler
-
+from cryptofeed.callback import BookCallback, TradeCallback
+from cryptofeed.defines import ASK, BID, L2_BOOK, TRADES
 from cryptofeed.exchanges import Bybit
-from cryptofeed.defines import TRADES, L2_BOOK, BID, ASK
 
 
 async def trade(feed, pair, order_id, timestamp, side, amount, price, receipt):

--- a/examples/demo_check_trade_timestamps.py
+++ b/examples/demo_check_trade_timestamps.py
@@ -4,12 +4,7 @@ import time
 from datetime import datetime
 
 from cryptofeed import FeedHandler
-from cryptofeed.callback import (
-    BookCallback,
-    FundingCallback,
-    TickerCallback,
-    TradeCallback,
-)
+from cryptofeed.callback import BookCallback, FundingCallback, TickerCallback, TradeCallback
 from cryptofeed.defines import (
     ASK,
     BID,

--- a/examples/demo_check_trade_timestamps.py
+++ b/examples/demo_check_trade_timestamps.py
@@ -6,7 +6,7 @@ from datetime import datetime
 from cryptofeed import FeedHandler
 from cryptofeed.callback import BookCallback, FundingCallback, TickerCallback, TradeCallback
 from cryptofeed.defines import (ASK, BID, BINANCE, BITFINEX, BITMEX, BITSTAMP, BYBIT, COINBASE, DERIBIT, EXX, FUNDING,
-                                GEMINI, HITBTC, HUOBI, KRAKEN, L2_BOOK, OKCOIN, OKEX, POLONIEX, TICKER, TRADES,)
+                                GEMINI, HITBTC, HUOBI, KRAKEN, L2_BOOK, OKCOIN, OKEX, POLONIEX, TICKER, TRADES)
 
 # Gathers the first trade of each exchange and prints out info on the timestamps.
 # To add an exchange, setup exch_sym_map with the most liquid pair.

--- a/examples/demo_check_trade_timestamps.py
+++ b/examples/demo_check_trade_timestamps.py
@@ -1,11 +1,38 @@
+import collections
 import os
 import time
-import collections
 from datetime import datetime
-from cryptofeed.callback import TickerCallback, TradeCallback, BookCallback, FundingCallback
+
 from cryptofeed import FeedHandler
-from cryptofeed.defines import L2_BOOK, BID, ASK, TRADES, TICKER, FUNDING
-from cryptofeed.defines import BINANCE, BITFINEX, BITMEX, BITSTAMP, BYBIT, COINBASE, DERIBIT, EXX, GEMINI, HITBTC, HUOBI, KRAKEN, OKCOIN, OKEX, POLONIEX
+from cryptofeed.callback import (
+    BookCallback,
+    FundingCallback,
+    TickerCallback,
+    TradeCallback,
+)
+from cryptofeed.defines import (
+    ASK,
+    BID,
+    BINANCE,
+    BITFINEX,
+    BITMEX,
+    BITSTAMP,
+    BYBIT,
+    COINBASE,
+    DERIBIT,
+    EXX,
+    FUNDING,
+    GEMINI,
+    HITBTC,
+    HUOBI,
+    KRAKEN,
+    L2_BOOK,
+    OKCOIN,
+    OKEX,
+    POLONIEX,
+    TICKER,
+    TRADES,
+)
 
 # Gathers the first trade of each exchange and prints out info on the timestamps.
 # To add an exchange, setup exch_sym_map with the most liquid pair.

--- a/examples/demo_check_trade_timestamps.py
+++ b/examples/demo_check_trade_timestamps.py
@@ -5,29 +5,8 @@ from datetime import datetime
 
 from cryptofeed import FeedHandler
 from cryptofeed.callback import BookCallback, FundingCallback, TickerCallback, TradeCallback
-from cryptofeed.defines import (
-    ASK,
-    BID,
-    BINANCE,
-    BITFINEX,
-    BITMEX,
-    BITSTAMP,
-    BYBIT,
-    COINBASE,
-    DERIBIT,
-    EXX,
-    FUNDING,
-    GEMINI,
-    HITBTC,
-    HUOBI,
-    KRAKEN,
-    L2_BOOK,
-    OKCOIN,
-    OKEX,
-    POLONIEX,
-    TICKER,
-    TRADES,
-)
+from cryptofeed.defines import (ASK, BID, BINANCE, BITFINEX, BITMEX, BITSTAMP, BYBIT, COINBASE, DERIBIT, EXX, FUNDING,
+                                GEMINI, HITBTC, HUOBI, KRAKEN, L2_BOOK, OKCOIN, OKEX, POLONIEX, TICKER, TRADES,)
 
 # Gathers the first trade of each exchange and prints out info on the timestamps.
 # To add an exchange, setup exch_sym_map with the most liquid pair.

--- a/examples/demo_config.py
+++ b/examples/demo_config.py
@@ -4,10 +4,10 @@ Copyright (C) 2017-2020  Bryant Moscon - bmoscon@gmail.com
 Please see the LICENSE file for the terms and conditions
 associated with this software.
 '''
-from cryptofeed.callback import TradeCallback, BookCallback
 from cryptofeed import FeedHandler
+from cryptofeed.callback import BookCallback, TradeCallback
+from cryptofeed.defines import ASK, BID, L3_BOOK, TRADES
 from cryptofeed.exchanges import Coinbase
-from cryptofeed.defines import L3_BOOK, BID, ASK, TRADES
 
 
 async def trade(feed, pair, order_id, timestamp, side, amount, price):

--- a/examples/demo_custom_agg.py
+++ b/examples/demo_custom_agg.py
@@ -4,12 +4,11 @@ Copyright (C) 2017-2020  Bryant Moscon - bmoscon@gmail.com
 Please see the LICENSE file for the terms and conditions
 associated with this software.
 '''
-from cryptofeed.callback import Callback
-from cryptofeed.backends.aggregate import CustomAggregate
-
 from cryptofeed import FeedHandler
-from cryptofeed.exchanges import Coinbase
+from cryptofeed.backends.aggregate import CustomAggregate
+from cryptofeed.callback import Callback
 from cryptofeed.defines import TRADES
+from cryptofeed.exchanges import Coinbase
 
 
 async def callback(data=None):

--- a/examples/demo_deribit.py
+++ b/examples/demo_deribit.py
@@ -1,8 +1,7 @@
-from cryptofeed.callback import TickerCallback, TradeCallback, BookCallback
 from cryptofeed import FeedHandler
-
+from cryptofeed.callback import BookCallback, TickerCallback, TradeCallback
+from cryptofeed.defines import ASK, BID, FUNDING, L2_BOOK, OPEN_INTEREST, TICKER, TRADES
 from cryptofeed.exchanges import Deribit
-from cryptofeed.defines import TRADES, TICKER, L2_BOOK, BID, ASK, FUNDING, OPEN_INTEREST
 
 
 async def trade(feed, pair, order_id, timestamp, side, amount, price):

--- a/examples/demo_elastic.py
+++ b/examples/demo_elastic.py
@@ -4,11 +4,15 @@ Copyright (C) 2018-2020  Bryant Moscon - bmoscon@gmail.com
 Please see the LICENSE file for the terms and conditions
 associated with this software.
 '''
-from cryptofeed.backends.elastic import TradeElastic, FundingElastic, BookDeltaElastic, BookElastic
 from cryptofeed import FeedHandler
-from cryptofeed.exchanges import Coinbase, Bitmex
-
-from cryptofeed.defines import TRADES, FUNDING, L2_BOOK, BOOK_DELTA
+from cryptofeed.backends.elastic import (
+    BookDeltaElastic,
+    BookElastic,
+    FundingElastic,
+    TradeElastic,
+)
+from cryptofeed.defines import BOOK_DELTA, FUNDING, L2_BOOK, TRADES
+from cryptofeed.exchanges import Bitmex, Coinbase
 
 """
 after writing, you can query all the trades out with the following curl:

--- a/examples/demo_elastic.py
+++ b/examples/demo_elastic.py
@@ -5,12 +5,7 @@ Please see the LICENSE file for the terms and conditions
 associated with this software.
 '''
 from cryptofeed import FeedHandler
-from cryptofeed.backends.elastic import (
-    BookDeltaElastic,
-    BookElastic,
-    FundingElastic,
-    TradeElastic,
-)
+from cryptofeed.backends.elastic import BookDeltaElastic, BookElastic, FundingElastic, TradeElastic
 from cryptofeed.defines import BOOK_DELTA, FUNDING, L2_BOOK, TRADES
 from cryptofeed.exchanges import Bitmex, Coinbase
 

--- a/examples/demo_existing_loop.py
+++ b/examples/demo_existing_loop.py
@@ -6,10 +6,10 @@ associated with this software.
 '''
 import asyncio
 
-from cryptofeed.callback import TickerCallback, TradeCallback, BookCallback
 from cryptofeed import FeedHandler
-from cryptofeed.exchanges import Coinbase, Binance
-from cryptofeed.defines import L2_BOOK, BID, ASK, TRADES, TICKER, COINBASE
+from cryptofeed.callback import BookCallback, TickerCallback, TradeCallback
+from cryptofeed.defines import ASK, BID, COINBASE, L2_BOOK, TICKER, TRADES
+from cryptofeed.exchanges import Binance, Coinbase
 
 
 # Examples of some handlers for different updates. These currently don't do much.

--- a/examples/demo_ftx_funding.py
+++ b/examples/demo_ftx_funding.py
@@ -5,11 +5,10 @@ Please see the LICENSE file for the terms and conditions
 associated with this software.
 '''
 
-from cryptofeed.callback import FundingCallback
 from cryptofeed import FeedHandler
-from cryptofeed.exchanges import FTX
+from cryptofeed.callback import FundingCallback
 from cryptofeed.defines import FUNDING
-
+from cryptofeed.exchanges import FTX
 
 # Examples of some handlers for different updates. These currently don't do much.
 # Handlers should conform to the patterns/signatures in callback.py

--- a/examples/demo_ftx_us.py
+++ b/examples/demo_ftx_us.py
@@ -6,10 +6,10 @@ associated with this software.
 '''
 from decimal import Decimal
 
-from cryptofeed.callback import TickerCallback, TradeCallback, BookCallback
 from cryptofeed import FeedHandler
+from cryptofeed.callback import BookCallback, TickerCallback, TradeCallback
+from cryptofeed.defines import ASK, BID, L2_BOOK, TICKER, TRADES
 from cryptofeed.exchanges import FTXUS
-from cryptofeed.defines import L2_BOOK, BID, ASK, TRADES, TICKER
 
 
 # Examples of some handlers for different updates. These currently don't do much.

--- a/examples/demo_influxdb.py
+++ b/examples/demo_influxdb.py
@@ -4,11 +4,16 @@ Copyright (C) 2018-2020  Bryant Moscon - bmoscon@gmail.com
 Please see the LICENSE file for the terms and conditions
 associated with this software.
 '''
-from cryptofeed.backends.influxdb import TradeInflux, FundingInflux, BookInflux, BookDeltaInflux, TickerInflux
 from cryptofeed import FeedHandler
+from cryptofeed.backends.influxdb import (
+    BookDeltaInflux,
+    BookInflux,
+    FundingInflux,
+    TickerInflux,
+    TradeInflux,
+)
+from cryptofeed.defines import BOOK_DELTA, FUNDING, L2_BOOK, TICKER, TRADES
 from cryptofeed.exchanges import Bitmex, Coinbase
-
-from cryptofeed.defines import TRADES, FUNDING, L2_BOOK, BOOK_DELTA, TICKER
 
 
 def main():

--- a/examples/demo_influxdb.py
+++ b/examples/demo_influxdb.py
@@ -5,13 +5,7 @@ Please see the LICENSE file for the terms and conditions
 associated with this software.
 '''
 from cryptofeed import FeedHandler
-from cryptofeed.backends.influxdb import (
-    BookDeltaInflux,
-    BookInflux,
-    FundingInflux,
-    TickerInflux,
-    TradeInflux,
-)
+from cryptofeed.backends.influxdb import BookDeltaInflux, BookInflux, FundingInflux, TickerInflux, TradeInflux
 from cryptofeed.defines import BOOK_DELTA, FUNDING, L2_BOOK, TICKER, TRADES
 from cryptofeed.exchanges import Bitmex, Coinbase
 

--- a/examples/demo_kafka.py
+++ b/examples/demo_kafka.py
@@ -4,12 +4,10 @@ Copyright (C) 2018-2020  Bryant Moscon - bmoscon@gmail.com
 Please see the LICENSE file for the terms and conditions
 associated with this software.
 '''
-from cryptofeed.backends.kafka import TradeKafka, BookKafka
 from cryptofeed import FeedHandler
+from cryptofeed.backends.kafka import BookKafka, TradeKafka
+from cryptofeed.defines import L2_BOOK, TRADES
 from cryptofeed.exchanges import Coinbase
-
-from cryptofeed.defines import TRADES, L2_BOOK
-
 
 """
 You can run a consumer in the console with the following command

--- a/examples/demo_kraken_futures.py
+++ b/examples/demo_kraken_futures.py
@@ -4,10 +4,10 @@ Copyright (C) 2017-2020  Bryant Moscon - bmoscon@gmail.com
 Please see the LICENSE file for the terms and conditions
 associated with this software.
 '''
-from cryptofeed.callback import TickerCallback, TradeCallback, BookCallback
 from cryptofeed import FeedHandler
+from cryptofeed.callback import BookCallback, TickerCallback, TradeCallback
+from cryptofeed.defines import ASK, BID, FUNDING, L2_BOOK, OPEN_INTEREST, TICKER, TRADES
 from cryptofeed.exchanges import KrakenFutures
-from cryptofeed.defines import L2_BOOK, BID, ASK, TRADES, TICKER, FUNDING, OPEN_INTEREST
 
 
 async def trade(feed, pair, order_id, timestamp, side, amount, price):

--- a/examples/demo_mongo.py
+++ b/examples/demo_mongo.py
@@ -4,11 +4,10 @@ Copyright (C) 2017-2020  Bryant Moscon - bmoscon@gmail.com
 Please see the LICENSE file for the terms and conditions
 associated with this software.
 '''
-from cryptofeed.backends.mongo import TradeMongo, BookDeltaMongo, BookMongo
 from cryptofeed import FeedHandler
+from cryptofeed.backends.mongo import BookDeltaMongo, BookMongo, TradeMongo
+from cryptofeed.defines import BOOK_DELTA, L2_BOOK, TRADES
 from cryptofeed.exchanges import Coinbase
-
-from cryptofeed.defines import TRADES, L2_BOOK, BOOK_DELTA
 
 
 def main():

--- a/examples/demo_multicb.py
+++ b/examples/demo_multicb.py
@@ -4,10 +4,10 @@ Copyright (C) 2017-2020  Bryant Moscon - bmoscon@gmail.com
 Please see the LICENSE file for the terms and conditions
 associated with this software.
 '''
-from cryptofeed.callback import TradeCallback, BookCallback
 from cryptofeed import FeedHandler
+from cryptofeed.callback import BookCallback, TradeCallback
+from cryptofeed.defines import ASK, BID, L3_BOOK, TRADES
 from cryptofeed.exchanges import Coinbase
-from cryptofeed.defines import L3_BOOK, BID, ASK, TRADES
 
 
 async def trade(feed, pair, order_id, timestamp, side, amount, price):

--- a/examples/demo_nbbo.py
+++ b/examples/demo_nbbo.py
@@ -5,7 +5,7 @@ Please see the LICENSE file for the terms and conditions
 associated with this software.
 '''
 from cryptofeed import FeedHandler
-from cryptofeed.exchanges import Coinbase, Kraken, Gemini
+from cryptofeed.exchanges import Coinbase, Gemini, Kraken
 
 
 def nbbo_update(pair, bid, bid_size, ask, ask_size, bid_feed, ask_feed):

--- a/examples/demo_ohlcv.py
+++ b/examples/demo_ohlcv.py
@@ -4,12 +4,11 @@ Copyright (C) 2017-2020  Bryant Moscon - bmoscon@gmail.com
 Please see the LICENSE file for the terms and conditions
 associated with this software.
 '''
-from cryptofeed.callback import Callback
-from cryptofeed.backends.aggregate import OHLCV
-
 from cryptofeed import FeedHandler
-from cryptofeed.exchanges import Coinbase
+from cryptofeed.backends.aggregate import OHLCV
+from cryptofeed.callback import Callback
 from cryptofeed.defines import TRADES
+from cryptofeed.exchanges import Coinbase
 
 
 async def ohlcv(data=None):

--- a/examples/demo_oi_liq.py
+++ b/examples/demo_oi_liq.py
@@ -6,11 +6,12 @@ associated with this software.
 '''
 from decimal import Decimal
 
-from cryptofeed.callback import OpenInterestCallback, LiquidationCallback
 from cryptofeed import FeedHandler
+from cryptofeed.callback import LiquidationCallback, OpenInterestCallback
+from cryptofeed.defines import ASK, BID, LIQUIDATIONS, OPEN_INTEREST
 from cryptofeed.exchanges import FTX, BinanceFutures, Deribit
-from cryptofeed.defines import  BID, ASK, OPEN_INTEREST, LIQUIDATIONS
-from cryptofeed.pairs import ftx_pairs, binance_futures_pairs
+from cryptofeed.pairs import binance_futures_pairs, ftx_pairs
+
 
 # Examples of some handlers for different updates. These currently don't do much.
 # Handlers should conform to the patterns/signatures in callback.py

--- a/examples/demo_okex_futures.py
+++ b/examples/demo_okex_futures.py
@@ -6,16 +6,7 @@ associated with this software.
 '''
 from cryptofeed import FeedHandler
 from cryptofeed.callback import BookCallback, TickerCallback, TradeCallback
-from cryptofeed.defines import (
-    ASK,
-    BID,
-    L2_BOOK,
-    L2_BOOK_FUTURES,
-    TICKER,
-    TICKER_FUTURES,
-    TRADES,
-    TRADES_FUTURES,
-)
+from cryptofeed.defines import ASK, BID, L2_BOOK, L2_BOOK_FUTURES, TICKER, TICKER_FUTURES, TRADES, TRADES_FUTURES
 from cryptofeed.exchanges import OKEx
 
 

--- a/examples/demo_okex_futures.py
+++ b/examples/demo_okex_futures.py
@@ -4,10 +4,19 @@ Copyright (C) 2017-2020  Bryant Moscon - bmoscon@gmail.com
 Please see the LICENSE file for the terms and conditions
 associated with this software.
 '''
-from cryptofeed.callback import TickerCallback, TradeCallback, BookCallback
 from cryptofeed import FeedHandler
+from cryptofeed.callback import BookCallback, TickerCallback, TradeCallback
+from cryptofeed.defines import (
+    ASK,
+    BID,
+    L2_BOOK,
+    L2_BOOK_FUTURES,
+    TICKER,
+    TICKER_FUTURES,
+    TRADES,
+    TRADES_FUTURES,
+)
 from cryptofeed.exchanges import OKEx
-from cryptofeed.defines import L2_BOOK_FUTURES, L2_BOOK, BID, ASK, TRADES, TRADES_FUTURES, TICKER, TICKER_FUTURES
 
 
 async def trade(feed, pair, order_id, timestamp, side, amount, price, receipt_timestamp):

--- a/examples/demo_okex_swaps.py
+++ b/examples/demo_okex_swaps.py
@@ -6,16 +6,7 @@ associated with this software.
 '''
 from cryptofeed import FeedHandler
 from cryptofeed.callback import BookCallback, TickerCallback, TradeCallback
-from cryptofeed.defines import (
-    ASK,
-    BID,
-    FUNDING,
-    L2_BOOK,
-    L2_BOOK_SWAP,
-    OPEN_INTEREST,
-    TRADES,
-    TRADES_SWAP,
-)
+from cryptofeed.defines import ASK, BID, FUNDING, L2_BOOK, L2_BOOK_SWAP, OPEN_INTEREST, TRADES, TRADES_SWAP
 from cryptofeed.exchanges import OKEx
 
 

--- a/examples/demo_okex_swaps.py
+++ b/examples/demo_okex_swaps.py
@@ -4,10 +4,19 @@ Copyright (C) 2017-2020  Bryant Moscon - bmoscon@gmail.com
 Please see the LICENSE file for the terms and conditions
 associated with this software.
 '''
-from cryptofeed.callback import TickerCallback, TradeCallback, BookCallback
 from cryptofeed import FeedHandler
+from cryptofeed.callback import BookCallback, TickerCallback, TradeCallback
+from cryptofeed.defines import (
+    ASK,
+    BID,
+    FUNDING,
+    L2_BOOK,
+    L2_BOOK_SWAP,
+    OPEN_INTEREST,
+    TRADES,
+    TRADES_SWAP,
+)
 from cryptofeed.exchanges import OKEx
-from cryptofeed.defines import L2_BOOK_SWAP, L2_BOOK, BID, ASK, TRADES, TRADES_SWAP, OPEN_INTEREST, FUNDING
 
 
 async def trade(feed, pair, order_id, timestamp, side, amount, price, receipt_timestamp):

--- a/examples/demo_open_interest.py
+++ b/examples/demo_open_interest.py
@@ -3,12 +3,11 @@ Copyright (C) 2017-2020  Bryant Moscon - bmoscon@gmail.com
 Please see the LICENSE file for the terms and conditions
 associated with this software.
 '''
-from cryptofeed.backends.arctic import TradeArctic, OpenInterestArctic
-from cryptofeed.backends.aggregate import OHLCV
-
 from cryptofeed import FeedHandler
+from cryptofeed.backends.aggregate import OHLCV
+from cryptofeed.backends.arctic import OpenInterestArctic, TradeArctic
+from cryptofeed.defines import OPEN_INTEREST, TRADES
 from cryptofeed.exchanges import Bitmex
-from cryptofeed.defines import TRADES, OPEN_INTEREST
 
 
 def main():

--- a/examples/demo_pair_separator.py
+++ b/examples/demo_pair_separator.py
@@ -4,10 +4,10 @@ Copyright (C) 2017-2020  Bryant Moscon - bmoscon@gmail.com
 Please see the LICENSE file for the terms and conditions
 associated with this software.
 '''
-from cryptofeed.callback import TickerCallback, TradeCallback, BookCallback
 from cryptofeed import FeedHandler
+from cryptofeed.callback import BookCallback, TickerCallback, TradeCallback
+from cryptofeed.defines import ASK, BID, COINBASE, L2_BOOK, L3_BOOK, TICKER, TRADES
 from cryptofeed.exchanges import Coinbase, Gemini
-from cryptofeed.defines import TRADES, TICKER, COINBASE, L2_BOOK, L3_BOOK, BID, ASK
 from cryptofeed.pairs import set_pair_separator
 
 

--- a/examples/demo_postgres.py
+++ b/examples/demo_postgres.py
@@ -4,12 +4,15 @@ Copyright (C) 2018-2020  Bryant Moscon - bmoscon@gmail.com
 Please see the LICENSE file for the terms and conditions
 associated with this software.
 '''
-from cryptofeed.backends.postgres import TradePostgres, TickerPostgres, BookPostgres, BookDeltaPostgres
 from cryptofeed import FeedHandler
+from cryptofeed.backends.postgres import (
+    BookDeltaPostgres,
+    BookPostgres,
+    TickerPostgres,
+    TradePostgres,
+)
+from cryptofeed.defines import BOOK_DELTA, L2_BOOK, TICKER, TRADES
 from cryptofeed.exchanges import Coinbase
-
-from cryptofeed.defines import TRADES, L2_BOOK, BOOK_DELTA, TICKER
-
 
 postgres_cfg = {'host': '127.0.0.1', 'user': 'postgres', 'db': 'postgres', 'pw': 'password123'}
 

--- a/examples/demo_postgres.py
+++ b/examples/demo_postgres.py
@@ -5,12 +5,7 @@ Please see the LICENSE file for the terms and conditions
 associated with this software.
 '''
 from cryptofeed import FeedHandler
-from cryptofeed.backends.postgres import (
-    BookDeltaPostgres,
-    BookPostgres,
-    TickerPostgres,
-    TradePostgres,
-)
+from cryptofeed.backends.postgres import BookDeltaPostgres, BookPostgres, TickerPostgres, TradePostgres
 from cryptofeed.defines import BOOK_DELTA, L2_BOOK, TICKER, TRADES
 from cryptofeed.exchanges import Coinbase
 

--- a/examples/demo_rabbitmq.py
+++ b/examples/demo_rabbitmq.py
@@ -2,8 +2,8 @@ from multiprocessing import Process
 
 from cryptofeed import FeedHandler
 from cryptofeed.backends.rabbitmq import BookRabbit
-from cryptofeed.exchanges import Kraken
 from cryptofeed.defines import L2_BOOK
+from cryptofeed.exchanges import Kraken
 
 
 def callback(ch, method, properties, body):

--- a/examples/demo_raw_data.py
+++ b/examples/demo_raw_data.py
@@ -4,10 +4,10 @@ Copyright (C) 2017-2020  Bryant Moscon - bmoscon@gmail.com
 Please see the LICENSE file for the terms and conditions
 associated with this software.
 '''
-from cryptofeed.util.async_file import AsyncFileCallback
 from cryptofeed import FeedHandler
-from cryptofeed.exchanges import Coinbase
 from cryptofeed.defines import L3_BOOK, TICKER, TRADES
+from cryptofeed.exchanges import Coinbase
+from cryptofeed.util.async_file import AsyncFileCallback
 
 
 def main():

--- a/examples/demo_redis.py
+++ b/examples/demo_redis.py
@@ -5,12 +5,7 @@ Please see the LICENSE file for the terms and conditions
 associated with this software.
 '''
 from cryptofeed import FeedHandler
-from cryptofeed.backends.redis import (
-    BookRedis,
-    FundingRedis,
-    OpenInterestRedis,
-    TradeRedis,
-)
+from cryptofeed.backends.redis import BookRedis, FundingRedis, OpenInterestRedis, TradeRedis
 from cryptofeed.defines import FUNDING, L2_BOOK, OPEN_INTEREST, TRADES
 from cryptofeed.exchanges import Bitfinex, Bitmex, Coinbase, Gemini
 

--- a/examples/demo_redis.py
+++ b/examples/demo_redis.py
@@ -4,11 +4,15 @@ Copyright (C) 2018-2020  Bryant Moscon - bmoscon@gmail.com
 Please see the LICENSE file for the terms and conditions
 associated with this software.
 '''
-from cryptofeed.backends.redis import TradeRedis, FundingRedis, BookRedis, OpenInterestRedis
 from cryptofeed import FeedHandler
-from cryptofeed.exchanges import Bitmex, Bitfinex, Coinbase, Gemini
-
-from cryptofeed.defines import TRADES, FUNDING, L2_BOOK, OPEN_INTEREST
+from cryptofeed.backends.redis import (
+    BookRedis,
+    FundingRedis,
+    OpenInterestRedis,
+    TradeRedis,
+)
+from cryptofeed.defines import FUNDING, L2_BOOK, OPEN_INTEREST, TRADES
+from cryptofeed.exchanges import Bitfinex, Bitmex, Coinbase, Gemini
 
 
 def main():

--- a/examples/demo_renko.py
+++ b/examples/demo_renko.py
@@ -4,14 +4,13 @@ Copyright (C) 2017-2020  Bryant Moscon - bmoscon@gmail.com
 Please see the LICENSE file for the terms and conditions
 associated with this software.
 '''
-from cryptofeed.callback import Callback
-from cryptofeed.backends.aggregate import RenkoFixed
+from datetime import datetime
 
 from cryptofeed import FeedHandler
-from cryptofeed.exchanges import Bitmex
+from cryptofeed.backends.aggregate import RenkoFixed
+from cryptofeed.callback import Callback
 from cryptofeed.defines import TRADES
-
-from datetime import datetime
+from cryptofeed.exchanges import Bitmex
 
 
 async def renko(data=None):

--- a/examples/demo_tcp.py
+++ b/examples/demo_tcp.py
@@ -5,14 +5,15 @@ Please see the LICENSE file for the terms and conditions
 associated with this software.
 '''
 import asyncio
-from multiprocessing import Process
-from yapic import json
 from decimal import Decimal
+from multiprocessing import Process
 
-from cryptofeed.backends.socket import TradeSocket, BookDeltaSocket, BookSocket
+from yapic import json
+
 from cryptofeed import FeedHandler
+from cryptofeed.backends.socket import BookDeltaSocket, BookSocket, TradeSocket
+from cryptofeed.defines import BOOK_DELTA, L2_BOOK, TRADES
 from cryptofeed.exchanges import Coinbase
-from cryptofeed.defines import TRADES, L2_BOOK, BOOK_DELTA
 
 
 async def reader(reader, writer):

--- a/examples/demo_udp.py
+++ b/examples/demo_udp.py
@@ -4,14 +4,15 @@ Copyright (C) 2018-2020  Bryant Moscon - bmoscon@gmail.com
 Please see the LICENSE file for the terms and conditions
 associated with this software.
 '''
-from multiprocessing import Process
 import socket
+from multiprocessing import Process
+
 from yapic import json
 
-from cryptofeed.backends.socket import TradeSocket, BookSocket, BookDeltaSocket
 from cryptofeed import FeedHandler
+from cryptofeed.backends.socket import BookDeltaSocket, BookSocket, TradeSocket
+from cryptofeed.defines import BOOK_DELTA, L2_BOOK, TRADES
 from cryptofeed.exchanges import Coinbase
-from cryptofeed.defines import L2_BOOK, TRADES, BOOK_DELTA
 
 
 def receiver(port):

--- a/examples/demo_uds.py
+++ b/examples/demo_uds.py
@@ -5,15 +5,16 @@ Please see the LICENSE file for the terms and conditions
 associated with this software.
 '''
 import asyncio
-from multiprocessing import Process
-from yapic import json
-from decimal import Decimal
 import os
+from decimal import Decimal
+from multiprocessing import Process
 
-from cryptofeed.backends.socket import TradeSocket, TickerSocket
+from yapic import json
+
 from cryptofeed import FeedHandler
+from cryptofeed.backends.socket import TickerSocket, TradeSocket
+from cryptofeed.defines import TICKER, TRADES
 from cryptofeed.exchanges import Coinbase
-from cryptofeed.defines import TRADES, TICKER
 
 
 async def reader(reader, writer):

--- a/examples/demo_upbit.py
+++ b/examples/demo_upbit.py
@@ -1,8 +1,7 @@
-from cryptofeed.callback import TradeCallback, BookCallback
 from cryptofeed import FeedHandler
-
+from cryptofeed.callback import BookCallback, TradeCallback
+from cryptofeed.defines import ASK, BID, L2_BOOK, TRADES
 from cryptofeed.exchanges import Upbit
-from cryptofeed.defines import TRADES, L2_BOOK, BID, ASK
 
 
 async def trade(feed, pair, order_id, timestamp, side, amount, price, receipt_timestamp):

--- a/examples/demo_zmq.py
+++ b/examples/demo_zmq.py
@@ -5,13 +5,13 @@ Please see the LICENSE file for the terms and conditions
 associated with this software.
 '''
 from multiprocessing import Process
+
 from yapic import json
 
-from cryptofeed.backends.zmq import BookZMQ, TickerZMQ
 from cryptofeed import FeedHandler
-from cryptofeed.exchanges import Kraken, Coinbase
-
+from cryptofeed.backends.zmq import BookZMQ, TickerZMQ
 from cryptofeed.defines import L2_BOOK, TICKER
+from cryptofeed.exchanges import Coinbase, Kraken
 
 
 def receiver(port):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,20 +1,19 @@
 [tool.isort]
 # These settings configure the tool isort to reformat the import sections
-# These settings are compatible with the tool black, see:
-# https://github.com/psf/black/blob/master/docs/compatible_configs.md#isort
 # isort requires the Cryptofeed dependencies to be installed
 # If you use Pipenv to manage the Cryptofeed dependencies,
-# you may use the following command line with isort v5:
+# You may use the following command line with isort v5:
+#     pipenv run isort --jobs 8 ./cryptofeed
+# or the safer alternative:
 #     python3 -m pipenv run python3 -m isort --jobs 8 ./cryptofeed
 # With isort v4, add option --recursive:
 #     python3 -m pipenv run python3 -m isort --jobs 8 --recursive ./cryptofeed
 known_first_party = "cryptofeed"
 py_version = 37
 atomic = true
-multi_line_output = 3
+# multi_line_output = 3
 include_trailing_comma = true
-force_grid_wrap = 0
+# force_grid_wrap = 0
 use_parentheses = true
 ensure_newline_before_comments = true
-line_length = 122
-profile = "black"
+line_length = 120

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,9 @@
 [tool.isort]
-# These settings configure the tool isort to reformat the import sections
-# isort requires the Cryptofeed dependencies to be installed
+# isort formats the import sections and
+# requires the Cryptofeed dependencies to be installed
+#
 # If you use Pipenv to manage the Cryptofeed dependencies,
-# You may use the following command line with isort v5:
+# you may use the following command line with isort v5:
 #     pipenv run isort --jobs 8 ./cryptofeed
 # or the safer alternative:
 #     python3 -m pipenv run python3 -m isort --jobs 8 ./cryptofeed
@@ -11,9 +12,12 @@
 known_first_party = "cryptofeed"
 py_version = 37
 atomic = true
-# multi_line_output = 3
-include_trailing_comma = true
-# force_grid_wrap = 0
+force_grid_wrap = 0
 use_parentheses = true
-ensure_newline_before_comments = true
 line_length = 120
+ensure_newline_before_comments = true
+#
+# Cryptofeed does not use black-compatible settings
+# multi_line_output = 3
+# include_trailing_comma = true
+# profile = "black"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,5 +16,5 @@ include_trailing_comma = true
 force_grid_wrap = 0
 use_parentheses = true
 ensure_newline_before_comments = true
-line_length = 88
+line_length = 122
 profile = "black"


### PR DESCRIPTION
Hi @bmoscon 

What do you think about this cleaning PR?
Do you like the `isort` result?
It sorts the imports alphabetically and when the line is too long, splits it using parenthesis.

On my opinion, `isort` does a good job.

If you like it, I can apply it on the entire code base.