### PR TITLE
arctic: default library quota is unlimited

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
   * Feature: New kwarg for exchange feed - `snapshot_interval` - used to control number of snapshot updates sent to client
   * Feature: Support for rabbitmq message routing
   * Feature: Support for raw file playback. Will be useful for testing features and building out new test suites for cryptofeed. 
+  * Feature: Arctic library quota can be configured, new default is unlimited
   
 ### 1.6.0 (2020-09-28)
   * Feature: Validate FTX book checksums (optionally enabled)

--- a/cryptofeed/backends/arctic.py
+++ b/cryptofeed/backends/arctic.py
@@ -13,7 +13,7 @@ from cryptofeed.defines import FUNDING, OPEN_INTEREST, TICKER, TRADES, LIQUIDATI
 
 
 class ArcticCallback:
-    def __init__(self, library, host='127.0.0.1', key=None, numeric_type=float, **kwargs):
+    def __init__(self, library, host='127.0.0.1', key=None, numeric_type=float, quota=0, **kwargs):
         """
         library: str
             arctic library. Will be created if does not exist.
@@ -21,6 +21,9 @@ class ArcticCallback:
             setting key lets you override the symbol name.
             The defaults are related to the data
             being stored, i.e. trade, funding, etc
+        quota: int
+            absolute number of bytes that this library is limited to.
+            The default of 0 means that the storage size is unlimited.
         kwargs:
             if library needs to be created you can specify the
             lib_type in the kwargs. Default is VersionStore, but you can
@@ -30,6 +33,7 @@ class ArcticCallback:
         if library not in con.list_libraries():
             lib_type = kwargs.get('lib_type', arctic.VERSION_STORE)
             con.initialize_library(library, lib_type=lib_type)
+        con.set_quota(library, quota)
         self.lib = con[library]
         self.key = key if key else self.default_key
         self.numeric_type = numeric_type


### PR DESCRIPTION
### Arctic library quota can be configured, new default is unlimited.

- [x] - Tested
- [x] - Changelog updated
- [ ] - Contributors file updated (optional)
