### PR TITLE
Use more clear rate limits values for FTX fundings

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@
   * Feature: Arctic library quota can be configured, new default is unlimited
   * Feature: New exchange: Probit
   * Bugfix: Correctly store receipt timestamp in mongo backend
+  * Change: FTX - set a funding rate requests limit constant (10 requests per second, 60 seconds pause between loops)
   
 ### 1.6.0 (2020-09-28)
   * Feature: Validate FTX book checksums (optionally enabled)

--- a/cryptofeed/exchange/ftx.py
+++ b/cryptofeed/exchange/ftx.py
@@ -133,7 +133,10 @@ class FTX(Feed):
               ]
             }
         """
-        wait_time = len(pairs) / 30
+        # do not send more than 30 requests per second: doing so will result in HTTP 429 errors 
+        rate_limiter = 0.1
+        # funding rates do not change frequently
+        wait_time = 60
         async with aiohttp.ClientSession() as session:
             while True:
                 for pair in pairs:
@@ -154,7 +157,8 @@ class FTX(Feed):
                                             pair=pair_exchange_to_std(data['result'][0]['future']),
                                             rate=data['result'][0]['rate'],
                                             timestamp=timestamp_normalize(self.id, data['result'][0]['time']))
-                    await asyncio.sleep(wait_time)
+                    await asyncio.sleep(rate_limiter)
+                await asyncio.sleep(wait_time)
 
     async def _trade(self, msg: dict, timestamp: float):
         """


### PR DESCRIPTION
### Currently FTX fundings rate limit can vary, it depends on pairs count. If you subscribe on 1 pair, the rate is 1/30 seconds which is too much for fundings I think. I propose sending 10 requests per second and wait 60 seconds between loops (perhaps it is too long?)

- [ yes ] - Tested
- [ yes ] - Changelog updated
- [ no ] - Contributors file updated (optional)
