### PR TITLE
Expose log filename and log level as parameters in FeedHandler and Rest initializers

### DIFF
--- a/cryptofeed/feedhandler.py
+++ b/cryptofeed/feedhandler.py
@@ -6,6 +6,7 @@ associated with this software.
 '''
 import asyncio
 import zlib
+import logging
 from collections import defaultdict
 from copy import deepcopy
 from socket import error as socket_error
@@ -28,7 +29,7 @@ from cryptofeed.log import get_logger
 from cryptofeed.nbbo import NBBO
 
 
-LOG = get_logger('feedhandler', 'feedhandler.log')
+LOG = None
 
 
 # Maps string name to class name for use with config
@@ -67,7 +68,8 @@ _EXCHANGES = {
 
 
 class FeedHandler:
-    def __init__(self, retries=10, timeout_interval=10, log_messages_on_error=False, raw_message_capture=None, handler_enabled=True):
+    def __init__(self, retries=10, timeout_interval=10, log_messages_on_error=False, raw_message_capture=None, handler_enabled=True,
+                 log_filename="feedhandler.log", log_level=logging.WARNING):
         """
         retries: int
             number of times the connection will be retried (in the event of a disconnect or other failure)
@@ -79,6 +81,10 @@ class FeedHandler:
             if defined, callback to save/process/handle raw message (primarily for debugging purposes)
         handler_enabled: boolean
             run message handlers (and any registered callbacks) when raw message capture is enabled
+        log_filename: str
+            filename to log feedhandler log messages to
+        log_level: int
+            minimum log level that log messages must have to be logged
         """
         self.feeds = []
         self.retries = retries
@@ -88,6 +94,8 @@ class FeedHandler:
         self.log_messages_on_error = log_messages_on_error
         self.raw_message_capture = raw_message_capture
         self.handler_enabled = handler_enabled
+        global LOG
+        LOG = get_logger('feedhandler', log_filename, log_level)
 
     def add_feed(self, feed, timeout=120, **kwargs):
         """

--- a/cryptofeed/feedhandler.py
+++ b/cryptofeed/feedhandler.py
@@ -5,8 +5,9 @@ Please see the LICENSE file for the terms and conditions
 associated with this software.
 '''
 import asyncio
-import zlib
 import logging
+import os
+import zlib
 from collections import defaultdict
 from copy import deepcopy
 from socket import error as socket_error
@@ -29,8 +30,9 @@ from cryptofeed.log import get_logger
 from cryptofeed.nbbo import NBBO
 
 
-LOG = None
-
+LOG = get_logger('feedhandler', 
+                 os.environ.get('CRYPTOFEED_FEEDHANDLER_LOG_FILENAME', "feedhandler.log"), 
+                 int(os.environ.get('CRYPTOFEED_FEEDHANDLER_LOG_LEVEL', logging.WARNING)))
 
 # Maps string name to class name for use with config
 _EXCHANGES = {
@@ -68,8 +70,7 @@ _EXCHANGES = {
 
 
 class FeedHandler:
-    def __init__(self, retries=10, timeout_interval=10, log_messages_on_error=False, raw_message_capture=None, handler_enabled=True,
-                 log_filename="feedhandler.log", log_level=logging.WARNING):
+    def __init__(self, retries=10, timeout_interval=10, log_messages_on_error=False, raw_message_capture=None, handler_enabled=True):
         """
         retries: int
             number of times the connection will be retried (in the event of a disconnect or other failure)
@@ -81,10 +82,6 @@ class FeedHandler:
             if defined, callback to save/process/handle raw message (primarily for debugging purposes)
         handler_enabled: boolean
             run message handlers (and any registered callbacks) when raw message capture is enabled
-        log_filename: str
-            filename to log feedhandler log messages to
-        log_level: int
-            minimum log level that log messages must have to be logged
         """
         self.feeds = []
         self.retries = retries
@@ -94,8 +91,6 @@ class FeedHandler:
         self.log_messages_on_error = log_messages_on_error
         self.raw_message_capture = raw_message_capture
         self.handler_enabled = handler_enabled
-        global LOG
-        LOG = get_logger('feedhandler', log_filename, log_level)
 
     def add_feed(self, feed, timeout=120, **kwargs):
         """

--- a/cryptofeed/rest/rest.py
+++ b/cryptofeed/rest/rest.py
@@ -5,6 +5,7 @@ Please see the LICENSE file for the terms and conditions
 associated with this software.
 '''
 import logging
+import os
 
 from cryptofeed.log import get_logger
 from cryptofeed.rest.bitfinex import Bitfinex
@@ -18,7 +19,9 @@ from cryptofeed.rest.poloniex import Poloniex
 from cryptofeed.standards import load_exchange_pair_mapping
 
 
-LOG = None
+LOG = get_logger('rest', 
+                 os.environ.get('CRYPTOFEED_REST_LOG_FILENAME', "rest.log"), 
+                 int(os.environ.get('CRYPTOFEED_REST_LOG_LEVEL', logging.WARNING)))
 
 
 class Rest:
@@ -30,10 +33,10 @@ class Rest:
 
     The Rest class optionally takes two exchange-related parameters, config, and sandbox. 
     In the config file the api key and secrets can be specified. Sandbox enables sandbox 
-    mode, if supported by the exchange. The Rest class also takes two logging parameters.
+    mode, if supported by the exchange.
     """
 
-    def __init__(self, config=None, sandbox=False, log_filename="rest.log", log_level=logging.WARNING):
+    def __init__(self, config=None, sandbox=False):
         self.config = config
         self.lookup = {
             'bitmex': Bitmex(config),
@@ -45,8 +48,6 @@ class Rest:
             'deribit': Deribit(config),
             'ftx': FTX(config)
         }
-        global LOG
-        LOG = get_logger('rest', log_filename, log_level)
 
     def __getitem__(self, key):
         exch = self.lookup[key.lower()]

--- a/cryptofeed/rest/rest.py
+++ b/cryptofeed/rest/rest.py
@@ -4,6 +4,8 @@ Copyright (C) 2017-2020  Bryant Moscon - bmoscon@gmail.com
 Please see the LICENSE file for the terms and conditions
 associated with this software.
 '''
+import logging
+
 from cryptofeed.log import get_logger
 from cryptofeed.rest.bitfinex import Bitfinex
 from cryptofeed.rest.bitmex import Bitmex
@@ -16,7 +18,7 @@ from cryptofeed.rest.poloniex import Poloniex
 from cryptofeed.standards import load_exchange_pair_mapping
 
 
-LOG = get_logger('rest', 'rest.log')
+LOG = None
 
 
 class Rest:
@@ -26,11 +28,12 @@ class Rest:
     r = Rest()
     r.bitmex.trades('XBTUSD', '2018-01-01', '2018-01-01')
 
-    The Rest class optionally takes two parameters, config, and sandbox. In the config file
-    the api key and secrets can be specified. sandbox enables sandbox mode, if supported by the exchange.
+    The Rest class optionally takes two exchange-related parameters, config, and sandbox. 
+    In the config file the api key and secrets can be specified. Sandbox enables sandbox 
+    mode, if supported by the exchange. The Rest class also takes two logging parameters.
     """
 
-    def __init__(self, config=None, sandbox=False):
+    def __init__(self, config=None, sandbox=False, log_filename="rest.log", log_level=logging.WARNING):
         self.config = config
         self.lookup = {
             'bitmex': Bitmex(config),
@@ -42,6 +45,8 @@ class Rest:
             'deribit': Deribit(config),
             'ftx': FTX(config)
         }
+        global LOG
+        LOG = get_logger('rest', log_filename, log_level)
 
     def __getitem__(self, key):
         exch = self.lookup[key.lower()]


### PR DESCRIPTION
This PR simply allows a user of the `Feedhandler` and `Rest` classes to specify the log filename and log level. Logging can then be done by the user like so:
```
import logging

f = Feedhandler(log_filename="log_filename_here.log", log_level=logging.INFO)
LOG = logging.getLogger("feedhandler")
LOG.info("starting feedhandler now")
f.run()
```
Existing filenames, levels, and log names are retained in default parameters.

NB: Setting the LOG object in feedhandler.py and rest.py is done using the `global` keyword; if you don't like this, let me know and I'll figure out something better.