### PR TITLE
Changed binancefutures ticker to correct api endpoint

### DIFF
--- a/cryptofeed/exchange/binance_futures.py
+++ b/cryptofeed/exchange/binance_futures.py
@@ -71,13 +71,13 @@ class BinanceFutures(Binance):
             # the ticker stream (<symbol>@bookTicker) is
             # the only payload without an "e" key describing the event type
             await self._ticker(msg, timestamp)
-        elif msg['e'] == 'depthUpdate':
+        elif msg_type == 'depthUpdate':
             await self._book(msg, pair, timestamp)
-        elif msg['e'] == 'aggTrade':
+        elif msg_type == 'aggTrade':
             await self._trade(msg, timestamp)
-        elif msg['e'] == 'forceOrder':
+        elif msg_type == 'forceOrder':
             await self._liquidations(msg, timestamp)
-        elif msg['e'] == 'markPriceUpdate':
+        elif msg_type == 'markPriceUpdate':
             await self._funding(msg, timestamp)
         else:
             LOG.warning("%s: Unexpected message received: %s", self.id, msg)

--- a/cryptofeed/exchange/binance_futures.py
+++ b/cryptofeed/exchange/binance_futures.py
@@ -4,11 +4,13 @@ Copyright (C) 2017-2020  Bryant Moscon - bmoscon@gmail.com
 Please see the LICENSE file for the terms and conditions
 associated with this software.
 '''
+from decimal import Decimal
 import logging
 
-from cryptofeed.defines import BINANCE_FUTURES
-from cryptofeed.exchange.binance import Binance
+from yapic import json
 
+from cryptofeed.defines import BINANCE_FUTURES, OPEN_INTEREST, TICKER
+from cryptofeed.exchange.binance import Binance
 
 LOG = logging.getLogger('feedhandler')
 
@@ -21,6 +23,20 @@ class BinanceFutures(Binance):
         self.ws_endpoint = 'wss://fstream.binance.com'
         self.rest_endpoint = 'https://fapi.binance.com/fapi/v1'
         self.address = self._address()
+
+    def _address(self):
+        address = self.ws_endpoint + '/stream?streams='
+        for chan in self.channels if not self.config else self.config:
+            if chan == OPEN_INTEREST:
+                continue
+            for pair in self.pairs if not self.config else self.config[chan]:
+                pair = pair.lower()
+                if chan == TICKER:
+                    stream = f"{pair}@bookTicker/"
+                else:
+                    stream = f"{pair}@{chan}/"
+                address += stream
+        return address[:-1]
 
     def _check_update_id(self, pair: str, msg: dict) -> (bool, bool):
         skip_update = False
@@ -38,3 +54,30 @@ class BinanceFutures(Binance):
             LOG.warning("%s: Missing book update detected, resetting book", self.id)
             skip_update = True
         return skip_update, forced
+
+    async def message_handler(self, msg: str, timestamp: float):
+        msg = json.loads(msg, parse_float=Decimal)
+
+        # Combined stream events are wrapped as follows: {"stream":"<streamName>","data":<rawPayload>}
+        # streamName is of format <symbol>@<channel>
+        pair, _ = msg['stream'].split('@', 1)
+        msg = msg['data']
+
+        pair = pair.upper()
+
+        msg_type = msg.get('e')
+        if msg_type is None:
+            # For the BinanceFutures API it appears
+            # the ticker stream (<symbol>@bookTicker) is
+            # the only payload without an "e" key describing the event type
+            await self._ticker(msg, timestamp)
+        elif msg['e'] == 'depthUpdate':
+            await self._book(msg, pair, timestamp)
+        elif msg['e'] == 'aggTrade':
+            await self._trade(msg, timestamp)
+        elif msg['e'] == 'forceOrder':
+            await self._liquidations(msg, timestamp)
+        elif msg['e'] == 'markPriceUpdate':
+            await self._funding(msg, timestamp)
+        else:
+            LOG.warning("%s: Unexpected message received: %s", self.id, msg)


### PR DESCRIPTION
BinanceFutures now has its own `_address` and `message_handler` class functions (instead of using parent Binance).

NOTE: as discussed, some more work could be done in moving some code from Binance parent class which belongs solely to BinanceFutures (i.e. liquidations, open interest and funding).
