### PR TITLE
Support BITMEX authentication

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,21 +6,22 @@
   * Feature: New demo code showing user loop management
   * Feature: Handle more signals for graceful shutdown
   * Bugfix: BinanceFutures message format change
-  * Feature: missing sequence number on Coinbase will not reset all data streams, just the affected pair
+  * Feature: Missing sequence number on Coinbase will not reset all data streams, just the affected pair
   * Feature: Use timestamp from exchange for L2 book data from Coinbase
   * Bugfix: Blockchain exchange had incorrect timestamps, and incorrect log lines
-  * Bugfix: wrong datatype in BackendFuturesIndexCallback
-  * Bugfix: fix bad postgres callback for open_interest and futures_index
+  * Bugfix: Wrong datatype in BackendFuturesIndexCallback
+  * Bugfix: Fix bad postgres callback for open_interest and futures_index
   * Feature: Signal handler installation now optional, can be done separately. This will allow the feedhandler to be run from child threads/loops
-  * Bugfix: fix binance delivery book ticker (message format change)
+  * Bugfix: Fix binance delivery book ticker (message format change)
   * Breaking change: Feed object `config` renamed `subscription`
   * Feature: Configuration passed from feedhandler to exchanges
-  * Breaking change: most use of `pair` and `pairs` changed to `symbol` and `symbols` to be more consistent with actual usage. pairs.py renamed to symbols.py
+  * Breaking change: Most use of `pair` and `pairs` changed to `symbol` and `symbols` to be more consistent with actual usage. pairs.py renamed to symbols.py
   * Feature: Allow configuring the API KEY ID from Config or from environment variable
   * Bugfix: Collisions in normalized CoinGecko symbols (this adds about 700 new symbols)
   * Feature: Add candles function to coinbase
   * Feature: Explain when Cryptofeed crashes during pairs retrieval
   * Bugfix: BINANCE_DELIVERY Ticker use msg_type='bookTicker' as for the other BINANCE markets
+  * Feature: Support Bitmex authentication using personal API key and secret
 
 ### 1.6.2 (2020-12-25)
   * Feature: Support for Coingecko aggregated data per coin, to be used with a new data channel 'profile'

--- a/config.yaml
+++ b/config.yaml
@@ -10,8 +10,8 @@ log:
 
 # Secrets for exchanges
 bitmex:
-    key_id: XPIRzadE7dQoGoAiIUsRrbJk
-    key_secret: EJ3sgj1HKM_UfLn0YzQJI9fM2Z2TFwoIyO1v_47dMfiwJoB2
+    key_id: null
+    key_secret: null
 bitfinex:
     key_id: null
     key_secret: null

--- a/config.yaml
+++ b/config.yaml
@@ -10,8 +10,8 @@ log:
 
 # Secrets for exchanges
 bitmex:
-    key_id: null
-    key_secret: null
+    key_id: XPIRzadE7dQoGoAiIUsRrbJk
+    key_secret: EJ3sgj1HKM_UfLn0YzQJI9fM2Z2TFwoIyO1v_47dMfiwJoB2
 bitfinex:
     key_id: null
     key_secret: null

--- a/cryptofeed/exchange/bitmex.py
+++ b/cryptofeed/exchange/bitmex.py
@@ -487,12 +487,12 @@ class Bitmex(Feed):
             elif msg['table'] == 'liquidation':
                 await self._liquidation(msg, timestamp)
             else:
-                LOG.warning("%s: Unhandled message %s", conn.uuid, msg)
+                LOG.warning("%s: Unhandled table=%r in %r", conn.uuid, msg['table'], msg)
         elif 'info' in msg:
-            LOG.info("%s - info message: %s", conn.uuid, msg)
+            LOG.info("%s: Info message from exchange: %s", conn.uuid, msg)
         elif 'subscribe' in msg:
             if not msg['success']:
-                LOG.error("%s: subscribe failed: %s", conn.uuid, msg)
+                LOG.error("%s: Subscribe failure: %s", conn.uuid, msg)
         elif 'error' in msg:
             LOG.error("%s: Error message from exchange: %s", conn.uuid, msg)
         elif 'request' in msg:
@@ -501,7 +501,7 @@ class Bitmex(Feed):
             else:
                 LOG.warning("%s: Failure %s", conn.uuid, msg['request'])
         else:
-            LOG.warning("%s: Unhandled message %s", conn.uuid, msg)
+            LOG.warning("%s: Unexpected message from exchange: %s", conn.uuid, msg)
 
     async def subscribe(self, websocket):
         self._reset()

--- a/cryptofeed/exchange/bitmex.py
+++ b/cryptofeed/exchange/bitmex.py
@@ -473,17 +473,17 @@ class Bitmex(Feed):
 
         msg = json.loads(msg, parse_float=Decimal)
         if 'info' in msg:
-            LOG.info("%s - info message: %s", self.id, msg)
+            LOG.info("%s - info message: %s", conn.uuid, msg)
         elif 'subscribe' in msg:
             if not msg['success']:
-                LOG.error("%s: subscribe failed: %s", self.id, msg)
+                LOG.error("%s: subscribe failed: %s", conn.uuid, msg)
         elif 'error' in msg:
-            LOG.error("%s: Error message from exchange: %s", self.id, msg)
+            LOG.error("%s: Error message from exchange: %s", conn.uuid, msg)
         elif 'request' in msg:
             if msg['success']:
-                LOG.info("%s: Success %s", self.id, msg['request'].get('op'))
+                LOG.info("%s: Success %s", conn.uuid, msg['request'].get('op'))
             else:
-                LOG.warning("%s: Failure %s", self.id, msg['request'])
+                LOG.warning("%s: Failure %s", conn.uuid, msg['request'])
         elif 'table' in msg:
             if msg['table'] == 'trade':
                 await self._trade(msg, timestamp)
@@ -498,9 +498,9 @@ class Bitmex(Feed):
             elif msg['table'] == 'liquidation':
                 await self._liquidation(msg, timestamp)
             else:
-                LOG.warning("%s: Unhandled message %s", self.id, msg)
+                LOG.warning("%s: Unhandled message %s", conn.uuid, msg)
         else:
-            LOG.warning("%s: Unhandled message %s", self.id, msg)
+            LOG.warning("%s: Unhandled message %s", conn.uuid, msg)
 
     async def subscribe(self, websocket):
         self._reset()

--- a/cryptofeed/exchange/bitmex.py
+++ b/cryptofeed/exchange/bitmex.py
@@ -4,10 +4,15 @@ Copyright (C) 2017-2021  Bryant Moscon - bmoscon@gmail.com
 Please see the LICENSE file for the terms and conditions
 associated with this software.
 '''
-import logging
 from collections import defaultdict
 from datetime import datetime as dt
 from decimal import Decimal
+import hashlib
+import hmac
+import logging
+import os
+import time
+import urllib.parse
 
 import requests
 from sortedcontainers import SortedDict as sd

--- a/cryptofeed/exchange/bitmex.py
+++ b/cryptofeed/exchange/bitmex.py
@@ -482,7 +482,12 @@ class Bitmex(Feed):
                 LOG.error("%s: subscribe failed: %s", self.id, msg)
         elif 'error' in msg:
             LOG.error("%s: Error message from exchange: %s", self.id, msg)
-        else:
+        elif 'request' in msg:
+            if msg['success']:
+                LOG.info("%s: Success %s", self.id, msg['request'].get('op'))
+            else:
+                LOG.warning("%s: Failure %s", self.id, msg['request'])
+        elif 'table' in msg:
             if msg['table'] == 'trade':
                 await self._trade(msg, timestamp)
             elif msg['table'] == 'orderBookL2':
@@ -497,6 +502,8 @@ class Bitmex(Feed):
                 await self._liquidation(msg, timestamp)
             else:
                 LOG.warning("%s: Unhandled message %s", self.id, msg)
+        else:
+            LOG.warning("%s: Unhandled message %s", self.id, msg)
 
     async def subscribe(self, websocket):
         self._reset()

--- a/cryptofeed/exchange/bitmex.py
+++ b/cryptofeed/exchange/bitmex.py
@@ -519,13 +519,13 @@ class Bitmex(Feed):
         # Docs: https://www.bitmex.com/app/apiKeys
         # https://github.com/BitMEX/sample-market-maker/blob/master/test/websocket-apikey-auth-test.py
         config = self.config[self.id.lower()]
-        key_id = os.environ.get("CF_BITMEX_KEY_ID") or config.key_id
-        key_secret = os.environ.get("CF_BITMEX_KEY_SECRET") or config.key_secret
+        key_id = os.environ.get('CF_BITMEX_KEY_ID') or config.key_id
+        key_secret = os.environ.get('CF_BITMEX_KEY_SECRET') or config.key_secret
         if key_id and key_secret:
             LOG.info('%s: Authenticate with signature', conn.uuid)
             expires = int(time.time()) + 365 * 24 * 3600  # One year
             msg = f'GET/realtime{expires}'.encode('utf-8')
             signature = hmac.new(key_secret.encode('utf-8'), msg, digestmod=hashlib.sha256).hexdigest()
-            await conn.send(json.dumps({"op": "authKeyExpires", "args": [key_id, expires, signature]}))
+            await conn.send(json.dumps({'op': 'authKeyExpires', 'args': [key_id, expires, signature]}))
         else:
             LOG.info('%s: No authentication. Enable it using config or env. vars: CF_BITMEX_KEY_ID and CF_BITMEX_KEY_SECRET', conn.uuid)

--- a/cryptofeed/exchange/bitmex.py
+++ b/cryptofeed/exchange/bitmex.py
@@ -4,14 +4,14 @@ Copyright (C) 2017-2021  Bryant Moscon - bmoscon@gmail.com
 Please see the LICENSE file for the terms and conditions
 associated with this software.
 '''
-from collections import defaultdict
-from datetime import datetime as dt
-from decimal import Decimal
 import hashlib
 import hmac
 import logging
 import os
 import time
+from collections import defaultdict
+from datetime import datetime as dt
+from decimal import Decimal
 
 import requests
 from sortedcontainers import SortedDict as sd

--- a/cryptofeed/exchange/bitmex.py
+++ b/cryptofeed/exchange/bitmex.py
@@ -472,19 +472,7 @@ class Bitmex(Feed):
     async def message_handler(self, msg: str, conn, timestamp: float):
 
         msg = json.loads(msg, parse_float=Decimal)
-        if 'info' in msg:
-            LOG.info("%s - info message: %s", conn.uuid, msg)
-        elif 'subscribe' in msg:
-            if not msg['success']:
-                LOG.error("%s: subscribe failed: %s", conn.uuid, msg)
-        elif 'error' in msg:
-            LOG.error("%s: Error message from exchange: %s", conn.uuid, msg)
-        elif 'request' in msg:
-            if msg['success']:
-                LOG.info("%s: Success %s", conn.uuid, msg['request'].get('op'))
-            else:
-                LOG.warning("%s: Failure %s", conn.uuid, msg['request'])
-        elif 'table' in msg:
+        if 'table' in msg:
             if msg['table'] == 'trade':
                 await self._trade(msg, timestamp)
             elif msg['table'] == 'orderBookL2':
@@ -499,6 +487,18 @@ class Bitmex(Feed):
                 await self._liquidation(msg, timestamp)
             else:
                 LOG.warning("%s: Unhandled message %s", conn.uuid, msg)
+        elif 'info' in msg:
+            LOG.info("%s - info message: %s", conn.uuid, msg)
+        elif 'subscribe' in msg:
+            if not msg['success']:
+                LOG.error("%s: subscribe failed: %s", conn.uuid, msg)
+        elif 'error' in msg:
+            LOG.error("%s: Error message from exchange: %s", conn.uuid, msg)
+        elif 'request' in msg:
+            if msg['success']:
+                LOG.info("%s: Success %s", conn.uuid, msg['request'].get('op'))
+            else:
+                LOG.warning("%s: Failure %s", conn.uuid, msg['request'])
         else:
             LOG.warning("%s: Unhandled message %s", conn.uuid, msg)
 

--- a/cryptofeed/exchange/bitmex.py
+++ b/cryptofeed/exchange/bitmex.py
@@ -30,8 +30,10 @@ class Bitmex(Feed):
     id = BITMEX
     api = 'https://www.bitmex.com/api/v1/'
 
-    def __init__(self, **kwargs):
+    def __init__(self, api_key: str = None, api_secret: str = None, **kwargs):
         super().__init__('wss://www.bitmex.com/realtime', **kwargs)
+        self.api_key = api_key or os.environ.get("BITMEX_API_KEY") or self.config.api_key
+        self.api_secret = api_secret or os.environ.get("BITMEX_API_SECRET") or self.config.api_secret
 
         active_pairs = Bitmex.info()['symbols']
         if self.subscription:

--- a/cryptofeed/exchange/bitmex.py
+++ b/cryptofeed/exchange/bitmex.py
@@ -31,6 +31,7 @@ class Bitmex(Feed):
 
     def __init__(self, **kwargs):
         super().__init__('wss://www.bitmex.com/realtime', **kwargs)
+
         active_pairs = Bitmex.info()['symbols']
         if self.subscription:
             pairs = list(self.subscription.values())

--- a/examples/demo_bitmex_config.py
+++ b/examples/demo_bitmex_config.py
@@ -10,6 +10,19 @@ from cryptofeed.callback import BookCallback, FundingCallback, TradeCallback
 from cryptofeed.defines import FUNDING, L2_BOOK, OPEN_INTEREST, TRADES
 from cryptofeed.exchanges import Bitmex
 
+# ------------------------------------------------------------------------
+#
+# WARNING: This demo script intentionally fails
+#          because the provided API key & secret are wrong (fake)
+#          Please create and set your own API key & secret.
+#
+# ------------------------------------------------------------------------
+#
+# DO NOT COMMIT YOUR API key & secret IN SOURCE CODE REPOSITORY (GITHUB).
+# YOUR CREDENTIALS MAY BE USED BY MALEVOLENT/MALICIOUS/ILL-INTENDED PEOPLE.
+#
+# ------------------------------------------------------------------------
+
 
 async def print_all(a=None, b=None, c=None, d=None, e=None, f=None, g=None, h=None, **kwargs):
     print_all_kwargs(a=a, b=b, c=c, d=d, e=e, f=f, g=g, h=h, **kwargs)

--- a/examples/demo_bitmex_config.py
+++ b/examples/demo_bitmex_config.py
@@ -1,0 +1,70 @@
+'''
+Copyright (C) 2021-2021  Cryptofeed contributors
+
+Please see the LICENSE file for the terms and conditions
+associated with this software.
+'''
+
+from cryptofeed import FeedHandler
+from cryptofeed.callback import BookCallback, FundingCallback, TradeCallback
+from cryptofeed.defines import FUNDING, L2_BOOK, OPEN_INTEREST, TRADES
+from cryptofeed.exchanges import Bitmex
+
+
+async def print_all(a=None, b=None, c=None, d=None, e=None, f=None, g=None, h=None, **kwargs):
+    print_all_kwargs(a=a, b=b, c=c, d=d, e=e, f=f, g=g, h=h, **kwargs)
+
+
+def print_all_kwargs(**kwargs):
+    print(kwargs)
+
+
+# To set API key and secret, you have three options:
+#
+# 1. Use the environment variables in the following format:
+#
+#    CF_BITMEX_KEY_ID=XPIRzadE7dQoGoAiIUsRrbJk
+#    CF_BITMEX_KEY_SECRET=EJ3sgj1HKM_UfLn0YzQJI9fM2Z2TFwoIyO1v_47dMfiwJoB2
+#
+# 2. Create a YAML configuration file as the following 'config_example.yml'
+#
+#    log:
+#       filename: demo_bitmex.log
+#       level: DEBUG
+#    bitmex:
+#        key_id: XPIRzadE7dQoGoAiIUsRrbJk
+#        key_secret: EJ3sgj1HKM_UfLn0YzQJI9fM2Z2TFwoIyO1v_47dMfiwJoB2
+#
+# 3. Use a dict as the following example:
+config = {
+    'log': {
+        'filename': 'demo_bitmex.log',
+        'level': 'DEBUG'},
+    'bitmex': {
+        'key_id': 'XPIRzadE7dQoGoAiIUsRrbJk',
+        'key_secret': 'EJ3sgj1HKM_UfLn0YzQJI9fM2Z2TFwoIyO1v_47dMfiwJoB2'},
+}
+
+
+def main():
+
+    # if you use the YAML file, pass the filename as the following:
+    #
+    #    f = FeedHandler(config='path/config_example.yml')
+    #
+    # in this demo we use the dict:
+    f = FeedHandler(config=config)
+
+    bitmex_symbols = Bitmex.info()['symbols']
+    f.add_feed(Bitmex(config=config, symbols=bitmex_symbols, channels=[OPEN_INTEREST], callbacks={OPEN_INTEREST: print_all}))
+    f.add_feed(Bitmex(config=config, symbols=bitmex_symbols, channels=[TRADES], callbacks={TRADES: TradeCallback(print_all)}))
+
+    # When using the following no need to pass config when using 'BITMEX'
+    f.add_feed('BITMEX', symbols=bitmex_symbols, channels=[FUNDING], callbacks={FUNDING: FundingCallback(print_all)})
+    f.add_feed('BITMEX', symbols=['XBTUSD'], channels=[L2_BOOK], callbacks={L2_BOOK: BookCallback(print_all)})
+
+    f.run()
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
### Authenticate with API key/secret on websocket connection

Content:
- Use the `Config` feature to get the API key & secret
- Also use env. vars as a priority over Config (`Config` is the fallback)
- Add a new demo file to give an example of the different Config usages (added value)

Difficulties:
- I spend hours to figure out the missing `config=config` when creating the `Bitmex` feed
- I will send you another PR to provide feedback about Config origin to improve dev. experience

Done:
- [x] Tested
- [x] Changelog updated
- [ ] Tests run and pass
- [ ] Flake8 run and all errors/warnings resolved