### PR TITLE
Support order_type in Trade Callback

### DIFF
--- a/cryptofeed/callback.py
+++ b/cryptofeed/callback.py
@@ -25,8 +25,16 @@ class Callback:
 
 
 class TradeCallback(Callback):
-    async def __call__(self, *, feed: str, pair: str, side: str, amount: Decimal, price: Decimal, order_id=None, timestamp: float, receipt_timestamp: float):
-        await super().__call__(feed, pair, order_id, timestamp, side, amount, price, receipt_timestamp)
+
+    def __init__(self, callback, include_order_type=False):
+        self.include_order_type = include_order_type
+        super().__init__(callback)
+
+    async def __call__(self, *, feed: str, pair: str, side: str, amount: Decimal, price: Decimal, order_id=None, timestamp: float, receipt_timestamp: float, order_type: str=None):
+        kwargs = {}
+        if self.include_order_type:
+            kwargs['order_type'] = order_type
+        await super().__call__(feed, pair, order_id, timestamp, side, amount, price, receipt_timestamp, **kwargs)
 
 
 class TickerCallback(Callback):

--- a/cryptofeed/exchange/kraken.py
+++ b/cryptofeed/exchange/kraken.py
@@ -60,7 +60,8 @@ class Kraken(Feed):
         channel id, price, amount, timestamp, size, limit/market order, misc
         """
         for trade in msg[1]:
-            price, amount, server_timestamp, side, _, _ = trade
+            price, amount, server_timestamp, side, order_type, _ = trade
+            order_type = 'limit' if order_type == 'l' else 'market'
             await self.callback(TRADES, feed=self.id,
                                 pair=pair,
                                 side=BUY if side == 'b' else SELL,
@@ -68,7 +69,8 @@ class Kraken(Feed):
                                 price=Decimal(price),
                                 order_id=None,
                                 timestamp=float(server_timestamp),
-                                receipt_timestamp=timestamp)
+                                receipt_timestamp=timestamp,
+                                order_type=order_type)
 
     async def _ticker(self, msg: dict, pair: str, timestamp: float):
         """


### PR DESCRIPTION
Kraken (and perhaps other exchanges) sends down the `order_type` (market vs limit) that triggered a particular trade. This PR optionally passes this into the TRADES callback; to receive the order type, `include_order_type=True` must be passed when initializing the `TradeCallback` (to prevent a breaking change with previously written callbacks that didn't expect another arg or kwarg).