### PR TITLE
Optionally keep track of order type for Coinbase, if L3_BOOK channel is enabled

### DIFF
--- a/cryptofeed/callback.py
+++ b/cryptofeed/callback.py
@@ -28,8 +28,11 @@ class TradeCallback(Callback):
 
     def __init__(self, callback, include_order_type=False):
         """
-        include_order_type is currently supported only on Kraken and enables
-        the order_type field in callbacks, which contains information about the order type (market/limit)
+        include_order_type is currently supported only on Kraken and Coinbase and enables
+        the order_type field in callbacks, which contains information about the order type (market/limit).
+
+        Note that to receive order_type on Coinbase, you must also subscribe to the L3_BOOK channel (though
+        do not need to specify any L3_BOOK callbacks)
         """
         self.include_order_type = include_order_type
         super().__init__(callback)

--- a/cryptofeed/exchange/coinbase.py
+++ b/cryptofeed/exchange/coinbase.py
@@ -13,7 +13,7 @@ import requests
 from sortedcontainers import SortedDict as sd
 from yapic import json
 
-from cryptofeed.defines import BID, ASK, BUY, COINBASE, L2_BOOK, L3_BOOK, SELL, TICKER, TRADES
+from cryptofeed.defines import BID, ASK, BOOK_DELTA, BUY, COINBASE, L2_BOOK, L3_BOOK, SELL, TICKER, TRADES
 from cryptofeed.feed import Feed
 from cryptofeed.standards import pair_exchange_to_std, timestamp_normalize
 
@@ -26,10 +26,16 @@ class Coinbase(Feed):
 
     def __init__(self, pairs=None, channels=None, callbacks=None, **kwargs):
         super().__init__('wss://ws-feed.pro.coinbase.com', pairs=pairs, channels=channels, callbacks=callbacks, **kwargs)
+        # we only keep track of the order book if we have at least one subscribed order-book callback
+        self.keep_order_book = False
+        for cb_type in callbacks:
+            if cb_type in (L3_BOOK, L2_BOOK, BOOK_DELTA):
+                self.keep_order_book = True
         self.__reset()
 
     def __reset(self):
         self.order_map = {}
+        self.order_type_map = {}
         self.seq_no = {}
         self.l3_book = {}
         self.l2_book = {}
@@ -92,7 +98,7 @@ class Coinbase(Feed):
         '''
         pair = pair_exchange_to_std(msg['product_id'])
 
-        if 'full' in self.channels or ('full' in self.config and pair in self.config['full']):
+        if self.keep_order_book and ('full' in self.channels or ('full' in self.config and pair in self.config['full'])):
             delta = {BID: [], ASK: []}
             price = Decimal(msg['price'])
             side = ASK if msg['side'] == 'sell' else BID
@@ -104,6 +110,7 @@ class Coinbase(Feed):
             new_size -= size
             if new_size <= 0:
                 del self.order_map[maker_order_id]
+                self.order_type_map.pop(maker_order_id, None)
                 delta[side].append((maker_order_id, price, 0))
                 del self.l3_book[pair][side][price][maker_order_id]
                 if len(self.l3_book[pair][side][price]) == 0:
@@ -115,6 +122,7 @@ class Coinbase(Feed):
 
             await self.book_callback(self.l3_book[pair], L3_BOOK, pair, False, delta, ts, timestamp)
 
+        order_type = self.order_type_map.get(msg['taker_order_id'])
         await self.callback(TRADES,
                             feed=self.id,
                             pair=pair_exchange_to_std(msg['product_id']),
@@ -123,10 +131,13 @@ class Coinbase(Feed):
                             amount=Decimal(msg['size']),
                             price=Decimal(msg['price']),
                             timestamp=timestamp_normalize(self.id, msg['time']),
-                            receipt_timestamp=timestamp
+                            receipt_timestamp=timestamp,
+                            order_type=order_type
                             )
 
     async def _pair_level2_snapshot(self, msg: dict, timestamp: float):
+        if not self.keep_order_book:
+            return
         pair = pair_exchange_to_std(msg['product_id'])
         self.l2_book[pair] = {
             BID: sd({
@@ -142,6 +153,8 @@ class Coinbase(Feed):
         await self.book_callback(self.l2_book[pair], L2_BOOK, pair, True, None, timestamp, timestamp)
 
     async def _pair_level2_update(self, msg: dict, timestamp: float):
+        if not self.keep_order_book:
+            return
         pair = pair_exchange_to_std(msg['product_id'])
         delta = {BID: [], ASK: []}
         for side, price, amount in msg['changes']:
@@ -195,6 +208,8 @@ class Coinbase(Feed):
             await self.book_callback(self.l3_book[npair], L3_BOOK, npair, True, None, timestamp, timestamp)
 
     async def _open(self, msg: dict, timestamp: float):
+        if not self.keep_order_book:
+            return
         delta = {BID: [], ASK: []}
         price = Decimal(msg['price'])
         side = ASK if msg['side'] == 'sell' else BID
@@ -221,27 +236,43 @@ class Coinbase(Feed):
         to self-trade prevention. There will be no open message for such orders. Done messages
         for orders which are not on the book should be ignored when maintaining a real-time order book.
         """
-        delta = {BID: [], ASK: []}
-
         if 'price' not in msg:
             return
 
         order_id = msg['order_id']
+        self.order_type_map.pop(order_id, None)
         if order_id not in self.order_map:
             return
 
-        price = Decimal(msg['price'])
-        side = ASK if msg['side'] == 'sell' else BID
-        pair = pair_exchange_to_std(msg['product_id'])
-        ts = timestamp_normalize(self.id, msg['time'])
-
-        del self.l3_book[pair][side][price][order_id]
-        if len(self.l3_book[pair][side][price]) == 0:
-            del self.l3_book[pair][side][price]
-        delta[side].append((order_id, price, 0))
         del self.order_map[order_id]
+        if self.keep_order_book:
+            delta = {BID: [], ASK: []}
 
-        await self.book_callback(self.l3_book[pair], L3_BOOK, pair, False, delta, ts, timestamp)
+            price = Decimal(msg['price'])
+            side = ASK if msg['side'] == 'sell' else BID
+            pair = pair_exchange_to_std(msg['product_id'])
+            ts = timestamp_normalize(self.id, msg['time'])
+
+            del self.l3_book[pair][side][price][order_id]
+            if len(self.l3_book[pair][side][price]) == 0:
+                del self.l3_book[pair][side][price]
+            delta[side].append((order_id, price, 0))
+
+            await self.book_callback(self.l3_book[pair], L3_BOOK, pair, False, delta, ts, timestamp)
+
+    async def _received(self, msg: dict, timestamp: float):
+        """
+        per Coinbase docs:
+        A valid order has been received and is now active. This message is emitted for every single
+        valid order as soon as the matching engine receives it whether it fills immediately or not.
+
+        This message is the only time we receive the order type (limit vs market) for a given order,
+        so we keep it in a map by order ID.
+        """
+        order_id = msg["order_id"]
+        order_type = msg["order_type"]
+        self.order_type_map[order_id] = order_type
+
 
     async def _change(self, msg: dict, timestamp: float):
         """
@@ -251,6 +282,8 @@ class Coinbase(Feed):
         be sent for received orders which are not yet on the order book. Do not alter
         the order book for such messages, otherwise your order book will be incorrect.
         """
+        if not self.keep_order_book:
+            return
 
         delta = {BID: [], ASK: []}
 
@@ -282,7 +315,7 @@ class Coinbase(Feed):
             pair = pair_exchange_to_std(msg['product_id'])
             if msg['sequence'] <= self.seq_no[pair]:
                 return
-            elif ('full' in self.channels or 'full' in self.config) and msg['sequence'] != self.seq_no[pair] + 1:
+            elif (self.keep_order_book and ('full' in self.channels or 'full' in self.config)) and msg['sequence'] != self.seq_no[pair] + 1:
                 LOG.warning("%s: Missing sequence number detected for %s", self.id, pair)
                 LOG.warning("%s: Requesting book snapshot", self.id)
                 await self._book_snapshot(self.pairs or self.book_pairs)
@@ -306,7 +339,7 @@ class Coinbase(Feed):
             elif msg['type'] == 'change':
                 await self._change(msg, timestamp)
             elif msg['type'] == 'received':
-                pass
+                await self._received(msg, timestamp)
             elif msg['type'] == 'activate':
                 pass
             elif msg['type'] == 'subscriptions':


### PR DESCRIPTION
Building off of #297, this adds support for order type (market/limit) to the taking side of a trade for Coinbase. 

Totally open to keeping a branch up to date instead of merging if this seems like too much intervention for this feature. I don't love that we now check for `keep_order_book` in multiple places, very open to different suggestions.

Test plan:
1) Subscribe to Coinbase with:
```
fh.add_feed(
    Coinbase(pairs=["BTC-USD"], channels=[L3_BOOK, TRADES], callbacks={
        TRADES: TradeCallback(process_trade, include_order_type=True)
    }
))
```
Verify that Order Type is sent to the process_trade callback

2) Subscribe to Coinbase with:
```
fh.add_feed(
    Coinbase(pairs=["BTC-USD"], channels=[TRADES], callbacks={
        TRADES: TradeCallback(process_trade, include_order_type=True)
    }
))
```
Verify that order_type=None is sent to Callback, since we haven't subscribed to the L3_BOOK.

3) Subscribe to Coinbase with:
```
fh.add_feed(
    Coinbase(pairs=["BTC-USD"], channels=[L3_BOOK, TRADES], callbacks={
        TRADES: TradeCallback(process_trade, include_order_type=True),
        L3_BOOK: BookCallback(process_book)
    }
))
```

Verify that `process_book` is correctly called (in other words verify that `keep_order_book` is True because we have at least one book callback, and the book is being correctly kept).
