### PR TITLE
Support order type in backend callbacks

### DIFF
--- a/cryptofeed/backends/backend.py
+++ b/cryptofeed/backends/backend.py
@@ -25,11 +25,15 @@ class BackendBookDeltaCallback:
 
 
 class BackendTradeCallback:
-    async def __call__(self, *, feed: str, pair: str, side: str, amount: Decimal, price: Decimal, order_id=None, timestamp: float, receipt_timestamp: float):
+    include_order_type = True
+
+    async def __call__(self, *, feed: str, pair: str, side: str, amount: Decimal, price: Decimal, order_id=None, timestamp: float, receipt_timestamp: float, order_type: str=None):
         data = {'feed': feed, 'pair': pair, 'timestamp': timestamp, 'receipt_timestamp': receipt_timestamp,
                 'side': side, 'amount': self.numeric_type(amount), 'price': self.numeric_type(price)}
         if order_id:
             data['id'] = order_id
+        if order_type:
+            data['order_type'] = order_type
         await self.write(feed, pair, timestamp, receipt_timestamp, data)
 
 

--- a/cryptofeed/backends/backend.py
+++ b/cryptofeed/backends/backend.py
@@ -25,8 +25,6 @@ class BackendBookDeltaCallback:
 
 
 class BackendTradeCallback:
-    include_order_type = True
-
     async def __call__(self, *, feed: str, pair: str, side: str, amount: Decimal, price: Decimal, order_id=None, timestamp: float, receipt_timestamp: float, order_type: str=None):
         data = {'feed': feed, 'pair': pair, 'timestamp': timestamp, 'receipt_timestamp': receipt_timestamp,
                 'side': side, 'amount': self.numeric_type(amount), 'price': self.numeric_type(price)}


### PR DESCRIPTION
Builds off of #297 .

Test Plan:
1) Modify `demo_zmq` to the following subscription:
```
f.add_feed(Kraken(max_depth=1, channels=[TRADES], pairs=['BTC-USD', 'ETH-USD'], callbacks={TRADES: TradeZMQ(port=5678)}))
```
Verify that the ZMQ data payload contains the order_type

2) Do the same but with a different exchange, verify that order_type is not present.