### PR TITLE
Add support for Binance Future Funding

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -5,3 +5,4 @@ Cryptofeed was originally created by Bryant Moscon, but many others have contrib
 * [Quantfiction](https://github.com/quantfiction)
 * [Cody Jacques](https://github.com/PandaXcentric) - <jacques.co@northeastern.edu>
 * [O. Libre](https://github.com/olibre) - <olibre@Lmap.org>
+* [Ryan Tam](https://github.com/ryantam626) - <ryantam626@gmail.com>

--- a/cryptofeed/standards.py
+++ b/cryptofeed/standards.py
@@ -200,6 +200,7 @@ _feed_to_exchange_map = {
     FUNDING: {
         BITMEX: 'funding',
         BITFINEX: 'trades',
+        BINANCE_FUTURES: 'markPrice',
         KRAKEN_FUTURES: 'ticker',
         DERIBIT: 'ticker',
         OKEX: 'swap/funding_rate',


### PR DESCRIPTION
As title.

One thing I am not sure is if I should be including the mark price in the callback, I figured if it's provided we might as well include this and let the user ignore this in their callbacks.

Not sure if any automated test is needed, I can't see any that can be easily added right now. But I did try it out with a dev installation

```

In [1]: from cryptofeed import FeedHandler
   ...: from cryptofeed.callback import Callback
   ...: from cryptofeed.defines import FUNDING
   ...: from cryptofeed.exchange.binance_futures import BinanceFutures
   ...:
   ...: fh = FeedHandler()
   ...:
   ...: async def printer(*args, **kwargs):
   ...:     print(args, kwargs)
   ...:
   ...: fh.add_feed(BinanceFutures(pairs=["BTC-USDT"], channels=[FUNDING], callbacks={FUNDING: Callback(printer)}))
   ...: fh.run()
() {'feed': 'BINANCE_FUTURES', 'pair': 'BTC-USDT', 'timestamp': 1596408105.0, 'receipt_timestamp': 1596408105.1485846, 'mark_price': '11151.85929007', 'rate': '0.00025617', 'next_funding_time': 1596412800.0}
() {'feed': 'BINANCE_FUTURES', 'pair': 'BTC-USDT', 'timestamp': 1596408108.0, 'receipt_timestamp': 1596408108.1449494, 'mark_price': '11148.46000000', 'rate': '0.00025617', 'next_funding_time': 1596412800.0}
() {'feed': 'BINANCE_FUTURES', 'pair': 'BTC-USDT', 'timestamp': 1596408111.0, 'receipt_timestamp': 1596408111.1350107, 'mark_price': '11148.75701734', 'rate': '0.00025617', 'next_funding_time': 1596412800.0}
() {'feed': 'BINANCE_FUTURES', 'pair': 'BTC-USDT', 'timestamp': 1596408114.0, 'receipt_timestamp': 1596408114.143617, 'mark_price': '11148.91610825', 'rate': '0.00025617', 'next_funding_time': 1596412800.0}
() {'feed': 'BINANCE_FUTURES', 'pair': 'BTC-USDT', 'timestamp': 1596408117.0, 'receipt_timestamp': 1596408117.169013, 'mark_price': '11148.85974462', 'rate': '0.00025617', 'next_funding_time': 1596412800.0}
() {'feed': 'BINANCE_FUTURES', 'pair': 'BTC-USDT', 'timestamp': 1596408120.0, 'receipt_timestamp': 1596408120.1474774, 'mark_price': '11143.87579462', 'rate': '0.00025617', 'next_funding_time': 1596412800.0}
() {'feed': 'BINANCE_FUTURES', 'pair': 'BTC-USDT', 'timestamp': 1596408123.003, 'receipt_timestamp': 1596408123.1377418, 'mark_price': '11142.64505333', 'rate': '0.00025533', 'next_funding_time': 1596412800.0}
() {'feed': 'BINANCE_FUTURES', 'pair': 'BTC-USDT', 'timestamp': 1596408126.0, 'receipt_timestamp': 1596408126.1362357, 'mark_price': '11142.45414424', 'rate': '0.00025533', 'next_funding_time': 1596412800.0}
```