### PR TITLE
Coingecko

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -6,3 +6,4 @@ Cryptofeed was originally created by Bryant Moscon, but many others have contrib
 * [Cody Jacques](https://github.com/PandaXcentric) - <jacques.co@northeastern.edu>
 * [O. Libre](https://github.com/olibre) - <olibre@Lmap.org>
 * [Ryan Tam](https://github.com/ryantam626) - <ryantam626@gmail.com>
+* [Yoh Plala](https://github.com/yohplala) - <yoh.plala@gmail.com>

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@
   * Bugfix: FTX - set a funding rate requests limit constant (10 requests per second, 60 seconds pause between loops)
   * Bugfix: Open Interest data on FTX erroneously had timestamps set to None
   * Update: Binance Jersey shutdown - feed removed
+  * Feature: Support for Coingecko aggregated data per coin, to be used with a new data channel 'profile'
   
 ### 1.6.0 (2020-09-28)
   * Feature: Validate FTX book checksums (optionally enabled)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 ## Changelog
 
+### 1.6.2
+  * Feature: Support for Coingecko aggregated data per coin, to be used with a new data channel 'profile'
+
 ### 1.6.1 (2020-11-12)
   * Feature: New kwarg for exchange feed - `snapshot_interval` - used to control number of snapshot updates sent to client
   * Feature: Support for rabbitmq message routing
@@ -10,7 +13,6 @@
   * Bugfix: FTX - set a funding rate requests limit constant (10 requests per second, 60 seconds pause between loops)
   * Bugfix: Open Interest data on FTX erroneously had timestamps set to None
   * Update: Binance Jersey shutdown - feed removed
-  * Feature: Support for Coingecko aggregated data per coin, to be used with a new data channel 'profile'
   
 ### 1.6.0 (2020-09-28)
   * Feature: Validate FTX book checksums (optionally enabled)

--- a/README.md
+++ b/README.md
@@ -81,6 +81,10 @@ To see an example of an application using cryptofeed to aggregate and store cryp
 * [ProBit](https://www.probit.com/)
 * [Upbit](https://sg.upbit.com/home)
 
+## Supported aggregated crypto data provider
+
+* [Coingecko](https://www.coingecko.com/en)
+
 ## National Best Bid/Offer (NBBO)
 
 Cryptofeed also provides a synthetic NBBO (National Best Bid/Offer) feed that aggregates the best bids and asks from the user specified feeds.
@@ -103,9 +107,9 @@ fh.add_nbbo([Coinbase, Bitfinex, HitBTC], ['BTC-USD'], nbbo_ticker)
 fh.run()
 ```
 
-## Supported Channels
+## Supported channels
 
-Cryptofeed supports the following channels:
+Cryptofeed supports the following channels from exchanges:
 
 * L2_BOOK - Price aggregated sizes. Some exchanges provide the entire depth, some provide a subset.
 * L3_BOOK - Price aggregated orders. Like the L2 book, some exchanges may only provide partial depth.
@@ -115,6 +119,11 @@ Cryptofeed supports the following channels:
 * FUNDING
 * BOOK_DELTA - Subscribed to with L2 or L3 books, receive book deltas rather than the entire book on updates. Full updates will be periodically sent on the L2 or L3 channel. If BOOK_DELTA is enabled, only L2 or L3 book can be enabled, not both. To receive both create two `feedhandler` objects. Not all exchanges are supported, as some exchanges send complete books on every update.
 * OPEN_INTEREST - Open interest data
+
+Aggregated data from provider is available in channel:
+
+* PROFILE - current aggregated price, market cap, volume (in USD, BTC or ETH currency), total and circulating supply,
+ as well as community data (twitter, reddit, facebook...) and scores (coingecko, developper, community...)
 
 ## Backends
 

--- a/cryptofeed/backends/arctic.py
+++ b/cryptofeed/backends/arctic.py
@@ -8,8 +8,9 @@ import arctic
 import pandas as pd
 
 from cryptofeed.backends.backend import (BackendFundingCallback, BackendOpenInterestCallback,
-                                         BackendTickerCallback, BackendTradeCallback, BackendLiquidationsCallback)
-from cryptofeed.defines import FUNDING, OPEN_INTEREST, TICKER, TRADES, LIQUIDATIONS
+                                         BackendTickerCallback, BackendTradeCallback, BackendLiquidationsCallback,
+                                         BackendProfileCallback)
+from cryptofeed.defines import FUNDING, OPEN_INTEREST, TICKER, TRADES, LIQUIDATIONS, PROFILE
 
 
 class ArcticCallback:
@@ -65,3 +66,8 @@ class OpenInterestArctic(ArcticCallback, BackendOpenInterestCallback):
 
 class LiquidationsArctic(ArcticCallback, BackendLiquidationsCallback):
     default_key = LIQUIDATIONS
+
+
+class ProfileArctic(ArcticCallback, BackendProfileCallback):
+    default_key = PROFILE
+    

--- a/cryptofeed/backends/backend.py
+++ b/cryptofeed/backends/backend.py
@@ -64,3 +64,12 @@ class BackendLiquidationsCallback:
     async def __call__(self, *, feed: str, pair: str, side: str, leaves_qty: Decimal, price: Decimal, order_id: str, timestamp: float, receipt_timestamp: float):
         data = {'feed': feed, 'pair': pair, 'side': side, 'leaves_qty': self.numeric_type(leaves_qty), 'price': self.numeric_type(price), 'order_id': order_id if order_id else "None", 'receipt_timestamp': receipt_timestamp, 'timestamp': timestamp}
         await self.write(feed, pair, timestamp, receipt_timestamp, data)
+
+
+class BackendProfileCallback:
+    async def __call__(self, *, feed: str, pair: str, timestamp: float, **kwargs):
+        kwargs['feed'] = feed
+        kwargs['pair'] = pair
+        kwargs['timestamp'] = timestamp
+        await self.write(feed, pair, timestamp, timestamp, kwargs)
+

--- a/cryptofeed/backends/elastic.py
+++ b/cryptofeed/backends/elastic.py
@@ -14,7 +14,7 @@ from yapic import json
 from cryptofeed.backends._util import book_flatten
 from cryptofeed.backends.backend import (BackendBookCallback, BackendBookDeltaCallback, BackendFundingCallback,
                                          BackendOpenInterestCallback, BackendTickerCallback, BackendTradeCallback,
-                                         BackendLiquidationsCallback)
+                                         BackendLiquidationsCallback, BackendProfileCallback)
 from cryptofeed.backends.http import HTTPCallback
 
 
@@ -100,3 +100,7 @@ class OpenInterestElastic(ElasticCallback, BackendOpenInterestCallback):
 
 class LiquidationsElastic(ElasticCallback, BackendLiquidationsCallback):
     default_index = 'liquidations'
+
+
+class ProfileElastic(ElasticCallback, BackendProfileCallback):
+    default_index = 'profile'

--- a/cryptofeed/backends/influxdb.py
+++ b/cryptofeed/backends/influxdb.py
@@ -10,7 +10,7 @@ from decimal import Decimal
 import requests
 
 from cryptofeed.backends.backend import (BackendBookCallback, BackendBookDeltaCallback, BackendFundingCallback,
-                                         BackendOpenInterestCallback, BackendTickerCallback, BackendTradeCallback, BackendLiquidationsCallback
+                                         BackendOpenInterestCallback, BackendTickerCallback, BackendTradeCallback, BackendLiquidationsCallback,
                                          BackendProfileCallback)
 from cryptofeed.backends.http import HTTPCallback
 from cryptofeed.defines import BID, ASK

--- a/cryptofeed/backends/influxdb.py
+++ b/cryptofeed/backends/influxdb.py
@@ -10,7 +10,8 @@ from decimal import Decimal
 import requests
 
 from cryptofeed.backends.backend import (BackendBookCallback, BackendBookDeltaCallback, BackendFundingCallback,
-                                         BackendOpenInterestCallback, BackendTickerCallback, BackendTradeCallback, BackendLiquidationsCallback)
+                                         BackendOpenInterestCallback, BackendTickerCallback, BackendTradeCallback, BackendLiquidationsCallback
+                                         BackendProfileCallback)
 from cryptofeed.backends.http import HTTPCallback
 from cryptofeed.defines import BID, ASK
 from cryptofeed.exceptions import UnsupportedType
@@ -160,3 +161,7 @@ class OpenInterestInflux(InfluxCallback, BackendOpenInterestCallback):
 
 class LiquidationsInflux(InfluxCallback, BackendLiquidationsCallback):
     default_key = 'liquidations'
+
+
+class ProfileInflux(InfluxCallback, BackendProfileCallback):
+    default_key = 'profile'

--- a/cryptofeed/backends/kafka.py
+++ b/cryptofeed/backends/kafka.py
@@ -10,7 +10,8 @@ from aiokafka import AIOKafkaProducer
 from yapic import json
 
 from cryptofeed.backends.backend import (BackendBookCallback, BackendBookDeltaCallback, BackendFundingCallback,
-                                         BackendOpenInterestCallback, BackendTickerCallback, BackendTradeCallback, BackendLiquidationsCallback)
+                                         BackendOpenInterestCallback, BackendTickerCallback, BackendTradeCallback,
+                                         BackendLiquidationsCallback, BackendProfileCallback)
 
 
 class KafkaCallback:
@@ -56,3 +57,7 @@ class OpenInterestKafka(KafkaCallback, BackendOpenInterestCallback):
 
 class LiquidationsKafka(KafkaCallback, BackendLiquidationsCallback):
     default_key = 'liquidations'
+
+
+class ProfileKafka(KafkaCallback, BackendProfileCallback):
+    default_key = 'profile'

--- a/cryptofeed/backends/mongo.py
+++ b/cryptofeed/backends/mongo.py
@@ -8,7 +8,8 @@ import bson
 import motor.motor_asyncio
 
 from cryptofeed.backends.backend import (BackendBookCallback, BackendBookDeltaCallback, BackendFundingCallback,
-                                         BackendOpenInterestCallback, BackendTickerCallback, BackendTradeCallback, BackendLiquidationsCallback)
+                                         BackendOpenInterestCallback, BackendTickerCallback, BackendTradeCallback,
+                                         BackendLiquidationsCallback, BackendProfileCallback)
 
 
 class MongoCallback:
@@ -51,3 +52,7 @@ class OpenInterestMongo(MongoCallback, BackendOpenInterestCallback):
 
 class LiquidationsMongo(MongoCallback, BackendLiquidationsCallback):
     default_key = 'liquidations'
+
+
+class ProfileMongo(MongoCallback, BackendProfileCallback):
+    default_key = 'profile'

--- a/cryptofeed/backends/rabbitmq.py
+++ b/cryptofeed/backends/rabbitmq.py
@@ -10,7 +10,8 @@ import aio_pika
 from yapic import json
 
 from cryptofeed.backends.backend import (BackendBookCallback, BackendBookDeltaCallback, BackendFundingCallback,
-                                         BackendOpenInterestCallback, BackendTickerCallback, BackendTradeCallback, BackendLiquidationsCallback)
+                                         BackendOpenInterestCallback, BackendTickerCallback, BackendTradeCallback,
+                                         BackendLiquidationsCallback, BackendProfileCallback)
 
 
 class RabbitCallback:
@@ -97,4 +98,8 @@ class OpenInterestRabbit(RabbitCallback, BackendOpenInterestCallback):
 
 
 class LiquidationsRabbit(RabbitCallback, BackendLiquidationsCallback):
+    pass
+
+
+class ProfileRabbit(RabbitCallback, BackendProfileCallback):
     pass

--- a/cryptofeed/backends/redis.py
+++ b/cryptofeed/backends/redis.py
@@ -9,7 +9,7 @@ from yapic import json
 
 from cryptofeed.backends.backend import (BackendBookCallback, BackendBookDeltaCallback, BackendFundingCallback,
                                          BackendOpenInterestCallback, BackendTickerCallback, BackendTradeCallback,
-                                         BackendLiquidationsCallback)
+                                         BackendLiquidationsCallback, BackendProfileCallback)
 
 
 class RedisCallback:
@@ -102,3 +102,13 @@ class LiquidationsRedis(RedisZSetCallback, BackendLiquidationsCallback):
 
 class LiquidationsStream(RedisStreamCallback, BackendLiquidationsCallback):
     default_key = 'liquidations'
+
+
+class ProfileRedis(RedisZSetCallback, BackendProfileCallback):
+    default_key = 'profile'
+
+
+class ProfileStream(RedisStreamCallback, BackendProfileCallback):
+    default_key = 'profile'
+
+

--- a/cryptofeed/backends/socket.py
+++ b/cryptofeed/backends/socket.py
@@ -11,7 +11,8 @@ from textwrap import wrap
 from yapic import json
 
 from cryptofeed.backends.backend import (BackendBookCallback, BackendBookDeltaCallback, BackendFundingCallback,
-                                         BackendOpenInterestCallback, BackendTickerCallback, BackendTradeCallback, BackendLiquidationsCallback)
+                                         BackendOpenInterestCallback, BackendTickerCallback, BackendTradeCallback,
+                                         BackendLiquidationsCallback, BackendProfileCallback)
 
 
 LOG = logging.getLogger('feedhandler')
@@ -123,3 +124,8 @@ class OpenInterestSocket(SocketCallback, BackendOpenInterestCallback):
 
 class LiquidationsSocket(SocketCallback, BackendLiquidationsCallback):
     default_key = 'liquidations'
+
+
+class ProfileSocket(SocketCallback, BackendProfileCallback):
+    default_key = 'profile'
+    

--- a/cryptofeed/backends/zmq.py
+++ b/cryptofeed/backends/zmq.py
@@ -9,7 +9,8 @@ import zmq.asyncio
 from yapic import json
 
 from cryptofeed.backends.backend import (BackendBookCallback, BackendBookDeltaCallback, BackendFundingCallback,
-                                         BackendOpenInterestCallback, BackendTickerCallback, BackendTradeCallback, BackendLiquidationsCallback)
+                                         BackendOpenInterestCallback, BackendTickerCallback, BackendTradeCallback,
+                                         BackendLiquidationsCallback, BackendProfileCallback)
 
 
 class ZMQCallback:
@@ -55,3 +56,7 @@ class OpenInterestZMQ(ZMQCallback, BackendOpenInterestCallback):
 
 class LiquidationsZMQ(ZMQCallback, BackendLiquidationsCallback):
     default_key = 'liquidations'
+
+
+class FundingZMQ(ZMQCallback, BackendProfileCallback):
+    default_key = 'profile'

--- a/cryptofeed/defines.py
+++ b/cryptofeed/defines.py
@@ -41,6 +41,9 @@ BITMAX = 'BITMAX'
 UPBIT = 'UPBIT'
 
 
+COINGECKO = 'COINGECKO'
+
+
 L2_BOOK = 'l2_book'
 L3_BOOK = 'l3_book'
 BOOK_DELTA = 'book_delta'

--- a/cryptofeed/defines.py
+++ b/cryptofeed/defines.py
@@ -54,6 +54,7 @@ FUNDING = 'funding'
 OPEN_INTEREST = 'open_interest'
 LIQUIDATIONS = 'liquidations'
 UNSUPPORTED = 'unsupported'
+PROFILE = 'profile'
 
 BUY = 'buy'
 SELL = 'sell'

--- a/cryptofeed/feed.py
+++ b/cryptofeed/feed.py
@@ -96,7 +96,7 @@ class Feed:
         """
         pairs, info = get_exchange_info(cls.id)
         data = {'pairs': list(pairs.keys()), 'channels': []}
-        for channel in (LIQUIDATIONS, OPEN_INTEREST, FUNDING, VOLUME, TICKER, L2_BOOK, L3_BOOK, TRADES):
+        for channel in (LIQUIDATIONS, OPEN_INTEREST, FUNDING, VOLUME, TICKER, L2_BOOK, L3_BOOK, TRADES, PROFILE):
             try:
                 feed_to_exchange(cls.id, channel, silent=True)
                 data['channels'].append(channel)

--- a/cryptofeed/feed.py
+++ b/cryptofeed/feed.py
@@ -9,7 +9,8 @@ from collections import defaultdict
 
 from cryptofeed.callback import Callback
 from cryptofeed.defines import (ASK, BID, BOOK_DELTA, FUNDING, L2_BOOK, L3_BOOK,
-                                LIQUIDATIONS, OPEN_INTEREST, TICKER, TRADES, VOLUME)
+                                LIQUIDATIONS, OPEN_INTEREST, TICKER, TRADES, VOLUME,
+                                PROFILE)
 from cryptofeed.exceptions import BidAskOverlapping, UnsupportedDataFeed
 from cryptofeed.standards import feed_to_exchange, get_exchange_info, load_exchange_pair_mapping, pair_std_to_exchange
 from cryptofeed.util.book import book_delta, depth
@@ -75,7 +76,8 @@ class Feed:
                           VOLUME: Callback(None),
                           FUNDING: Callback(None),
                           OPEN_INTEREST: Callback(None),
-                          LIQUIDATIONS: Callback(None)}
+                          LIQUIDATIONS: Callback(None),
+                          PROFILE: Callback(None)}
 
         if callbacks:
             for cb_type, cb_func in callbacks.items():

--- a/cryptofeed/feedhandler.py
+++ b/cryptofeed/feedhandler.py
@@ -212,13 +212,11 @@ class FeedHandler:
         """
         retries = 0
         delay = 1
-        sem = asyncio.Semaphore(500)
         while retries <= self.retries or self.retries == -1:
             await feed.subscribe()
             try:
                 while True:
-                    async with sem:
-                        await feed.message_handler()
+                    await feed.message_handler()
             except Exception:
                 LOG.error("%s: encountered an exception, reconnecting", feed.id, exc_info=True)
                 await asyncio.sleep(delay)
@@ -234,7 +232,6 @@ class FeedHandler:
         """
         retries = 0
         delay = 1
-        sem = asyncio.Semaphore(500)
         while retries <= self.retries or self.retries == -1:
             self.last_msg[feed.uuid] = None
             try:
@@ -256,8 +253,7 @@ class FeedHandler:
                     retries = 0
                     delay = 1
                     await feed.subscribe(websocket)
-                    async with sem:
-                        await self._handler(websocket, feed.message_handler, feed.uuid)
+                    await self._handler(websocket, feed.message_handler, feed.uuid)
             except (ConnectionClosed, ConnectionAbortedError, ConnectionResetError, socket_error) as e:
                 LOG.warning("%s: encountered connection issue %s - reconnecting...", feed.id, str(e), exc_info=True)
                 await asyncio.sleep(delay)

--- a/cryptofeed/feedhandler.py
+++ b/cryptofeed/feedhandler.py
@@ -124,6 +124,7 @@ class FeedHandler:
                     counter += 1
                     await feed.message_handler(message, timestamp)
             return {'messages_processed': counter, 'callbacks': dict(callbacks)}
+
     def add_feed(self, feed, timeout=120, **kwargs):
         """
         feed: str or class

--- a/cryptofeed/feedhandler.py
+++ b/cryptofeed/feedhandler.py
@@ -18,14 +18,16 @@ import websockets
 from websockets import ConnectionClosed
 
 from cryptofeed.defines import (BINANCE, BINANCE_FUTURES, BINANCE_US, BITCOINCOM, BITFINEX,
-                                BITMAX, BITMEX, BITSTAMP, BITTREX, BLOCKCHAIN, BYBIT, COINBASE, COINBENE,
-                                PROBIT, DERIBIT)
+                                BITMAX, BITMEX, BITSTAMP, BITTREX, BLOCKCHAIN, BYBIT,
+                                COINBASE, COINBENE, COINGECKO, DERIBIT,
+                                FTX_US, GATEIO, GEMINI, HITBTC, HUOBI, HUOBI_DM, HUOBI_SWAP,
+                                KRAKEN, KRAKEN_FUTURES, OKCOIN, OKEX, POLONIEX, PROBIT, UPBIT)
 from cryptofeed.defines import EXX as EXX_str
 from cryptofeed.defines import FTX as FTX_str
-from cryptofeed.defines import (FTX_US, GATEIO, GEMINI, HITBTC, HUOBI, HUOBI_DM, HUOBI_SWAP, KRAKEN,
-                                KRAKEN_FUTURES, L2_BOOK, OKCOIN, OKEX, POLONIEX, UPBIT)
+from cryptofeed.defines import L2_BOOK
 from cryptofeed.exceptions import ExhaustedRetries
 from cryptofeed.exchanges import *
+from cryptofeed.providers import *
 from cryptofeed.feed import RestFeed
 from cryptofeed.log import get_logger
 from cryptofeed.nbbo import NBBO
@@ -50,6 +52,7 @@ _EXCHANGES = {
     BYBIT: Bybit,
     COINBASE: Coinbase,
     COINBENE: Coinbene,
+    COINGECKO: Coingecko,
     DERIBIT: Deribit,
     EXX_str: EXX,
     FTX_str: FTX,

--- a/cryptofeed/pairs.py
+++ b/cryptofeed/pairs.py
@@ -319,9 +319,13 @@ def probit_pairs():
     r = requests.get("https://api.probit.com/api/exchange/v1/market").json()
     return {entry['id']: entry['id'] for entry in r['data']}
 
-def coingecko_coins():
-    r = requests.get('https://api.coingecko.com/api/v3/coins/list').json()
-    return {f"{e['symbol']}".upper(): e['id'] for e in r}
+def coingecko_pairs():
+    quote_c = requests.get('https://api.coingecko.com/api/v3/coins/list').json()
+    # Base currencies are defined manually (USD + BTC + ETH).
+    # The full list from Coingecko is not used, as the generated dict of pairs would be tremendous.
+    # base_c =  requests.get('https://api.coingecko.com/api/v3/simple/supported_vs_currencies').json()
+    base_c = (('USD','usd'),('BTC','btc'),('ETH','eth'))
+    return {f"{q['symbol']}{PAIR_SEP}{bk}".upper(): f"{q['id']}_{bv}" for q in quote_c for bk,bv in base_c }
 
 
 _exchange_function_map = {
@@ -356,5 +360,5 @@ _exchange_function_map = {
     BITMEX: bitmex_pairs,
     DERIBIT: deribit_pairs,
     KRAKEN_FUTURES: kraken_future_pairs,
-    COINGECKO: coingecko_coins
+    COINGECKO: coingecko_pairs
 }

--- a/cryptofeed/pairs.py
+++ b/cryptofeed/pairs.py
@@ -322,14 +322,12 @@ def probit_pairs():
 def coingecko_pairs():
     quote_c = requests.get('https://api.coingecko.com/api/v3/coins/list').json()
     # Normalization
-    for q in quote_c:
-        if q['symbol'] == 'miota':
-            q['symbol'] = 'iota'
+    normalized = dict({'miota': 'iota'})
     # Base currencies are defined manually (USD + BTC + ETH).
     # The full list from Coingecko is not used, as the generated dict of pairs would be tremendous.
     # base_c =  requests.get('https://api.coingecko.com/api/v3/simple/supported_vs_currencies').json()
     base_c = (('USD','usd'),('BTC','btc'),('ETH','eth'))
-    return {f"{q['symbol']}{PAIR_SEP}{bk}".upper(): f"{q['id']}_{bv}" for q in quote_c for bk,bv in base_c }
+    return {(f"{q['symbol']}{PAIR_SEP}{bk}".upper() if q['symbol'] not in normalized else f"{normalized[q['symbol']]}{PAIR_SEP}{bk}".upper()) : f"{q['id']}_{bv}" for q in quote_c for bk,bv in base_c }
 
 
 _exchange_function_map = {

--- a/cryptofeed/pairs.py
+++ b/cryptofeed/pairs.py
@@ -319,6 +319,11 @@ def probit_pairs():
     r = requests.get("https://api.probit.com/api/exchange/v1/market").json()
     return {entry['id']: entry['id'] for entry in r['data']}
 
+def coingecko_coins():
+    r = requests.get('https://api.coingecko.com/api/v3/coins/list').json()
+    return {f"{e['symbol']}".upper(): e['id'] for e in r}
+
+
 _exchange_function_map = {
     BITFINEX: bitfinex_pairs,
     COINBASE: coinbase_pairs,
@@ -350,5 +355,6 @@ _exchange_function_map = {
     GATEIO: gateio_pairs,
     BITMEX: bitmex_pairs,
     DERIBIT: deribit_pairs,
-    KRAKEN_FUTURES: kraken_future_pairs
+    KRAKEN_FUTURES: kraken_future_pairs,
+    COINGECKO: coingecko_coins
 }

--- a/cryptofeed/pairs.py
+++ b/cryptofeed/pairs.py
@@ -321,6 +321,10 @@ def probit_pairs():
 
 def coingecko_pairs():
     quote_c = requests.get('https://api.coingecko.com/api/v3/coins/list').json()
+    # Normalization
+    for q in quote_c:
+        if q['symbol'] == 'miota':
+            q['symbol'] = 'iota'
     # Base currencies are defined manually (USD + BTC + ETH).
     # The full list from Coingecko is not used, as the generated dict of pairs would be tremendous.
     # base_c =  requests.get('https://api.coingecko.com/api/v3/simple/supported_vs_currencies').json()

--- a/cryptofeed/provider/coingecko.py
+++ b/cryptofeed/provider/coingecko.py
@@ -46,10 +46,10 @@ class Coingecko(RestFeed):
     async def message_handler(self):
         async def handle(session, pair, chan):
             # create instance of Semaphore
-            sem = asyncio.Semaphore(10)
+#            sem = asyncio.Semaphore(10)
             if chan == PROFILE:
-                async with sem:
-                    await self._profile(session, pair)
+#                async with sem:
+                 await self._profile(session, pair)
             # Rate Limit: 100 requests/minute -> sleep 0.6s between each request 
             # Data is refreshed on Coingecko approximately every 3 to 4 minutes.
             await asyncio.sleep(0.6)

--- a/cryptofeed/provider/coingecko.py
+++ b/cryptofeed/provider/coingecko.py
@@ -45,8 +45,11 @@ class Coingecko(RestFeed):
 
     async def message_handler(self):
         async def handle(session, pair, chan):
+            # create instance of Semaphore
+            sem = asyncio.Semaphore(10)
             if chan == PROFILE:
-                await self._profile(session, pair)
+                async with sem:
+                    await self._profile(session, pair)
             # Rate Limit: 100 requests/minute -> sleep 0.6s between each request 
             # Data is refreshed on Coingecko approximately every 3 to 4 minutes.
             await asyncio.sleep(0.6)

--- a/cryptofeed/provider/coingecko.py
+++ b/cryptofeed/provider/coingecko.py
@@ -14,25 +14,17 @@ from cryptofeed.feed import RestFeed
 from cryptofeed.standards import pair_exchange_to_std, timestamp_normalize
 
 
+# Keys retained from 'PROFILE' data.
+profile_filter = ('name', 'asset_platform_id', 'contract_address', 'sentiment_votes_up_percentage',
+                  'sentiment_votes_down_percentage', 'market_cap_rank', 'coingecko_rank', 'coingecko_score',
+                  'developer_score', 'community_score', 'liquidity_score', 'public_interest_score', 'status_updates')
+market_data_vs_currency = ('current_price', 'market_cap', 'fully_diluted_valuation', 'total_volume', 'high_24h', 'low_24h')
+other_market_data_filter = ('price_change_percentage_24h', 'market_cap_change_percentage_24h', 'total_supply', 'max_supply',
+                            'circulating_supply', 'last_updated')
+
 class Coingecko(RestFeed):
     
     id = COINGECKO
-
-    # Keys not retained from 'PROFILE' data.
-    _profile_filter_out = set({'block_time_in_minutes', 'hashing_algorithm', 'categories', 'public_notice', 'ico_data',
-                               'description', 'links', 'image', 'country_origin', 'last_updated', 'symbol', 'id',
-                               'genesis_date'})
-    _market_data_filter_out = set({'roi', 'ath', 'ath_change_percentage', 'ath_date', 'atl',
-                                   'atl_change_percentage', 'atl_date', 'market_cap_rank',
-                                   'price_change_percentage_14d', 'price_change_percentage_30d', 'price_change_percentage_60d',
-                                   'price_change_percentage_200d', 'price_change_percentage_1y',
-                                   'price_change_24h_in_currency', 'price_change_percentage_1h_in_currency',
-                                   'price_change_percentage_24h_in_currency', 'price_change_percentage_7d_in_currency',
-                                   'price_change_percentage_14d_in_currency', 'price_change_percentage_30d_in_currency',
-                                   'price_change_percentage_60d_in_currency', 'price_change_percentage_200d_in_currency',
-                                   'price_change_percentage_1y_in_currency', 'market_cap_change_24h_in_currency',
-                                   'market_cap_change_percentage_24h_in_currency'})
-    _currency_to_filter_in = set({'btc', 'eth', 'usd', 'eur', 'gbp', 'jpy', 'cny', 'cad', 'aud'})
 
     def __init__(self, pairs=None, channels=None, callbacks=None, config=None, **kwargs):
         super().__init__('https://api.coingecko.com/api/v3/', pairs=pairs, channels=channels, config=config, callbacks=callbacks, **kwargs)
@@ -72,17 +64,23 @@ class Coingecko(RestFeed):
         Data from /coins/{id}.
         """
 
-        async with session.get(f"{self.address}coins/{pair}?localization=false&tickers=false\
+        quote_c, base_c = pair.split('_')
+
+        async with session.get(f"{self.address}coins/{quote_c}?localization=false&tickers=false\
 &market_data=true&community_data=true&developer_data=false&sparkline=false") as response:
             data = await response.json()
 
         timestamp=timestamp_normalize(self.id, data['last_updated'])
         if (pair not in self.last_profile_update) or (self.last_profile_update[pair] < timestamp):
             self.last_profile_update[pair] = timestamp
-            data = {k:v for k,v in data.items() if k not in self._profile_filter_out}
-            data['market_data'] = {k:v for k,v in data['market_data'].items() if k not in self._market_data_filter_out}
-            for value in set({'current_price', 'market_cap', 'fully_diluted_valuation', 'total_volume', 'high_24h', 'low_24h'}):
-                data['market_data'][value] = {k:v for k,v in data['market_data'][value].items() if k in self._currency_to_filter_in}
+            market_data = {k:data['market_data'][k][base_c] for k in market_data_vs_currency if base_c in data['market_data'][k]}
+            other_market_data = {k:data['market_data'][k] for k in other_market_data_filter}
+            community_data = data['community_data']
+            public_interest_stats = data['public_interest_stats']
+            # `market_data`, `community_data` and `public_interest_stats` are removed from `data`
+            data = {k:v for k,v in data.items() if k in profile_filter}
+            # Merge everything in a flatten dict.
+            data = {**data, **market_data, **other_market_data, **community_data, **public_interest_stats}
             await self.callback(PROFILE, feed=self.id,
                                 pair=pair_exchange_to_std(pair),
                                 timestamp=timestamp,

--- a/cryptofeed/provider/coingecko.py
+++ b/cryptofeed/provider/coingecko.py
@@ -6,7 +6,6 @@ associated with this software.
 '''
 
 import asyncio
-from decimal import Decimal
 
 import aiohttp
 
@@ -20,15 +19,20 @@ class Coingecko(RestFeed):
     id = COINGECKO
 
     # Keys not retained from 'PROFILE' data.
-    _profile_filter_out = set({'block_time_in_minutes', 'hashing_algorithm', 'categories', 'public_notice', 'description', 'links', 'image', 'country_origin'})
+    _profile_filter_out = set({'block_time_in_minutes', 'hashing_algorithm', 'categories', 'public_notice', 'ico_data',
+                               'description', 'links', 'image', 'country_origin', 'last_updated', 'symbol', 'id',
+                               'genesis_date'})
     _market_data_filter_out = set({'roi', 'ath', 'ath_change_percentage', 'ath_date', 'atl',
                                    'atl_change_percentage', 'atl_date', 'market_cap_rank',
+                                   'price_change_percentage_14d', 'price_change_percentage_30d', 'price_change_percentage_60d',
+                                   'price_change_percentage_200d', 'price_change_percentage_1y',
                                    'price_change_24h_in_currency', 'price_change_percentage_1h_in_currency',
                                    'price_change_percentage_24h_in_currency', 'price_change_percentage_7d_in_currency',
                                    'price_change_percentage_14d_in_currency', 'price_change_percentage_30d_in_currency',
                                    'price_change_percentage_60d_in_currency', 'price_change_percentage_200d_in_currency',
                                    'price_change_percentage_1y_in_currency', 'market_cap_change_24h_in_currency',
                                    'market_cap_change_percentage_24h_in_currency'})
+    _currency_to_filter_in = set({'btc', 'eth', 'usd', 'eur', 'gbp', 'jpy', 'cny', 'cad', 'aud'})
 
     def __init__(self, pairs=None, channels=None, callbacks=None, config=None, **kwargs):
         super().__init__('https://api.coingecko.com/api/v3/', pairs=pairs, channels=channels, config=config, callbacks=callbacks, **kwargs)
@@ -77,9 +81,10 @@ class Coingecko(RestFeed):
             self.last_profile_update[pair] = timestamp
             data = {k:v for k,v in data.items() if k not in self._profile_filter_out}
             data['market_data'] = {k:v for k,v in data['market_data'].items() if k not in self._market_data_filter_out}
-            data['last_updated'] = timestamp
+            for value in set({'current_price', 'market_cap', 'fully_diluted_valuation', 'total_volume', 'high_24h', 'low_24h'}):
+                data['market_data'][value] = {k:v for k,v in data['market_data'][value].items() if k in self._currency_to_filter_in}
             await self.callback(PROFILE, feed=self.id,
                                 pair=pair_exchange_to_std(pair),
                                 timestamp=timestamp,
-                                data=data)
+                                **data)
         return

--- a/cryptofeed/provider/coingecko.py
+++ b/cryptofeed/provider/coingecko.py
@@ -78,7 +78,7 @@ class Coingecko(RestFeed):
             if (pair not in self.last_profile_update) or (self.last_profile_update[pair] < timestamp):
                 self.last_profile_update[pair] = timestamp
                 # `None` and null data is systematically replaced with '-1' for digits and '' for string (empty string), for compatibility with Redis stream.
-                market_data = {k:(-1 if (not v or (isinstance(v,dict) and not v[base_c])) else v if k in other_market_data_filter else v[base_c]) for k,v in data['market_data'].items() if k in all_market_data}
+                market_data = {k:(-1 if (not v or (isinstance(v,dict) and not (base_c in v and v[base_c]))) else v if k in other_market_data_filter else v[base_c]) for k,v in data['market_data'].items() if k in all_market_data}
                 # 'last_updated' here is specifically for market data.
                 market_data['last_updated']=timestamp_normalize(self.id, data['market_data']['last_updated'])
                 community_data = {k:(v if v else -1) for k,v in data['community_data'].items()}

--- a/cryptofeed/provider/coingecko.py
+++ b/cryptofeed/provider/coingecko.py
@@ -1,0 +1,135 @@
+'''
+Copyright (C) 2017-2020  Bryant Moscon - bmoscon@gmail.com
+
+Please see the LICENSE file for the terms and conditions
+associated with this software.
+'''
+import asyncio
+from decimal import Decimal
+
+import aiohttp
+from sortedcontainers import SortedDict as sd
+
+from cryptofeed.defines import COINGECKO
+from cryptofeed.feed import RestFeed
+from cryptofeed.standards import pair_exchange_to_std, timestamp_normalize
+
+
+class Coingecko(RestFeed):
+    id = COINGECKO
+
+    def __init__(self, pairs=None, channels=None, callbacks=None, config=None, **kwargs):
+        super().__init__('https://api.coingecko.com/api/v3', pairs=pairs, channels=channels, config=config, callbacks=callbacks, **kwargs)
+
+    async def _market(self, session, pair):
+
+
+    def __reset(self):
+        self.last_trade_update = {}
+
+    async def _trades(self, session, pair):
+        """
+        {
+            "status": "ok",
+            "timestamp": 1489473538996,
+            "symbol": "btcusdt",
+            "trades": [{
+                "tradeId ": 14894644510000001,
+                "price": 4000.00,
+                "quantity": 1.0000,
+                "take": "buy",
+                "time": "2018-03-14 18:36:32"
+            }]
+        }
+        """
+        if pair not in self.last_trade_update:
+            async with session.get(f"{self.address}trades?symbol={pair}") as response:
+                data = await response.json()
+                self.last_trade_update[pair] = timestamp_normalize(self.id, data['trades'][-1]['time'])
+        else:
+            async with session.get(f"{self.address}trades?symbol={pair}&size=2000") as response:
+                data = await response.json()
+                for trade in data['trades']:
+                    if timestamp_normalize(self.id, trade['time']) <= self.last_trade_update[pair]:
+                        continue
+                    price = Decimal(trade['price'])
+                    amount = Decimal(trade['quantity'])
+                    side = BUY if trade['take'] == 'buy' else SELL
+
+                    await self.callback(TRADES, feed=self.id,
+                                        pair=pair_exchange_to_std(pair),
+                                        side=side,
+                                        amount=amount,
+                                        price=price,
+                                        order_id=trade['tradeId'],
+                                        timestamp=timestamp_normalize(self.id, trade['time']))
+                self.last_trade_update[pair] = timestamp_normalize(self.id, data['trades'][-1]['time'])
+
+    async def _ticker(self, session, pair):
+        """
+        {
+            "status":"ok",
+            "ticker":[
+                {
+                    "24hrAmt":"1264748.00057000",
+                    "24hrHigh":"11709.54000000",
+                    "24hrLow":"9200.00000000",
+                    "24hrVol":"119.76200000",
+                    "ask":"0.81000000",
+                    "bid":"0.80000000",
+                    "last":"11525.00000000",
+                    "symbol":"BTCUSDT"
+                }
+            ],
+            "timestamp":1517536673213
+        }
+        """
+        async with session.get(f"{self.address}ticker?symbol={pair}") as response:
+            data = await response.json()
+            bid = Decimal(data['ticker'][0]['bid'])
+            ask = Decimal(data['ticker'][0]['ask'])
+            await self.callback(TICKER, feed=self.id,
+                                pair=pair_exchange_to_std(pair),
+                                bid=bid,
+                                ask=ask,
+                                timestamp=timestamp_normalize(self.id, data['timestamp']))
+
+    async def _book(self, session, pair):
+        async with session.get("{}orderbook?symbol={}".format(self.address, pair)) as response:
+            data = await response.json()
+
+            book = {ASK: sd({
+                Decimal(entry['price']): Decimal(entry['quantity']) for entry in data['orderbook']['asks']
+            }), BID: sd({
+                Decimal(entry['price']): Decimal(entry['quantity']) for entry in data['orderbook']['bids']
+            })}
+
+            await self.callback(L2_BOOK, feed=self.id,
+                                pair=pair_exchange_to_std(pair),
+                                book=book,
+                                timestamp=timestamp_normalize(self.id, data['timestamp']))
+
+    async def subscribe(self):
+        self.__reset()
+        return
+
+    async def message_handler(self):
+        async def handle(session, pair, chan):
+            if chan == TRADES:
+                await self._trades(session, pair)
+            elif chan == TICKER:
+                await self._ticker(session, pair)
+            elif chan == L2_BOOK:
+                await self._book(session, pair)
+            # We can do 15 requests a second
+            await asyncio.sleep(0.07)
+
+        async with aiohttp.ClientSession() as session:
+            if self.config:
+                for chan in self.config:
+                    for pair in self.config[chan]:
+                        await handle(session, pair, chan)
+            else:
+                for chan in self.channels:
+                    for pair in self.pairs:
+                        await handle(session, pair, chan)

--- a/cryptofeed/provider/coingecko.py
+++ b/cryptofeed/provider/coingecko.py
@@ -44,28 +44,31 @@ class Coingecko(RestFeed):
 
 
     async def message_handler(self):
-        async def handle(session, sem, pair, chan):
+#        async def handle(session, sem, pair, chan):
+        async def handle(session, pair, chan):
             if chan == PROFILE:
                 await self._profile(session, pair)
             # Rate Limit: 100 requests/minute -> sleep 0.6s after previous request.
             # Using 1s for safety
-            await asyncio.sleep(1)
+            await asyncio.sleep(10)
 
         async with aiohttp.ClientSession() as session:
             # Create instance of Semaphore: limit to 100 concurrent requests
             # to comply with 100 requests/minute.
             # Using 90 for safety
-            sem = asyncio.Semaphore(90)
+#            sem = asyncio.Semaphore(90)
             if self.config:
                 for chan in self.config:
                     for pair in self.config[chan]:
-                        async with sem:
-                            await handle(session, sem, pair, chan)
+#                        async with sem:
+#                            await handle(session, sem, pair, chan)
+                        await handle(session, pair, chan)
             else:
                 for chan in self.channels:
                     for pair in self.pairs:
-                        async with sem:
-                            await handle(session, sem, pair, chan)
+#                        async with sem:
+#                            await handle(session, sem, pair, chan)
+                        await handle(session, pair, chan)
         return
 
 

--- a/cryptofeed/provider/coingecko.py
+++ b/cryptofeed/provider/coingecko.py
@@ -5,23 +5,17 @@ Please see the LICENSE file for the terms and conditions
 associated with this software.
 '''
 
-import os
 import asyncio
 import aiohttp
-import logging
 
-from cryptofeed.log import get_logger
 from cryptofeed.defines import COINGECKO, PROFILE
 from cryptofeed.feed import RestFeed
 from cryptofeed.standards import pair_exchange_to_std, timestamp_normalize
 
-LOG = get_logger('feedhandler',
-                 os.environ.get('CRYPTOFEED_FEEDHANDLER_LOG_FILENAME', "feedhandler.log"),
-                 int(os.environ.get('CRYPTOFEED_FEEDHANDLER_LOG_LEVEL', logging.WARNING)))
 
 # Keys retained from Coingecko for `PROFILE` channel.
 # 'status_updates' is not in the list, but is added back in the data (see `_profile()`)
-# It is worthwhile to notice that all digit data is positive. Sometime, Coingecko sends also null or None value,
+# It is worthwhile to notice that all digit data is positive. Sometimes, Coingecko sends also null or None value,
 # in which case they are then converted to -1 value, for compatibility reason with Redis stream.
 profile_filter_s = ('name', 'asset_platform_id', 'contract_address')
 profile_filter_d = ('sentiment_votes_up_percentage', 'sentiment_votes_down_percentage', 'market_cap_rank', 'coingecko_rank',
@@ -30,36 +24,32 @@ market_data_vs_currency = ('current_price', 'market_cap', 'fully_diluted_valuati
 other_market_data_filter = ('total_supply', 'max_supply', 'circulating_supply')
 all_market_data = (market_data_vs_currency + other_market_data_filter)
 
+
 class Coingecko(RestFeed):
-    
+
     id = COINGECKO
 
     def __init__(self, pairs=None, channels=None, callbacks=None, config=None, **kwargs):
-        self.cooling=False
         super().__init__('https://api.coingecko.com/api/v3/', pairs=pairs, channels=channels, config=config, callbacks=callbacks, **kwargs)
 
     async def subscribe(self):
         self.__reset()
         return
 
-
     def __reset(self):
         self.last_profile_update = {}
         pass
-
 
     async def message_handler(self):
         async def handle(session, pair, chan):
             if chan == PROFILE:
                 await self._profile(session, pair)
-            if self.cooling:
-                # If Coingecko API goes crazy, let's cool it down by waiting for 10s.
-                await asyncio.sleep(10)
-                self.cooling=False
-            else:
-                # Rate Limit: 100 requests/minute -> sleep 0.6s after previous request.
-                # From testing, need to use 3x this limit.
-                await asyncio.sleep(1.8)
+            # Rate Limit: 100 requests/minute -> sleep 0.6s after previous request.
+            # From support (mail exchange):
+            # "May I suggest (as provided by the engineers) that you try to make approximately 50 requests per minute instead?
+            # We are currently experiencing very heavy loads from certain irresponsible individuals and have temporarily stepped up security measures."
+            # From testing, safer to use 3x this limit.
+            await asyncio.sleep(1.8)
 
         async with aiohttp.ClientSession() as session:
             if self.config:
@@ -72,7 +62,6 @@ class Coingecko(RestFeed):
                         await handle(session, pair, chan)
         return
 
-
     async def _profile(self, session, pair):
         """
         Data from /coins/{id}.
@@ -84,31 +73,26 @@ class Coingecko(RestFeed):
 &market_data=true&community_data=true&developer_data=false&sparkline=false") as response:
             data = await response.json()
 
-            try:
-                timestamp=timestamp_normalize(self.id, data['last_updated'])
-                if (pair not in self.last_profile_update) or (self.last_profile_update[pair] < timestamp):
-                    self.last_profile_update[pair] = timestamp
-                    # `None` and null data is systematically replaced with '-1' for digits and '' for string (empty string), for compatibility with Redis stream.
-                    market_data = {k:(-1 if (not v or (isinstance(v,dict) and not (base_c in v and v[base_c]))) else v if k in other_market_data_filter else v[base_c]) for k,v in data['market_data'].items() if k in all_market_data}
-                    # 'last_updated' here is assumed to be specific for market data, so it is kept as well.
-                    market_data['last_updated']=timestamp_normalize(self.id, data['market_data']['last_updated'])
-                    community_data = {k:(v if v else -1) for k,v in data['community_data'].items()}
-                    public_interest_stats = {k:(v if v else -1) for k,v in data['public_interest_stats'].items()}
-                    # Only retain selected data, and remove as well `market_data`, `community_data` and `public_interest_stats`.
-                    # These latter are added back in `data` to have it in the shape of a flatten dict.
-                    data_s = {k:(v if v else '') for k,v in data.items() if k in profile_filter_s}
-                    data_d = {k:(v if v else -1) for k,v in data.items() if k in profile_filter_d}
-                    status = str(data['status_updates'])
-                    data = {**data_s, **data_d, **market_data, **community_data, **public_interest_stats}
-                    # `list` data type is converted to string for compatibility with Redis stream.
-                    data['status_updates'] = status
-                    await self.callback(PROFILE, feed=self.id,
-                                        pair=pair_exchange_to_std(pair),
-                                        timestamp=timestamp,
-                                        **data)
-            except KeyError as ke:
-                LOG.warning("Coingecko API going crazy.\n{!s}\nResponse returned:\n{!s}\n".format(ke, str(data)))
-                self.cooling = True
-                pass
+            timestamp = timestamp_normalize(self.id, data['last_updated'])
+            if (pair not in self.last_profile_update) or (self.last_profile_update[pair] < timestamp):
+                self.last_profile_update[pair] = timestamp
+                # `None` and null data is systematically replaced with '-1' for digits and '' for string (empty string), for compatibility with Redis stream.
+                market_data = {k: (-1 if (not v or (isinstance(v, dict) and not (base_c in v and v[base_c]))) else v if k in other_market_data_filter else v[base_c]) for k, v in data['market_data'].items() if k in all_market_data}
+                # 'last_updated' here is assumed to be specific for market data, so it is kept as well.
+                market_data['last_updated'] = timestamp_normalize(self.id, data['market_data']['last_updated'])
+                community_data = {k: (v if v else -1) for k, v in data['community_data'].items()}
+                public_interest_stats = {k: (v if v else -1) for k, v in data['public_interest_stats'].items()}
+                # Only retain selected data, and remove as well `market_data`, `community_data` and `public_interest_stats`.
+                # These latter are added back in `data` to have it in the shape of a flatten dict.
+                data_s = {k: (v if v else '') for k, v in data.items() if k in profile_filter_s}
+                data_d = {k: (v if v else -1) for k, v in data.items() if k in profile_filter_d}
+                status = str(data['status_updates'])
+                data = {**data_s, **data_d, **market_data, **community_data, **public_interest_stats}
+                # `list` data type is converted to string for compatibility with Redis stream.
+                data['status_updates'] = status
+                await self.callback(PROFILE, feed=self.id,
+                                    pair=pair_exchange_to_std(pair),
+                                    timestamp=timestamp,
+                                    **data)
 
         return

--- a/cryptofeed/provider/coingecko.py
+++ b/cryptofeed/provider/coingecko.py
@@ -15,13 +15,14 @@ from cryptofeed.standards import pair_exchange_to_std, timestamp_normalize
 
 
 # Keys retained from Coingecko for `PROFILE` channel.
-# 'status_updates' is not in the list, but if a not empty list, is added back in the data (see `_profile()`)
-profile_filter = ('name', 'asset_platform_id', 'contract_address', 'sentiment_votes_up_percentage',
-                  'sentiment_votes_down_percentage', 'market_cap_rank', 'coingecko_rank', 'coingecko_score',
-                  'developer_score', 'community_score', 'liquidity_score', 'public_interest_score')
+# 'status_updates' is not in the list, but is added back in the data (see `_profile()`)
+# It is worthwhile to notice that all digit data is positive. Sometime, Coingecko sends also null or None value,
+# in which case they are then converted to -1 value, for compatibility reason with Redis stream.
+profile_filter_s = ('name', 'asset_platform_id', 'contract_address')
+profile_filter_d = ('sentiment_votes_up_percentage', 'sentiment_votes_down_percentage', 'market_cap_rank', 'coingecko_rank',
+                    'coingecko_score', 'developer_score', 'community_score', 'liquidity_score', 'public_interest_score')
 market_data_vs_currency = ('current_price', 'market_cap', 'fully_diluted_valuation', 'total_volume', 'high_24h', 'low_24h')
-other_market_data_filter = ('price_change_percentage_24h', 'market_cap_change_percentage_24h', 'total_supply', 'max_supply',
-                            'circulating_supply', 'last_updated')
+other_market_data_filter = ('total_supply', 'max_supply', 'circulating_supply')
 
 class Coingecko(RestFeed):
     
@@ -74,18 +75,20 @@ class Coingecko(RestFeed):
         timestamp=timestamp_normalize(self.id, data['last_updated'])
         if (pair not in self.last_profile_update) or (self.last_profile_update[pair] < timestamp):
             self.last_profile_update[pair] = timestamp
-            # `None` and null data is systematically removed for compatibility with Redis stream.
-            market_data = {k:data['market_data'][k][base_c] for k in market_data_vs_currency if (base_c in data['market_data'][k] and data['market_data'][k][base_c])}
-            other_market_data = {k:data['market_data'][k] for k in other_market_data_filter if data['market_data'][k]}
-            community_data = {k:v for k,v in data['community_data'].items() if v}
-            public_interest_stats = {k:v for k,v in data['public_interest_stats'].items() if v}
+            # `None` and null data is systematically replaced with '-1' for digits and '' for string (empty string), for compatibility with Redis stream.
+            market_data = {k:(data['market_data'][k][base_c] if data['market_data'][k][base_c] else -1) for k in market_data_vs_currency}
+            other_market_data = {k:(data['market_data'][k] if data['market_data'][k] else -1) for k in other_market_data_filter}
+            # 'last_updated' here is specifically for market data.
+            other_market_data['last_updated']=timestamp_normalize(self.id, data['market_data']['last_updated'])
+            community_data = {k:(v if v else -1) for k,v in data['community_data'].items()}
+            public_interest_stats = {k:(v if v else -1) for k,v in data['public_interest_stats'].items()}
             # Only retain selected data, and remove as well `market_data`, `community_data` and `public_interest_stats`.
             # These latter are added back in `data` to have it in the shape of a flatten dict.
-            data = {k:v for k,v in data.items() if (k in profile_filter and v)}
-            data = {**data, **market_data, **other_market_data, **community_data, **public_interest_stats}
+            data_s = {k:(v if v else '') for k,v in data.items() if k in profile_filter_s}
+            data_d = {k:(v if v else -1) for k,v in data.items() if k in profile_filter_d}
+            data = {**data_s, **data_d, **market_data, **other_market_data, **community_data, **public_interest_stats}
             # `list` data type is converted to string for compatibility with Redis stream.
-            if 'status_updates' in data:
-                data['status_updates'] = str(data['status_updates'])
+            data['status_updates'] = str(data['status_updates'])
             await self.callback(PROFILE, feed=self.id,
                                 pair=pair_exchange_to_std(pair),
                                 timestamp=timestamp,

--- a/cryptofeed/provider/coingecko.py
+++ b/cryptofeed/provider/coingecko.py
@@ -5,14 +5,19 @@ Please see the LICENSE file for the terms and conditions
 associated with this software.
 '''
 
+import os
 import asyncio
-
 import aiohttp
+import logging
 
+from cryptofeed.log import get_logger
 from cryptofeed.defines import COINGECKO, PROFILE
 from cryptofeed.feed import RestFeed
 from cryptofeed.standards import pair_exchange_to_std, timestamp_normalize
 
+LOG = get_logger('feedhandler',
+                 os.environ.get('CRYPTOFEED_FEEDHANDLER_LOG_FILENAME', "feedhandler.log"),
+                 int(os.environ.get('CRYPTOFEED_FEEDHANDLER_LOG_LEVEL', logging.WARNING)))
 
 # Keys retained from Coingecko for `PROFILE` channel.
 # 'status_updates' is not in the list, but is added back in the data (see `_profile()`)
@@ -30,8 +35,8 @@ class Coingecko(RestFeed):
     id = COINGECKO
 
     def __init__(self, pairs=None, channels=None, callbacks=None, config=None, **kwargs):
+        self.cooling=False
         super().__init__('https://api.coingecko.com/api/v3/', pairs=pairs, channels=channels, config=config, callbacks=callbacks, **kwargs)
-
 
     async def subscribe(self):
         self.__reset()
@@ -47,9 +52,14 @@ class Coingecko(RestFeed):
         async def handle(session, pair, chan):
             if chan == PROFILE:
                 await self._profile(session, pair)
-            # Rate Limit: 100 requests/minute -> sleep 0.6s after previous request.
-            # From testing, need to use 3x this limit.
-            await asyncio.sleep(1.8)
+            if self.cooling:
+                # If Coingecko API goes crazy, let's cool it down by waiting for 10s.
+                await asyncio.sleep(10)
+                self.cooling=False
+            else:
+                # Rate Limit: 100 requests/minute -> sleep 0.6s after previous request.
+                # From testing, need to use 3x this limit.
+                await asyncio.sleep(1.8)
 
         async with aiohttp.ClientSession() as session:
             if self.config:
@@ -74,25 +84,31 @@ class Coingecko(RestFeed):
 &market_data=true&community_data=true&developer_data=false&sparkline=false") as response:
             data = await response.json()
 
-            timestamp=timestamp_normalize(self.id, data['last_updated'])
-            if (pair not in self.last_profile_update) or (self.last_profile_update[pair] < timestamp):
-                self.last_profile_update[pair] = timestamp
-                # `None` and null data is systematically replaced with '-1' for digits and '' for string (empty string), for compatibility with Redis stream.
-                market_data = {k:(-1 if (not v or (isinstance(v,dict) and not (base_c in v and v[base_c]))) else v if k in other_market_data_filter else v[base_c]) for k,v in data['market_data'].items() if k in all_market_data}
-                # 'last_updated' here is assumed to be specific for market data, so it is kept as well.
-                market_data['last_updated']=timestamp_normalize(self.id, data['market_data']['last_updated'])
-                community_data = {k:(v if v else -1) for k,v in data['community_data'].items()}
-                public_interest_stats = {k:(v if v else -1) for k,v in data['public_interest_stats'].items()}
-                # Only retain selected data, and remove as well `market_data`, `community_data` and `public_interest_stats`.
-                # These latter are added back in `data` to have it in the shape of a flatten dict.
-                data_s = {k:(v if v else '') for k,v in data.items() if k in profile_filter_s}
-                data_d = {k:(v if v else -1) for k,v in data.items() if k in profile_filter_d}
-                status = str(data['status_updates'])
-                data = {**data_s, **data_d, **market_data, **community_data, **public_interest_stats}
-                # `list` data type is converted to string for compatibility with Redis stream.
-                data['status_updates'] = status
-                await self.callback(PROFILE, feed=self.id,
-                                    pair=pair_exchange_to_std(pair),
-                                    timestamp=timestamp,
-                                    **data)
+            try:
+                timestamp=timestamp_normalize(self.id, data['last_updated'])
+                if (pair not in self.last_profile_update) or (self.last_profile_update[pair] < timestamp):
+                    self.last_profile_update[pair] = timestamp
+                    # `None` and null data is systematically replaced with '-1' for digits and '' for string (empty string), for compatibility with Redis stream.
+                    market_data = {k:(-1 if (not v or (isinstance(v,dict) and not (base_c in v and v[base_c]))) else v if k in other_market_data_filter else v[base_c]) for k,v in data['market_data'].items() if k in all_market_data}
+                    # 'last_updated' here is assumed to be specific for market data, so it is kept as well.
+                    market_data['last_updated']=timestamp_normalize(self.id, data['market_data']['last_updated'])
+                    community_data = {k:(v if v else -1) for k,v in data['community_data'].items()}
+                    public_interest_stats = {k:(v if v else -1) for k,v in data['public_interest_stats'].items()}
+                    # Only retain selected data, and remove as well `market_data`, `community_data` and `public_interest_stats`.
+                    # These latter are added back in `data` to have it in the shape of a flatten dict.
+                    data_s = {k:(v if v else '') for k,v in data.items() if k in profile_filter_s}
+                    data_d = {k:(v if v else -1) for k,v in data.items() if k in profile_filter_d}
+                    status = str(data['status_updates'])
+                    data = {**data_s, **data_d, **market_data, **community_data, **public_interest_stats}
+                    # `list` data type is converted to string for compatibility with Redis stream.
+                    data['status_updates'] = status
+                    await self.callback(PROFILE, feed=self.id,
+                                        pair=pair_exchange_to_std(pair),
+                                        timestamp=timestamp,
+                                        **data)
+            except KeyError as ke:
+                LOG.warning("Coingecko API going crazy.\n{!s}\nResponse returned:\n{!s}\n".format(ke, str(data)))
+                self.cooling = True
+                pass
+
         return

--- a/cryptofeed/provider/coingecko.py
+++ b/cryptofeed/provider/coingecko.py
@@ -4,125 +4,52 @@ Copyright (C) 2017-2020  Bryant Moscon - bmoscon@gmail.com
 Please see the LICENSE file for the terms and conditions
 associated with this software.
 '''
+
 import asyncio
 from decimal import Decimal
 
 import aiohttp
-from sortedcontainers import SortedDict as sd
 
-from cryptofeed.defines import COINGECKO
+from cryptofeed.defines import COINGECKO, PROFILE
 from cryptofeed.feed import RestFeed
 from cryptofeed.standards import pair_exchange_to_std, timestamp_normalize
 
 
 class Coingecko(RestFeed):
+    
     id = COINGECKO
 
+    # Keys not retained from 'PROFILE' data.
+    _profile_filter_out = set({'block_time_in_minutes', 'hashing_algorithm', 'categories', 'public_notice', 'description', 'links', 'image', 'country_origin'})
+    _market_data_filter_out = set({'roi', 'ath', 'ath_change_percentage', 'ath_date', 'atl',
+                                   'atl_change_percentage', 'atl_date', 'market_cap_rank',
+                                   'price_change_24h_in_currency', 'price_change_percentage_1h_in_currency',
+                                   'price_change_percentage_24h_in_currency', 'price_change_percentage_7d_in_currency',
+                                   'price_change_percentage_14d_in_currency', 'price_change_percentage_30d_in_currency',
+                                   'price_change_percentage_60d_in_currency', 'price_change_percentage_200d_in_currency',
+                                   'price_change_percentage_1y_in_currency', 'market_cap_change_24h_in_currency',
+                                   'market_cap_change_percentage_24h_in_currency'})
+
     def __init__(self, pairs=None, channels=None, callbacks=None, config=None, **kwargs):
-        super().__init__('https://api.coingecko.com/api/v3', pairs=pairs, channels=channels, config=config, callbacks=callbacks, **kwargs)
+        super().__init__('https://api.coingecko.com/api/v3/', pairs=pairs, channels=channels, config=config, callbacks=callbacks, **kwargs)
 
-    async def _market(self, session, pair):
-
-
-    def __reset(self):
-        self.last_trade_update = {}
-
-    async def _trades(self, session, pair):
-        """
-        {
-            "status": "ok",
-            "timestamp": 1489473538996,
-            "symbol": "btcusdt",
-            "trades": [{
-                "tradeId ": 14894644510000001,
-                "price": 4000.00,
-                "quantity": 1.0000,
-                "take": "buy",
-                "time": "2018-03-14 18:36:32"
-            }]
-        }
-        """
-        if pair not in self.last_trade_update:
-            async with session.get(f"{self.address}trades?symbol={pair}") as response:
-                data = await response.json()
-                self.last_trade_update[pair] = timestamp_normalize(self.id, data['trades'][-1]['time'])
-        else:
-            async with session.get(f"{self.address}trades?symbol={pair}&size=2000") as response:
-                data = await response.json()
-                for trade in data['trades']:
-                    if timestamp_normalize(self.id, trade['time']) <= self.last_trade_update[pair]:
-                        continue
-                    price = Decimal(trade['price'])
-                    amount = Decimal(trade['quantity'])
-                    side = BUY if trade['take'] == 'buy' else SELL
-
-                    await self.callback(TRADES, feed=self.id,
-                                        pair=pair_exchange_to_std(pair),
-                                        side=side,
-                                        amount=amount,
-                                        price=price,
-                                        order_id=trade['tradeId'],
-                                        timestamp=timestamp_normalize(self.id, trade['time']))
-                self.last_trade_update[pair] = timestamp_normalize(self.id, data['trades'][-1]['time'])
-
-    async def _ticker(self, session, pair):
-        """
-        {
-            "status":"ok",
-            "ticker":[
-                {
-                    "24hrAmt":"1264748.00057000",
-                    "24hrHigh":"11709.54000000",
-                    "24hrLow":"9200.00000000",
-                    "24hrVol":"119.76200000",
-                    "ask":"0.81000000",
-                    "bid":"0.80000000",
-                    "last":"11525.00000000",
-                    "symbol":"BTCUSDT"
-                }
-            ],
-            "timestamp":1517536673213
-        }
-        """
-        async with session.get(f"{self.address}ticker?symbol={pair}") as response:
-            data = await response.json()
-            bid = Decimal(data['ticker'][0]['bid'])
-            ask = Decimal(data['ticker'][0]['ask'])
-            await self.callback(TICKER, feed=self.id,
-                                pair=pair_exchange_to_std(pair),
-                                bid=bid,
-                                ask=ask,
-                                timestamp=timestamp_normalize(self.id, data['timestamp']))
-
-    async def _book(self, session, pair):
-        async with session.get("{}orderbook?symbol={}".format(self.address, pair)) as response:
-            data = await response.json()
-
-            book = {ASK: sd({
-                Decimal(entry['price']): Decimal(entry['quantity']) for entry in data['orderbook']['asks']
-            }), BID: sd({
-                Decimal(entry['price']): Decimal(entry['quantity']) for entry in data['orderbook']['bids']
-            })}
-
-            await self.callback(L2_BOOK, feed=self.id,
-                                pair=pair_exchange_to_std(pair),
-                                book=book,
-                                timestamp=timestamp_normalize(self.id, data['timestamp']))
 
     async def subscribe(self):
         self.__reset()
         return
 
+
+    def __reset(self):
+        self.last_profile_update = {}
+        pass
+
+
     async def message_handler(self):
         async def handle(session, pair, chan):
-            if chan == TRADES:
-                await self._trades(session, pair)
-            elif chan == TICKER:
-                await self._ticker(session, pair)
-            elif chan == L2_BOOK:
-                await self._book(session, pair)
-            # We can do 15 requests a second
-            await asyncio.sleep(0.07)
+            if chan == PROFILE:
+                await self._profile(session, pair)
+            # Rate Limit: 100 requests/minute -> sleep 0.6s between each request 
+            await asyncio.sleep(0.6)
 
         async with aiohttp.ClientSession() as session:
             if self.config:
@@ -133,3 +60,26 @@ class Coingecko(RestFeed):
                 for chan in self.channels:
                     for pair in self.pairs:
                         await handle(session, pair, chan)
+        return
+
+
+    async def _profile(self, session, pair):
+        """
+        Data from /coins/{id}.
+        """
+
+        async with session.get(f"{self.address}coins/{pair}?localization=false&tickers=false\
+&market_data=true&community_data=true&developer_data=false&sparkline=false") as response:
+            data = await response.json()
+
+        timestamp=timestamp_normalize(self.id, data['last_updated'])
+        if (pair not in self.last_profile_update) or (self.last_profile_update[pair] < timestamp):
+            self.last_profile_update[pair] = timestamp
+            data = {k:v for k,v in data.items() if k not in self._profile_filter_out}
+            data['market_data'] = {k:v for k,v in data['market_data'].items() if k not in self._market_data_filter_out}
+            data['last_updated'] = timestamp
+            await self.callback(PROFILE, feed=self.id,
+                                pair=pair_exchange_to_std(pair),
+                                timestamp=timestamp,
+                                data=data)
+        return

--- a/cryptofeed/providers.py
+++ b/cryptofeed/providers.py
@@ -1,0 +1,8 @@
+'''
+Copyright (C) 2017-2020  Bryant Moscon - bmoscon@gmail.com
+
+Please see the LICENSE file for the terms and conditions
+associated with this software.
+'''
+from cryptofeed.provider.coingecko import Coingecko
+

--- a/cryptofeed/standards.py
+++ b/cryptofeed/standards.py
@@ -16,8 +16,8 @@ import pandas as pd
 from cryptofeed.defines import (BINANCE, BINANCE_FUTURES, BINANCE_US, BITCOINCOM, BITFINEX, BITMAX, BITMEX,
                                 BITSTAMP, BITTREX, BLOCKCHAIN, BYBIT, COINBASE, COINBENE, DERIBIT, EXX, FILL_OR_KILL, FTX,
                                 FTX_US, FUNDING, GATEIO, GEMINI, HITBTC, HUOBI, HUOBI_DM, HUOBI_SWAP, IMMEDIATE_OR_CANCEL, KRAKEN,
-                                KRAKEN_FUTURES, L2_BOOK, L3_BOOK, LIMIT, LIQUIDATIONS,
-                                MAKER_OR_CANCEL, MARKET, OKCOIN, OKEX, OPEN_INTEREST, POLONIEX, PROBIT, TICKER,
+                                KRAKEN_FUTURES, L2_BOOK, L3_BOOK, LIMIT, LIQUIDATIONS, PROFILE, COINGECKO,
+                                MAKER_OR_CANCEL, MARKET, OKCOIN, OKEX, OPEN_INTEREST, POLONIEX, PROBIT, TICKER
                                 TRADES, UNSUPPORTED, UPBIT, VOLUME)
 from cryptofeed.exceptions import UnsupportedDataFeed, UnsupportedTradingOption, UnsupportedTradingPair
 from cryptofeed.pairs import gen_pairs, _exchange_info
@@ -74,7 +74,7 @@ def pair_exchange_to_std(pair):
 
 
 def timestamp_normalize(exchange, ts):
-    if exchange in {BITMEX, COINBASE, HITBTC, OKCOIN, OKEX, BYBIT, FTX, FTX_US, BITCOINCOM, BLOCKCHAIN, PROBIT}:
+    if exchange in {BITMEX, COINBASE, HITBTC, OKCOIN, OKEX, BYBIT, FTX, FTX_US, BITCOINCOM, BLOCKCHAIN, PROBIT, COINGECKO}:
         return pd.Timestamp(ts).timestamp()
     elif exchange in {HUOBI, HUOBI_DM, HUOBI_SWAP, BITFINEX, COINBENE, DERIBIT, BINANCE, BINANCE_US, BINANCE_FUTURES, GEMINI, BITTREX, BITMAX, KRAKEN_FUTURES, UPBIT}:
         return ts / 1000.0
@@ -231,6 +231,9 @@ _feed_to_exchange_map = {
         BINANCE_FUTURES: 'forceOrder',
         FTX: 'trades',
         DERIBIT: 'trades'
+    },
+    PROFILE: {
+        COINGECKO: PROFILE,
     }
 }
 

--- a/cryptofeed/standards.py
+++ b/cryptofeed/standards.py
@@ -17,7 +17,7 @@ from cryptofeed.defines import (BINANCE, BINANCE_FUTURES, BINANCE_US, BITCOINCOM
                                 BITSTAMP, BITTREX, BLOCKCHAIN, BYBIT, COINBASE, COINBENE, DERIBIT, EXX, FILL_OR_KILL, FTX,
                                 FTX_US, FUNDING, GATEIO, GEMINI, HITBTC, HUOBI, HUOBI_DM, HUOBI_SWAP, IMMEDIATE_OR_CANCEL, KRAKEN,
                                 KRAKEN_FUTURES, L2_BOOK, L3_BOOK, LIMIT, LIQUIDATIONS, PROFILE, COINGECKO,
-                                MAKER_OR_CANCEL, MARKET, OKCOIN, OKEX, OPEN_INTEREST, POLONIEX, PROBIT, TICKER
+                                MAKER_OR_CANCEL, MARKET, OKCOIN, OKEX, OPEN_INTEREST, POLONIEX, PROBIT, TICKER,
                                 TRADES, UNSUPPORTED, UPBIT, VOLUME)
 from cryptofeed.exceptions import UnsupportedDataFeed, UnsupportedTradingOption, UnsupportedTradingPair
 from cryptofeed.pairs import gen_pairs, _exchange_info


### PR DESCRIPTION
### Description of code - what bug does this fix / what feature does this add?

- [x] - Partially tested:
only with backend Redis (stream) as function of cryptofeed library
with Cryptostore: Redis backend + Parquet storage / running now in prod since about 2 weeks
- [x] - Changelog updated
- [x] - Contributors file updated (optional)

Support for Coingecko https://api.coingecko.com/api/v3/coins/coin_id endpoint.
Data is retrieved through a newly created profile channel and gathers miscellaneous market data.
Some data being expressed in a base currency (for instance current_price or volume...), the pair format is retained with only 3 base currencies possible: USD, BTC or ETH.
To call a pair, use 'usual format' {BTC-USD, ETH-USD, ETH-BTC}