### PR TITLE
Use `async` and `await` in API Rest

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -16,7 +16,7 @@ pandas = "*"
 requests = ">=2.18.4"
 sortedcontainers = ">=1.5.9"
 websockets = ">=7.0"
-"yapic.json" = ">=1.4.3"   # fast, drop-in replacement of the built-in python.json
+"yapic.json" = ">=1.4.3"   # fast drop-in replacement of the built-in python.json
 # --- Optional packages to speed-up Cryptofeed -----------------------------------------------
 aiodns = ">=1.1"   # aiodns speeds up DNS resolving
 cchardet = "*"     # cchardet is a faster replacement for chardet

--- a/cryptofeed/rest/api.py
+++ b/cryptofeed/rest/api.py
@@ -88,19 +88,19 @@ class API:
             resp.raise_for_status()
 
     # public / non account specific
-    def ticker(self, symbol: str, retry=None, retry_wait=10):
+    async def ticker(self, symbol: str, start=None, end=None, retry=None, retry_wait=10):
         raise NotImplementedError
 
-    def trades(self, symbol: str, start=None, end=None, retry=None, retry_wait=0):
+    async def trades(self, symbol: str, start=None, end=None, retry=None, retry_wait=0):
         raise NotImplementedError
 
-    def funding(self, symbol: str, retry=None, retry_wait=0):
+    async def funding(self, symbol: str, start=None, end=None, retry=None, retry_wait=10):
         raise NotImplementedError
 
-    def l2_book(self, symbol: str, retry=None, retry_wait=0):
+    async def l2_book(self, symbol: str, retry=None, retry_wait=0):
         raise NotImplementedError
 
-    def l3_book(self, symbol: str, retry=None, retry_wait=0):
+    async def l3_book(self, symbol: str, retry=None, retry_wait=0):
         raise NotImplementedError
 
     # account specific

--- a/cryptofeed/rest/gemini.py
+++ b/cryptofeed/rest/gemini.py
@@ -1,9 +1,10 @@
+import asyncio
 import base64
 import hashlib
 import hmac
 import logging
 from decimal import Decimal
-from time import sleep, time
+from time import time
 
 import pandas as pd
 import requests
@@ -89,7 +90,7 @@ class Gemini(API):
         return resp.json()
 
     # Public Routes
-    def ticker(self, symbol: str, retry=None, retry_wait=0):
+    async def ticker(self, symbol: str, start=None, end=None, retry=None, retry_wait=0):
         sym = pair_std_to_exchange(symbol, self.ID)
         data = self._get(f"/v1/pubticker/{sym}", retry, retry_wait)
         return {'pair': symbol,
@@ -98,7 +99,7 @@ class Gemini(API):
                 'ask': Decimal(data['ask'])
                 }
 
-    def l2_book(self, symbol: str, retry=None, retry_wait=0):
+    async def l2_book(self, symbol: str, retry=None, retry_wait=0):
         sym = pair_std_to_exchange(symbol, self.ID)
         data = self._get(f"/v1/book/{sym}", retry, retry_wait)
         return {
@@ -112,7 +113,7 @@ class Gemini(API):
             })
         }
 
-    def trades(self, symbol: str, start=None, end=None, retry=None, retry_wait=10):
+    async def trades(self, symbol: str, start=None, end=None, retry=None, retry_wait=10):
         sym = pair_std_to_exchange(symbol, self.ID)
         params = {'limit_trades': 500}
         if start:
@@ -146,7 +147,7 @@ class Gemini(API):
             if not start and not end:
                 break
             # GEMINI rate limits to 120 requests a minute
-            sleep(RATE_LIMIT_SLEEP)
+            await asyncio.sleep(RATE_LIMIT_SLEEP)
 
     # Trading APIs
     def place_order(self, symbol: str, side: str, order_type: str, amount: Decimal, price=None, client_order_id=None, options=None):

--- a/cryptofeed/rest/poloniex.py
+++ b/cryptofeed/rest/poloniex.py
@@ -121,7 +121,7 @@ class Poloniex(API):
         return resp.json()
 
     # Public API Routes
-    def ticker(self, symbol: str, retry=None, retry_wait=10):
+    async def ticker(self, symbol: str, start=None, end=None, retry=None, retry_wait=10):
         sym = pair_std_to_exchange(symbol, self.ID)
         data = self._get("returnTicker", retry=retry, retry_wait=retry_wait)
         return {'pair': symbol,
@@ -130,7 +130,7 @@ class Poloniex(API):
                 'ask': Decimal(data[sym]['highestBid'])
                 }
 
-    def l2_book(self, symbol: str, retry=None, retry_wait=0):
+    async def l2_book(self, symbol: str, retry=None, retry_wait=0):
         sym = pair_std_to_exchange(symbol, self.ID)
         data = self._get("returnOrderBook", {'currencyPair': sym}, retry=retry, retry_wait=retry_wait)
         return {
@@ -155,7 +155,7 @@ class Poloniex(API):
             'price': Decimal(trade['rate'])
         }
 
-    def trades(self, symbol, start=None, end=None, retry=None, retry_wait=10):
+    async def trades(self, symbol, start=None, end=None, retry=None, retry_wait=10):
         symbol = pair_std_to_exchange(symbol, self.ID)
 
         @request_retry(self.ID, retry, retry_wait)

--- a/tests/integration/rest/test_rest.py
+++ b/tests/integration/rest/test_rest.py
@@ -1,21 +1,24 @@
 import pandas as pd
+import pytest
 
 from cryptofeed.defines import BUY, SELL
 from cryptofeed.rest import Rest
 
 
-def test_rest_bitmex():
+@pytest.mark.asyncio
+async def test_rest_bitmex():
     r = Rest()
     ret = []
     end = pd.Timestamp.now()
     start = end - pd.Timedelta(minutes=2)
-    for data in r.bitmex.trades('XBTUSD', start=start, end=end):
+    async for data in r.bitmex.trades('XBTUSD', start=start, end=end):
         ret.extend(data)
 
     assert len(ret) > 0
 
 
-def test_rest_bitfinex():
+@pytest.mark.asyncio
+async def test_rest_bitfinex():
     expected = {'timestamp': 1483228812.0,
                 'pair': 'BTC-USD',
                 'id': 25291508,
@@ -25,14 +28,15 @@ def test_rest_bitfinex():
                 'price': 966.61}
     r = Rest()
     ret = []
-    for data in r.bitfinex.trades('BTC-USD', start='2017-01-01 00:00:00', end='2017-01-01 0:00:13'):
+    async for data in r.bitfinex.trades('BTC-USD', start='2017-01-01 00:00:00', end='2017-01-01 0:00:13'):
         ret.extend(data)
 
     assert len(ret) == 1
     assert ret[0] == expected
 
 
-def test_rest_deribit():
+@pytest.mark.asyncio
+async def test_rest_deribit():
     expected = {'timestamp': 1550062892.378,
                 'pair': 'BTC-PERPETUAL',
                 'id': 15340745,
@@ -42,12 +46,13 @@ def test_rest_deribit():
                 'price': 3580.25}
     r = Rest()
     ret = []
-    for data in r.deribit.trades('BTC-PERPETUAL', start='2019-02-13 12:59:10', end='2019-02-13 13:01:33'):
+    async for data in r.deribit.trades('BTC-PERPETUAL', start='2019-02-13 12:59:10', end='2019-02-13 13:01:33'):
         ret.extend(data)
     assert ret[0] == expected
 
 
-def test_rest_ftx():
+@pytest.mark.asyncio
+async def test_rest_ftx():
     expected = {'timestamp': 1591992000.0,
                 'pair': 'BTC-PERP',
                 'feed': 'FTX',
@@ -55,7 +60,7 @@ def test_rest_ftx():
 
     r = Rest()
     ret = []
-    data = r.ftx.funding('BTC-PERP', start_date='2020-06-10 12:59:10', end_date='2020-06-13 13:01:33')
+    data = await r.ftx.funding('BTC-PERP', start='2020-06-10 12:59:10', end='2020-06-13 13:01:33')
     ret.extend(data)
     try:
         assert ret[0] == expected

--- a/tests/unit/rest_apis/test_gemini.py
+++ b/tests/unit/rest_apis/test_gemini.py
@@ -8,22 +8,25 @@ public = Rest('config.yaml').Gemini
 sandbox = Rest('config.yaml', sandbox=True).Gemini
 
 
-def test_ticker():
-    ticker = public.ticker('BTC-USD')
+@pytest.mark.asyncio
+async def test_ticker():
+    ticker = await public.ticker('BTC-USD')
 
     assert BID in ticker
     assert ASK in ticker
 
 
-def test_order_book():
-    current_order_book = public.l2_book('BTC-USD')
+@pytest.mark.asyncio
+async def test_order_book():
+    current_order_book = await public.l2_book('BTC-USD')
 
     assert BID in current_order_book
     assert len(current_order_book[BID]) > 0
 
 
-def test_trade_history():
-    trade_history = list(public.trades('BTC-USD'))
+@pytest.mark.asyncio
+async def test_trade_history():
+    trade_history = [trade async for trade in public.trades('BTC-USD')]
 
     assert len(trade_history) > 0
 

--- a/tests/unit/rest_apis/test_kraken.py
+++ b/tests/unit/rest_apis/test_kraken.py
@@ -7,13 +7,15 @@ from cryptofeed.rest import Rest
 kraken = Rest('config.yaml').kraken
 
 
-def test_get_order_book():
-    book = kraken.l2_book('BTC-USD')
+@pytest.mark.asyncio
+async def test_get_order_book():
+    book = await kraken.l2_book('BTC-USD')
     assert len(book[BID]) > 0
 
 
-def test_get_recent_trades():
-    trades = list(kraken.trades('BTC-USD'))
+@pytest.mark.asyncio
+async def test_get_recent_trades():
+    trades = [trade async for trade in kraken.trades('BTC-USD')]
     assert len(trades) > 0
 
 

--- a/tests/unit/rest_apis/test_poloniex.py
+++ b/tests/unit/rest_apis/test_poloniex.py
@@ -7,21 +7,24 @@ from cryptofeed.rest import Rest
 poloniex = Rest('config.yaml').Poloniex
 
 
-def test_get_ticker():
-    ticker = poloniex.ticker('BTC-USDT')
+@pytest.mark.asyncio
+async def test_get_ticker():
+    ticker = await poloniex.ticker('BTC-USDT')
     assert ticker['bid'] > 0
 
 
-def test_order_book():
-    order_book = poloniex.l2_book('BTC-USDT')
+@pytest.mark.asyncio
+async def test_order_book():
+    order_book = await poloniex.l2_book('BTC-USDT')
 
     assert BID in order_book
     assert ASK in order_book
     assert len(order_book[BID]) > 0
 
 
-def test_trade_history():
-    trade_history = list(next(poloniex.trades('BTC-USDT', start='2020-01-01', end='2020-01-02')))
+@pytest.mark.asyncio
+async def test_trade_history():
+    trade_history = [next(trade) async for trade in poloniex.trades('BTC-USDT', start='2020-01-01', end='2020-01-02')]
     assert len(trade_history) > 0
     assert float(trade_history[0]['amount']) > 0
 


### PR DESCRIPTION
Hi @bmoscon 

This PR to boost the performance of the API Rest by using good AsyncIO practices :
- Use `async` and `await` in API Rest
- Replace `time.sleep()` --> `await asyncio.sleep()`
- Adapt the unit tests with `@pytest.mark.asyncio`

Moreover, all the functions `ticker()`, `trades()` and `funding()` use the parameters `start=None` and `end=None` because on some exchanges, these parameters were already present, but not within the base `class Api`. Now everything is consistent.

Therefore the parameters `start_date` and `end_date` in `Ftx.funding()` have been renamed.
And the nested `helper()` function does not need these parameters because it already accesses scoped variables of the parent function.

Please perform a carefully code review.
Cheers