### PR TITLE
Require aiofile>=2.0.0; fix write bug in AsyncFileCallback's write method for aiofile>=2.0.0 

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -16,21 +16,21 @@ pandas = "*"
 requests = ">=2.18.4"
 sortedcontainers = ">=1.5.9"
 websockets = ">=7.0"
-"yapic.json" = ">=1.4.3"   # fast, drop-in replacement of the built-in python.json
+"yapic.json" = ">=1.4.3"    # fast, drop-in replacement of the built-in python.json
 # --- Optional packages to speed-up Cryptofeed -----------------------------------------------
-aiodns = ">=1.1"   # aiodns speeds up DNS resolving
-cchardet = "*"     # cchardet is a faster replacement for chardet
+aiodns = ">=1.1"            # aiodns speeds up DNS resolving
+cchardet = "*"              # cchardet is a faster replacement for chardet
 # --- Optional dependencies ------------------------------------------------------------------
-aiofile = ">=2.0.0"      # used by util/async_file.py
-aiokafka = "*"     # pip install cryptofeed[kafka]
-aioredis = "*"     # pip install cryptofeed[redis]
-arctic = "*"       # pip install cryptofeed[arctic]
-asyncpg = "*"      # pip install cryptofeed[postgres]
-motor = "*"        # pip install cryptofeed[mongo]
-aio_pika = "*"     # pip install cryptofeed[rabbit]
-pika = "*"         # used by demo_rabbitmq.py
-pyyaml = "*"       # pip install cryptofeed[rest_api]
-pyzmq = "*"        # pip install cryptofeed[zmq]
+aiofile = ">=2.0.0"         # used by util/async_file.py
+aiokafka = "*"              # pip install cryptofeed[kafka]
+aioredis = "*"              # pip install cryptofeed[redis]
+arctic = "*"                # pip install cryptofeed[arctic]
+asyncpg = "*"               # pip install cryptofeed[postgres]
+motor = "*"                 # pip install cryptofeed[mongo]
+aio_pika = "*"              # pip install cryptofeed[rabbit]
+pika = "*"                  # used by demo_rabbitmq.py
+pyyaml = "*"                # pip install cryptofeed[rest_api]
+pyzmq = "*"                 # pip install cryptofeed[zmq]
 
 [dev-packages]
 isort = {extras = ["pipfile"], version = "*"}

--- a/Pipfile
+++ b/Pipfile
@@ -21,7 +21,7 @@ websockets = ">=7.0"
 aiodns = ">=1.1"   # aiodns speeds up DNS resolving
 cchardet = "*"     # cchardet is a faster replacement for chardet
 # --- Optional dependencies ------------------------------------------------------------------
-aiofile = "*"      # used by util/async_file.py
+aiofile = ">=2.0.0"      # used by util/async_file.py
 aiokafka = "*"     # pip install cryptofeed[kafka]
 aioredis = "*"     # pip install cryptofeed[redis]
 arctic = "*"       # pip install cryptofeed[arctic]

--- a/cryptofeed/util/async_file.py
+++ b/cryptofeed/util/async_file.py
@@ -29,7 +29,7 @@ class AsyncFileCallback:
         p = f"{self.path}/{uuid}.{self.count[uuid]}"
         async with AIOFile(p, mode='a') as fp:
             r = await fp.write("\n".join(self.data[uuid]) + "\n", offset=self.pointer[uuid])
-            self.pointer[uuid] += len(r)
+            self.pointer[uuid] += r
             self.data[uuid] = []
 
         if self.pointer[uuid] >= self.rotate:

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ setup(
         "sortedcontainers>=1.5.9",
         "pandas",
         "aiohttp==3.6.2",
-        "aiofile",
+        "aiofile>=2.0.0",
         "yapic.json>=1.4.3",
         # Two (optional) dependencies that speed up Cryptofeed:
         "aiodns>=1.1",  # aiodns speeds up DNS resolving


### PR DESCRIPTION
Implements the second fix from #282, and closes #282 

Summary:

- Fixes write bug in async_file.py
- Requires aiofile>=2.0.0 in Pipfile
- Formats Pipfile comments

EDIT: Also adds aiofile>=2.0.0 to setup.py