### PR TITLE
WIP - Refactor the unification of the HTTP/Websocket connections

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,6 +30,7 @@
   * Feature: Shutdown multiple backends asynchronously, and close the event loop properly
   * Bugfix: Repair the Bitfinex FUNDING
   * Feature: Speedup the handling of Bitfinex messages by reducing intermediate mappings
+  * Bugfix: Cancel the pending tasks to gracefully/properly close the ASyncIO loop
 
 ### 1.6.2 (2020-12-25)
   * Feature: Support for Coingecko aggregated data per coin, to be used with a new data channel 'profile'

--- a/cryptofeed/connection.py
+++ b/cryptofeed/connection.py
@@ -135,6 +135,11 @@ class WSAsyncConn(AsyncConnection):
 
         await self.socket.send(data)
         self.sent += 1
+
+        if __debug__:
+            if all(c.isprintable() for c in str(data)):
+                LOG.debug('%s: Send msg %s', self.id, data)
+
         # slow down the subscription batch by waiting for a response or for a half of a second before next send
         try:
             data = await asyncio.wait_for(self.socket.recv(), timeout=0.5)

--- a/cryptofeed/connection.py
+++ b/cryptofeed/connection.py
@@ -5,96 +5,147 @@ Please see the LICENSE file for the terms and conditions
 associated with this software.
 '''
 import asyncio
+import logging
+import time
 from contextlib import asynccontextmanager
-from typing import Union, List
-import uuid
+from typing import AsyncIterable, Awaitable, Callable, Dict, Iterable, List, Optional, Tuple, Union
 
 import aiohttp
 import websockets
 
 
+LOG = logging.getLogger('feedhandler')
+
+
+def split_opt_addr(address: dict) -> List[dict]:
+    return [{'opt': key, 'addr': val} for key, val in address.items()]
+
+
 class AsyncConnection:
-    def __init__(self, address: Union[str, List[str]], identifier: str, delay: float = 1.0, sleep: float = 0.0, **kwargs):
-        """
-        address: str, or list of str
-            address to be used to create the connection. A list of addresses is only valid for HTTPS connections.
-            The address protocol (wss or https) will be used to determine the connection type.
+    conn_count: int = 0  # total number of AsyncConnection objects created
 
-        identifier: str
-            unique string used to identify the connection.
-
-        delay: float
-            time in seconds to delay between reconnects (due to errors).
-
-        sleep: float
-            time in seconds to delay between requests.
-
-        kwargs:
-            passed into the websocket connection.
-        """
-        self.address = address
-        self.kwargs = kwargs
-        self.conn = None
-        self.__sleep = sleep
-        self.__delay = delay
-        self.__identifier = f"{identifier}-{str(uuid.uuid4())[:6]}"
-
-        if isinstance(address, str) and self.address[:2] == 'ws':
-            self.conn_type = "ws"
-        elif isinstance(address, list) and all(addr[:5] == 'https' for addr in address):
-            self.conn_type = 'https'
-        elif isinstance(address, str) and address[:5] == 'https':
-            self.conn_type = 'https'
-        else:
-            raise ValueError("Invalid connection type, ensure address contains valid protocol")
+    def __init__(self, conn_id: str, ctx: dict):
+        AsyncConnection.conn_count += 1
+        self.id: str = conn_id  # unique identifier of the connection
+        self.ctx: dict = ctx    # ctx (context) is passed to subscribe() and handle()
+        self.received: int = 0  # count messages received since last watchdog check
+        self.sent: int = 0      # count messages sent on the websocket
+        self.socket: Union[websockets.WebSocketClientProtocol, aiohttp.ClientSession, None] = None
 
     @asynccontextmanager
     async def connect(self):
-        if self.conn_type == "ws":
-            self.conn = await websockets.connect(self.address, **self.kwargs)
-        else:
-            self.conn = aiohttp.ClientSession()
+        await self._open()
         try:
             yield self
         finally:
-            if self.conn:
-                await self.conn.close()
-                self.conn = None
+            await self.close()
 
-    async def send(self, msg: str):
-        return await self.conn.send(msg)
+    async def _open(self):
+        raise NotImplementedError
+
+    @property
+    def is_open(self) -> bool:
+        # This is the Websocket implementation. Could be replaced by raise NotImplementedError.
+        return self.socket and self.socket.open
 
     async def close(self):
-        if self.conn:
-            await self.conn.close()
-            self.conn = None
+        if self.is_open:
+            # Swap socket value to avoid multiple closing occurring at the same time
+            socket = self.socket
+            self.socket = None
+            await socket.close()
+            LOG.info('%s: closed connection %r', self.id, socket.__class__.__name__)
 
-    async def read(self):
-        if self.conn_type == 'ws':
-            async for data in self.conn:
-                yield data
-        elif self.conn_type == 'https':
-            while True:
-                for addr in self.address:
-                    async with self.conn.get(addr) as response:
-                        response.raise_for_status()
-                        data = await response.text()
-                        yield data
-                    await asyncio.sleep(self.__sleep)
+    async def read(self) -> AsyncIterable[Tuple[bytes, float]]:
+        # This is the Websocket implementation. Could be replaced by raise NotImplementedError.
+        assert self.socket is not None
+        async for data in self.socket:
+            self.received += 1
+            yield data, time.time()
+            # if not self.is_open:
+            #     LOG.info("%s: detect connection closed in read()", self.id)
+            #     return
+
+
+class HTTPAsyncConn(AsyncConnection):
+
+    def __init__(self, address: Dict[str, str], feed_id: str, sleep: float,
+                 feed_addr_compute: Optional[Callable[[], Iterable[dict]]]):
+        """
+        sleep: float
+            time in seconds to limit rate of request polling.
+        """
+        if not isinstance(address, dict) or not all(addr[:4] == 'http' for addr in address.values()):
+            raise ValueError(f'Invalid address for HTTPAsyncConn, must be a dict of quote/address, all starting with "http" but got: {address!r}')
+        super().__init__(conn_id=f'{feed_id}-HTTP-{self.conn_count}', ctx={})
+        self.opt_addr = split_opt_addr(address)
+        self.sleep: float = sleep  # in seconds
+        self.addr_compute: Optional[Callable[[], Iterable[dict]]] = feed_addr_compute
 
     @property
-    def open(self):
-        if self.conn:
-            if self.conn_type == "ws":
-                return self.conn.open
-            elif self.conn_type == 'https':
-                return not self.conn.closed
-        return False
+    def is_open(self) -> bool:
+        return self.socket and not self.socket.closed
 
-    @property
-    def uuid(self):
-        return self.__identifier
+    async def _open(self):
+        if self.is_open:
+            LOG.exception('%s: HTTP session already created', self.id)
+        else:
+            LOG.info('%s: create HTTP session', self.id)
+            self.socket = aiohttp.ClientSession()
+        self.sent = -1  # no subscriptions on HTTP connection
 
-    @property
-    def delay(self):
-        return self.__delay
+    async def read(self) -> AsyncIterable[Tuple[bytes, float]]:
+        while True:
+
+            for ctx in self.addr_compute() if self.addr_compute else self.opt_addr:
+                if not self.is_open:
+                    LOG.info('%s: detect connection closed in read()', self.id)
+                    return
+                async with self.socket.get(ctx['addr']) as response:
+                    timestamp = time.time()
+                    response.raise_for_status()
+                    data = await response.read()
+                    self.received += 1
+                    self.ctx = ctx
+                    yield data, timestamp
+                await asyncio.sleep(self.sleep)
+
+
+class WSAsyncConn(AsyncConnection):
+
+    def __init__(self, address: Dict[str, str], feed_id: str,
+                 feed_msg_handler: Callable[[bytes, float, AsyncConnection], Awaitable], **kwargs):
+        """
+        kwargs:
+            passed into the websocket connection.
+        """
+        if not isinstance(address, dict) or len(address) == 0 or list(address.values())[0][:2] != 'ws':
+            raise ValueError(f'Invalid address for WSAsyncConn, must be a dict containing one single address starting with "ws" but got: {address!r}')
+        ctx = split_opt_addr(address)[0]
+        opt_or_count = ctx['opt'] if isinstance(ctx['opt'], str) and 0 < len(ctx['opt']) < 9 else self.conn_count
+        super().__init__(conn_id=f'{feed_id}-WS-{opt_or_count}', ctx=ctx)
+        self.handle: Callable[[bytes, float, AsyncConnection], Awaitable] = feed_msg_handler  # used by WSAsyncConn.send()
+        self.ws_kwargs = kwargs  # optional args for websocket
+
+    async def send(self, data: Union[str, bytes]):
+        """Only used for Websocket, especially by Feed.subscribe()."""
+        if not self.is_open:
+            LOG.warning('%s: abort sending because websocket is closed - raise ConnectionError', self.id)
+            raise ConnectionError
+
+        await self.socket.send(data)
+        self.sent += 1
+        # slow down the subscription batch by waiting for a response or for a half of a second before next send
+        try:
+            data = await asyncio.wait_for(self.socket.recv(), timeout=0.5)
+            await self.handle(data, time.time(), self)
+        except asyncio.exceptions.TimeoutError:
+            pass
+
+    async def _open(self):
+        if self.is_open:
+            LOG.exception('%s: websocket already opened', self.id)
+        else:
+            LOG.info('%s: create websocket', self.id)
+            self.socket = await websockets.connect(self.ctx['addr'], **self.ws_kwargs)
+        self.sent = 0  # reset counter

--- a/cryptofeed/exchange/binance_futures.py
+++ b/cryptofeed/exchange/binance_futures.py
@@ -9,6 +9,7 @@ import logging
 
 from yapic import json
 
+from cryptofeed.connection import AsyncConnection
 from cryptofeed.defines import BINANCE_FUTURES, OPEN_INTEREST, TICKER
 from cryptofeed.exchange.binance import Binance
 
@@ -21,25 +22,8 @@ class BinanceFutures(Binance):
     def __init__(self, depth=1000, **kwargs):
         super().__init__(depth=depth, **kwargs)
         # overwrite values previously set by the super class Binance
-        self.ws_endpoint = 'wss://fstream.binance.com'
         self.rest_endpoint = 'https://fapi.binance.com/fapi/v1'
-        self.address = self._address()
-
-    def _address(self):
-        address = self.ws_endpoint + '/stream?streams='
-        for chan in self.channels if not self.subscription else self.subscription:
-            if chan == OPEN_INTEREST:
-                continue
-            for pair in self.symbols if not self.subscription else self.subscription[chan]:
-                pair = pair.lower()
-                if chan == TICKER:
-                    stream = f"{pair}@bookTicker/"
-                else:
-                    stream = f"{pair}@{chan}/"
-                address += stream
-        if address == f"{self.ws_endpoint}/stream?streams=":
-            return None
-        return address[:-1]
+        self.address = self._address('wss://fstream.binance.com', stream_builder=self.book_ticker_stream)
 
     def _check_update_id(self, pair: str, msg: dict) -> (bool, bool):
         skip_update = False
@@ -58,8 +42,9 @@ class BinanceFutures(Binance):
             skip_update = True
         return skip_update, forced
 
-    async def message_handler(self, msg: str, conn, timestamp: float):
-        msg = json.loads(msg, parse_float=Decimal)
+    async def handle(self, data: bytes, timestamp: float, conn: AsyncConnection):
+
+        msg = json.loads(data, parse_float=Decimal)
 
         # Combined stream events are wrapped as follows: {"stream":"<streamName>","data":<rawPayload>}
         # streamName is of format <symbol>@<channel>
@@ -80,4 +65,4 @@ class BinanceFutures(Binance):
         elif msg_type == 'markPriceUpdate':
             await self._funding(msg, timestamp)
         else:
-            LOG.warning("%s: Unexpected message received: %s", self.id, msg)
+            LOG.warning("%s: Unexpected message received: %s", conn.id, msg)

--- a/cryptofeed/exchange/binance_us.py
+++ b/cryptofeed/exchange/binance_us.py
@@ -19,6 +19,5 @@ class BinanceUS(Binance):
     def __init__(self, depth=1000, **kwargs):
         super().__init__(depth=depth, **kwargs)
         # overwrite values previously set by the super class Binance
-        self.ws_endpoint = 'wss://stream.binance.us:9443'
         self.rest_endpoint = 'https://api.binance.us/api/v1'
-        self.address = self._address()
+        self.address = self._address('wss://stream.binance.us:9443', stream_builder=self.classic_stream)

--- a/cryptofeed/exchange/bitmax.py
+++ b/cryptofeed/exchange/bitmax.py
@@ -140,7 +140,7 @@ class Bitmax(Feed):
     async def subscribe(self, conn: AsyncConnection):
         assert isinstance(conn, WSAsyncConn)
         assert 'opt' in conn.ctx
-        assert isinstance(conn.ctx['opt'], Tuple)
+        assert isinstance(conn.ctx['opt'], tuple)
         opt: Tuple[Tuple[str, str]] = conn.ctx['opt']
         self.__reset()
 
@@ -162,4 +162,3 @@ class Bitmax(Feed):
         #         for symbol in symbols:
         #             message = {"op": "req", "action": "depth-snapshot", "args": {"symbol": symbol}}
         #             await conn.send(json.dumps(message))
-

--- a/cryptofeed/exchange/bitmax.py
+++ b/cryptofeed/exchange/bitmax.py
@@ -4,18 +4,21 @@ Copyright (C) 2017-2021  Bryant Moscon - bmoscon@gmail.com
 Please see the LICENSE file for the terms and conditions
 associated with this software.
 '''
+import random
 from collections import defaultdict
 import logging
 from decimal import Decimal
+from typing import Dict, List, Tuple
 
 from sortedcontainers import SortedDict as sd
 from yapic import json
 
+from cryptofeed.connection import AsyncConnection, WSAsyncConn
 from cryptofeed.defines import BID, ASK, BITMAX, BUY, L2_BOOK, SELL, TRADES
 from cryptofeed.exceptions import MissingSequenceNumber
 from cryptofeed.feed import Feed
 from cryptofeed.standards import symbol_exchange_to_std, timestamp_normalize
-
+from cryptofeed.util import split
 
 LOG = logging.getLogger('feedhandler')
 
@@ -26,10 +29,32 @@ class Bitmax(Feed):
     def __init__(self, **kwargs):
         super().__init__('wss://bitmax.io/0/api/pro/v1/stream', **kwargs)
         self.__reset()
+        self.address = self._address('wss://bitmax.io/0/api/pro/v1/stream')
 
     def __reset(self):
+        # TODO: store context data in conn.ctx
         self.l2_book = {}
         self.seq_no = defaultdict(lambda: None)
+
+    def _address(self, ws_endpoint: str) -> Dict[Tuple[Tuple[str, str]], str]:
+        """
+        When 11 pair-channels in one subscribe msg, BITMAX responds
+        "Invalid operation: No more than 10 symbols per subscribe operation.".
+        When sending multiple "sub" messages in the same websocket, BITMAX responds the same error.
+        """
+        pair_channels: List[Tuple[str, str]] = []
+        for chan in set(self.channels or self.subscription):
+            for pair in set(self.symbols or self.subscription[chan]):
+                pair_channels.append((pair, chan))
+
+        # mix pair/channel combinations to avoid having most of the BTC & USD pairs in the same websocket
+        random.shuffle(pair_channels)
+
+        address: Dict[Tuple[Tuple[str, str]], str] = {}
+        for chunk in split.list_by_max_items(pair_channels, 10):
+            address[tuple(chunk)] = ws_endpoint
+        LOG.info("%s: prepared %s WS subscriptions using %s", self.id, len(address), ws_endpoint)
+        return address
 
     async def _trade(self, msg: dict, timestamp: float):
         """
@@ -88,9 +113,13 @@ class Bitmax(Feed):
 
         await self.book_callback(self.l2_book[pair], L2_BOOK, pair, forced, delta, timestamp_normalize(self.id, msg['data']['ts']), timestamp)
 
-    async def message_handler(self, msg: str, conn, timestamp: float):
+    async def handle(self, data: bytes, timestamp: float, conn: AsyncConnection):
+        """
+        {'m': 'depth', 'ts': 0, 'seqnum': 0, 's': 'ETH/PAX', 'asks': [], 'bids': []}
+        """
+        assert isinstance(conn, WSAsyncConn)
 
-        msg = json.loads(msg, parse_float=Decimal)
+        msg = json.loads(data, parse_float=Decimal)
 
         if 'm' in msg:
             if msg['m'] == 'depth' or msg['m'] == 'depth-snapshot':
@@ -104,24 +133,33 @@ class Bitmax(Feed):
             elif msg['m'] == 'sub':
                 return
             else:
-                LOG.warning("%s: Invalid message type %s", self.id, msg)
+                LOG.warning("%s: Invalid message type %s", conn.id, msg)
         else:
-            LOG.warning("%s: Invalid message type %s", self.id, msg)
+            LOG.warning("%s: Invalid message type %s", conn.id, msg)
 
-    async def subscribe(self, websocket):
+    async def subscribe(self, conn: AsyncConnection):
+        assert isinstance(conn, WSAsyncConn)
+        assert 'opt' in conn.ctx
+        assert isinstance(conn.ctx['opt'], Tuple)
+        opt: Tuple[Tuple[str, str]] = conn.ctx['opt']
         self.__reset()
-        l2_pairs = []
 
-        for channel in self.channels if not self.subscription else self.subscription:
-            pairs = self.symbols if not self.subscription else self.subscription[channel]
+        assert opt
+        for symbol, chan in opt:
+            if chan == "depth:":
+                message = {"op": "req", "action": "depth-snapshot", "args": {"symbol": symbol}}
+            else:
+                message = {'op': 'sub', 'ch': chan + symbol}
+            await conn.send(json.dumps(message))
 
-            if channel == "depth:":
-                l2_pairs.extend(pairs)
+        # # Fallback if options is None
+        # for chan in set(self.channels or self.subscription):
+        #     symbols = set(self.symbols or self.subscription[chan])
+        #     for chunk in split.list_by_max_items(symbols, 10):
+        #         message = {'op': 'sub', 'ch': chan + ','.join(chunk)}
+        #         await conn.send(json.dumps(message))
+        #     if chan == "depth:":
+        #         for symbol in symbols:
+        #             message = {"op": "req", "action": "depth-snapshot", "args": {"symbol": symbol}}
+        #             await conn.send(json.dumps(message))
 
-            pairs = self.symbols if not self.subscription else self.subscription[channel]
-            message = {'op': 'sub', 'ch': channel + ','.join(pairs)}
-            await websocket.send(json.dumps(message))
-
-        for pair in l2_pairs:
-            message = {"op": "req", "action": "depth-snapshot", "args": {"symbol": pair}}
-            await websocket.send(json.dumps(message))

--- a/cryptofeed/exchange/bitstamp.py
+++ b/cryptofeed/exchange/bitstamp.py
@@ -124,9 +124,9 @@ class Bitstamp(Feed):
         elif msg['event'] == 'trade':
             await self._trades(msg, timestamp)
         elif msg['event'] == 'data':
-            if msg['channel'].startswith(feed_to_exchange(conn.id, L2_BOOK)):
+            if msg['channel'].startswith(feed_to_exchange(self.id, L2_BOOK)):
                 await self._l2_book(msg, timestamp)
-            if msg['channel'].startswith(feed_to_exchange(conn.id, L3_BOOK)):
+            if msg['channel'].startswith(feed_to_exchange(self.id, L3_BOOK)):
                 await self._l3_book(msg, timestamp)
         else:
             LOG.warning("%s: Invalid message type %s", conn.id, msg)

--- a/cryptofeed/exchange/gemini.py
+++ b/cryptofeed/exchange/gemini.py
@@ -39,7 +39,7 @@ class Gemini(Feed):
             return
 
         data = msg['changes']
-        forced = not len(self.l2_book[pair][BID])
+        forced = len(self.l2_book[pair][BID]) != 0
         delta = {BID: [], ASK: []}
         for entry in data:
             side = ASK if entry[0] == 'sell' else BID

--- a/cryptofeed/exchange/huobi_dm.py
+++ b/cryptofeed/exchange/huobi_dm.py
@@ -32,7 +32,7 @@ from decimal import Decimal
 from sortedcontainers import SortedDict as sd
 from yapic import json
 
-from cryptofeed.connection import AsyncConnection
+from cryptofeed.connection import AsyncConnection, WSAsyncConn
 from cryptofeed.defines import BID, ASK, BUY, HUOBI_DM, L2_BOOK, SELL, TRADES
 from cryptofeed.feed import Feed
 from cryptofeed.standards import symbol_exchange_to_std, symbol_std_to_exchange, timestamp_normalize
@@ -118,11 +118,11 @@ class HuobiDM(Feed):
                                 receipt_timestamp=timestamp
                                 )
 
-    async def message_handler(self, msg: str, conn, timestamp: float):
-
+    async def handle(self, data: bytes, timestamp: float, conn: AsyncConnection):
+        assert isinstance(conn, WSAsyncConn)
         # unzip message
-        msg = zlib.decompress(msg, 16 + zlib.MAX_WBITS)
-        msg = json.loads(msg, parse_float=Decimal)
+        data = zlib.decompress(data, 16 + zlib.MAX_WBITS)
+        msg = json.loads(data, parse_float=Decimal)
 
         # Huobi sends a ping evert 5 seconds and will disconnect us if we do not respond to it
         if 'ping' in msg:
@@ -135,11 +135,12 @@ class HuobiDM(Feed):
             elif 'depth' in msg['ch']:
                 await self._book(msg, timestamp)
             else:
-                LOG.warning("%s: Invalid message type %s", self.id, msg)
+                LOG.warning("%s: Invalid message type %s", conn.id, msg)
         else:
-            LOG.warning("%s: Invalid message type %s", self.id, msg)
+            LOG.warning("%s: Invalid message type %s", conn.id, msg)
 
     async def subscribe(self, conn: AsyncConnection):
+        assert isinstance(conn, WSAsyncConn)
         self.__reset()
         client_id = 0
         for chan in set(self.channels or self.subscription):

--- a/cryptofeed/exchange/huobi_swap.py
+++ b/cryptofeed/exchange/huobi_swap.py
@@ -6,7 +6,7 @@ from decimal import Decimal
 import aiohttp
 from yapic import json
 
-from cryptofeed.connection import AsyncConnection
+from cryptofeed.connection import AsyncConnection, WSAsyncConn
 from cryptofeed.defines import HUOBI_SWAP, FUNDING
 from cryptofeed.exchange.huobi_dm import HuobiDM
 from cryptofeed.feed import Feed
@@ -24,6 +24,7 @@ class HuobiSwap(HuobiDM):
         self.funding_updates = {}
 
     async def _funding(self, pairs):
+        # TODO: use HTTPAsyncConn by passing the HTTP addresses to super.__init__()
         async with aiohttp.ClientSession() as session:
             while True:
                 for pair in pairs:
@@ -49,10 +50,11 @@ class HuobiSwap(HuobiDM):
                         await asyncio.sleep(0.1)
 
     async def subscribe(self, conn: AsyncConnection):
+        assert isinstance(conn, WSAsyncConn)
         chans = list(self.channels)
         sub = dict(self.subscription)
         if FUNDING in (self.channels or self.subscription):
-            loop = asyncio.get_event_loop()
+            loop = asyncio.get_event_loop()  # TODO: use HTTPAsyncConn
             loop.create_task(self._funding(self.symbols if FUNDING in self.channels else self.subscription[FUNDING]))
             self.channels.remove(FUNDING) if FUNDING in self.channels else self.subscription.pop(FUNDING)
 

--- a/cryptofeed/exchange/okcoin.py
+++ b/cryptofeed/exchange/okcoin.py
@@ -17,7 +17,7 @@ from cryptofeed.defines import ASK, BID, BUY, FUNDING, L2_BOOK, OKCOIN, OPEN_INT
 from cryptofeed.exceptions import BadChecksum
 from cryptofeed.feed import Feed
 from cryptofeed.standards import symbol_exchange_to_std, timestamp_normalize
-from cryptofeed.util.split import split_list_by_max_items
+from cryptofeed.util import split
 
 
 LOG = logging.getLogger('feedhandler')
@@ -67,7 +67,7 @@ class OKCoin(Feed):
             return False
 
         # Avoid error "Max frame length of 65536 has been exceeded" by limiting requests to some args
-        for chunk in split_list_by_max_items(symbol_channels, 33):
+        for chunk in split.list_by_max_items(symbol_channels, 33):
             LOG.info("%s: Subscribe to %s args from %r to %r", self.id, len(chunk), chunk[0], chunk[-1])
             request = {"op": "subscribe", "args": chunk}
             await conn.send(json.dumps(request))

--- a/cryptofeed/exchange/okcoin.py
+++ b/cryptofeed/exchange/okcoin.py
@@ -12,10 +12,12 @@ import zlib
 from sortedcontainers import SortedDict as sd
 from yapic import json
 
+from cryptofeed.connection import AsyncConnection
 from cryptofeed.defines import ASK, BID, BUY, FUNDING, L2_BOOK, OKCOIN, OPEN_INTEREST, SELL, TICKER, TRADES, LIQUIDATIONS
 from cryptofeed.exceptions import BadChecksum
 from cryptofeed.feed import Feed
 from cryptofeed.standards import symbol_exchange_to_std, timestamp_normalize
+from cryptofeed.util.split import split_list_by_max_items
 
 
 LOG = logging.getLogger('feedhandler')
@@ -54,32 +56,42 @@ class OKCoin(Feed):
         computed = ":".join(combined).encode()
         return zlib.crc32(computed)
 
-    async def subscribe(self, websocket):
+    async def subscribe(self, conn: AsyncConnection):
         self.__reset()
 
-        def chan_format(channel, pair):
-            if "SWAP" in pair:
-                return channel.format('swap')
-            elif len(pair.split("-")) == 3:
-                return channel.format('futures')
-            else:
-                return channel.format('spot')
+        symbol_channels = list(self.get_channel_symbol_combinations())
+        LOG.info("%s: Got %r combinations of pairs and channels", self.id, len(symbol_channels))
 
-        if self.subscription:
-            for chan in self.subscription:
-                if chan == LIQUIDATIONS:
-                    continue
-                args = [f"{chan_format(chan, pair)}:{pair}" for pair in self.subscription[chan]]
-                await websocket.send(json.dumps({
-                    "op": "subscribe",
-                    "args": args
-                }))
-        else:
-            chans = [f"{chan_format(chan, pair)}:{pair}" for chan in self.channels for pair in self.symbols if chan != LIQUIDATIONS]
-            await websocket.send(json.dumps({
-                "op": "subscribe",
-                "args": chans
-            }))
+        if len(symbol_channels) == 0:
+            LOG.info("%s: No websocket subscription", self.id)
+            return False
+
+        # Avoid error "Max frame length of 65536 has been exceeded" by limiting requests to some args
+        for chunk in split_list_by_max_items(symbol_channels, 33):
+            LOG.info("%s: Subscribe to %s args from %r to %r", self.id, len(chunk), chunk[0], chunk[-1])
+            request = {"op": "subscribe", "args": chunk}
+            await conn.send(json.dumps(request))
+
+    @staticmethod
+    def instrument_type(pair):
+        dash_count = pair.count("-")
+        if dash_count == 1:  # BTC-USDT
+            return 'spot'
+        if dash_count == 4:  # BTC-USD-201225-35000-P
+            return 'option'
+        if pair[-4:] == "SWAP":  # BTC-USDT-SWAP
+            return 'swap'
+        return 'futures'  # BTC-USDT-201225
+
+    def get_channel_symbol_combinations(self):
+        for chan in set(self.channels or self.subscription):
+            if chan == LIQUIDATIONS:
+                continue
+            for symbol in set(self.symbols or self.subscription[chan]):
+                instrument_type = self.instrument_type(symbol)
+                if instrument_type != 'swap' and 'funding' in chan:
+                    continue  # No funding for spot, futures and options
+                yield f"{chan.format(instrument_type)}:{symbol}"
 
     async def _ticker(self, msg: dict, timestamp: float):
         """

--- a/cryptofeed/exchange/okex.py
+++ b/cryptofeed/exchange/okex.py
@@ -13,7 +13,7 @@ import aiohttp
 import requests
 from yapic import json
 
-from cryptofeed.connection import AsyncConnection
+from cryptofeed.connection import AsyncConnection, WSAsyncConn
 from cryptofeed.defines import OKEX, LIQUIDATIONS, BUY, SELL
 from cryptofeed.exchange.okcoin import OKCoin
 
@@ -56,6 +56,7 @@ class OKEx(OKCoin):
         return symbols
 
     async def _liquidations(self, pairs: list):
+        # TODO: Append HTTP addresses in self.address to use HTTPAsyncConn
         last_update = {}
         async with aiohttp.ClientSession() as session:
             while True:
@@ -95,6 +96,7 @@ class OKEx(OKCoin):
                 await asyncio.sleep(60)
 
     async def subscribe(self, conn: AsyncConnection):
+        assert isinstance(conn, WSAsyncConn)
         if LIQUIDATIONS in self.subscription or LIQUIDATIONS in self.channels:
             pairs = self.subscription[LIQUIDATIONS] if LIQUIDATIONS in self.subscription else self.symbols
             asyncio.create_task(self._liquidations(pairs))  # TODO: use HTTPAsyncConn

--- a/cryptofeed/feed.py
+++ b/cryptofeed/feed.py
@@ -112,6 +112,7 @@ class Feed:
         for key, callback in self.callbacks.items():
             if not isinstance(callback, list):
                 self.callbacks[key] = [callback]
+
     @classmethod
     def info(cls, key_id: str = None) -> dict:
         """
@@ -229,4 +230,3 @@ class Feed:
                     LOG.info('%s: stopping backend %s', self.id, name)
                     await callback.stop()
         LOG.info('%s: feed shutdown completed', self.id)
-

--- a/cryptofeed/feedhandler.py
+++ b/cryptofeed/feedhandler.py
@@ -182,7 +182,7 @@ class FeedHandler:
             runners.append(Runner(feed, conn, timeout, max_retries))
 
         if len(runners) == 0:
-            txt = f'FH {feed.id}: No connection prepared.'
+            txt = f'FH {feed.id}: Nothing to subscribe (no runner).'
             LOG.critical(txt)
             raise ValueError(txt)
 

--- a/cryptofeed/feedhandler.py
+++ b/cryptofeed/feedhandler.py
@@ -244,6 +244,8 @@ class FeedHandler:
             self.stop(loop=loop)
             self.close(loop=loop)
 
+        LOG.info('FH: leaving run()')
+
     def stop(self, loop=None):
         """Shutdown the Feed backends asynchronously."""
         if not loop:

--- a/cryptofeed/feedhandler.py
+++ b/cryptofeed/feedhandler.py
@@ -232,8 +232,9 @@ class FeedHandler:
                 loop.create_task(self._connect(conn, sub, handler))
                 self.timeout[conn.uuid] = timeout
 
-        if not start_loop:
-            return
+        if not start_loop:return
+
+        return
 
         try:
             loop.run_forever()
@@ -251,9 +252,6 @@ class FeedHandler:
         """Shutdown the Feed backends asynchronously."""
         if not loop:
             loop = asyncio.get_event_loop()
-
-        LOG.info('FH: flag retries=0 to stop the tasks running the connection handlers')
-        self.retries = 0
 
         LOG.info('FH: create the tasks to properly shutdown the backends (to flush the local cache)')
         shutdown_tasks = []

--- a/cryptofeed/feedhandler.py
+++ b/cryptofeed/feedhandler.py
@@ -7,14 +7,15 @@ associated with this software.
 import asyncio
 import logging
 import signal
-from signal import SIGTERM, SIGINT, SIGABRT
+from signal import SIGABRT, SIGINT, SIGTERM
 import sys
+
 try:
     # unix / macos only
     from signal import SIGHUP
-    SIGNALS = (SIGTERM, SIGINT, SIGABRT, SIGHUP)
+    SIGNALS = (SIGABRT, SIGINT, SIGTERM, SIGHUP)
 except ImportError:
-    SIGNALS = (SIGTERM, SIGINT, SIGABRT)
+    SIGNALS = (SIGABRT, SIGINT, SIGTERM)
 
 import zlib
 from collections import defaultdict

--- a/cryptofeed/feedhandler.py
+++ b/cryptofeed/feedhandler.py
@@ -269,9 +269,8 @@ class FeedHandler:
                 task = loop.create_task(r.run(self.handler_enabled, self.raw_message_capture, self.log_messages_on_error))
                 task.set_name(f'runner_{r.id}')
 
-        if not start_loop:return
-
-        return
+        if not start_loop:
+            return
 
         try:
             loop.run_forever()

--- a/cryptofeed/feedhandler.py
+++ b/cryptofeed/feedhandler.py
@@ -290,7 +290,7 @@ class FeedHandler:
         if not loop:
             loop = asyncio.get_event_loop()
 
-        LOG.info('FH: close WS connections and stop Runner loops (asynchronous run)')
+        LOG.info('FH: close WS connections and stop Runner loops')
         for feed, runners in self.feeds:
             for r in runners:
                 task = loop.create_task(r.shutdown())

--- a/cryptofeed/provider/coingecko.py
+++ b/cryptofeed/provider/coingecko.py
@@ -4,111 +4,276 @@ Copyright (C) 2017-2021  Bryant Moscon - bmoscon@gmail.com
 Please see the LICENSE file for the terms and conditions
 associated with this software.
 '''
-from collections import defaultdict
+import logging
 from decimal import Decimal
-from typing import Tuple, Callable, List
+from typing import Dict
 
 from yapic import json
 
-from cryptofeed.connection import AsyncConnection
+from cryptofeed.connection import AsyncConnection, HTTPAsyncConn
 from cryptofeed.defines import COINGECKO, MARKET_INFO
 from cryptofeed.feed import Feed
-from cryptofeed.standards import timestamp_normalize
+from cryptofeed.symbols import SYMBOL_SEP
+from cryptofeed.standards import symbol_exchange_to_std, timestamp_normalize
 
+
+LOG = logging.getLogger('feedhandler')
 
 # Keys retained from Coingecko for `MARKET_INFO` channel.
 # 'status_updates' is not in the list, but is added back in the data (see `_market_info()`)
 # It is worthwhile to notice that all digit data is positive. Sometimes, Coingecko sends also null or None value,
 # in which case they are then converted to -1 value, for compatibility reason with Redis stream.
-MARKET_INFO_FILTER_S = {'name', 'asset_platform_id', 'contract_address'}
-MARKET_INFO_FILTER_D = {'sentiment_votes_up_percentage', 'sentiment_votes_down_percentage', 'market_cap_rank', 'coingecko_rank',
-                        'coingecko_score', 'developer_score', 'community_score', 'liquidity_score', 'public_interest_score'}
-MARKET_DATA_VS_CURRENCY = {'current_price', 'market_cap', 'fully_diluted_valuation', 'total_volume', 'high_24h', 'low_24h'}
-OTHER_MARKET_DATA_FILTER = {'total_supply', 'max_supply', 'circulating_supply'}
-ALL_MARKET_DATA = set(list(MARKET_DATA_VS_CURRENCY) + list(OTHER_MARKET_DATA_FILTER))
+ROOT_KEYS = {
+    'sentiment_votes_up_percentage': 'up',
+    'sentiment_votes_down_percentage': 'down',
+    'market_cap_rank': 'capRank',
+    'coingecko_rank': 'rank',
+    'coingecko_score': 'score',
+    'developer_score': 'developer',
+    'community_score': 'community',
+    'liquidity_score': 'liquidity',
+    'public_interest_score': 'interest',
+}
+COMMUNITY_KEYS = {
+    'reddit_average_posts_48h': 'redditPosts',
+    'reddit_average_comments_48h': 'redditComments',
+    'reddit_accounts_active_48h': 'redditAccounts',
+    'telegram_channel_user_count': 'telegramUsers',
+}
+INTEREST_KEYS = {
+    'alexa_rank': 'alexa',
+    'bing_matches': 'bing',
+}
+MARKET_KEYS = {
+    'price_change_24h': 'chgA',
+    'price_change_percentage_24h': 'chgP',
+    'market_cap_change_24h': 'mktCapChgA',
+    'market_cap_change_percentage_24h': 'mktCapChgP',
+    'total_supply': 'totSply',
+    'max_supply': 'maxSply',
+    'circulating_supply': 'circSply',
+}
+CCY_KEYS = {
+    'current_price': 'px',
+    'market_cap': 'mktCap',
+    'fully_diluted_valuation': 'fdv',
+    'total_volume': 'vol',
+    'high_24h': 'high',  # Daily high
+    'low_24h': 'low',    # Daily low
+}
+
+API_URL = 'https://api.coingecko.com/api/v3/coins'
+
+QUERY_PARAMS = 'localization=false'
+QUERY_PARAMS += '&tickers=false'
+QUERY_PARAMS += '&market_data=true'
+QUERY_PARAMS += '&community_data=true'
+QUERY_PARAMS += '&developer_data=false'
+QUERY_PARAMS += '&sparkline=false'
 
 
 class Coingecko(Feed):
-
     id = COINGECKO
+
     # Rate Limit: 100 requests/minute -> sleep 0.6s after previous request.
     # From support (mail exchange):
     # "May I suggest (as provided by the engineers) that you try to make approximately 50 requests per minute instead?
     # We are currently experiencing very heavy loads from certain irresponsible individuals and have temporarily stepped up security measures."
     # From testing, safer to use 3x this limit.
-    sleep_time = 1.8
+    SLEEP_TIME = 1.8
 
-    def __init__(self, symbols=None, subscription=None, **kwargs):
-        self.currencies = defaultdict(list)
+    def __init__(self, **kwargs):
+        super().__init__({}, **kwargs)
+        self.last_updated = {}
+        self.address = self._address()
 
-        if symbols:
-            for symbol in symbols:
-                base, quote = symbol.split("-")
-                self.currencies[base].append(quote.lower())
-            symbols = list(self.currencies.keys())
+    def _address(self):
+        address: Dict[str, str] = {}
+        for chan in set(self.channels or self.subscription):
+            if chan != MARKET_INFO:
+                continue
+            for symbol_id in set(self.symbols or self.subscription[chan]):
+                quote = symbol_exchange_to_std(symbol_id)
+                LOG.debug('%s: Prepare quote=%s symbol_id=%s', self.id, quote, symbol_id)
+                address[quote] = f'{API_URL}/{symbol_id}?{QUERY_PARAMS}'
+        return address
 
-        if subscription and MARKET_INFO in subscription:
-            for symbol in subscription[MARKET_INFO]:
-                base, quote = symbol.split("-")
-                self.currencies[base].append(quote.lower())
-            subscription[MARKET_INFO] = list(self.currencies.keys())
+    async def subscribe(self, conn: AsyncConnection):
+        assert isinstance(conn, HTTPAsyncConn)
+        conn.sleep += 0.5  # increase sleep time when we start a new HTTP polling session to limit the bit rate
 
-        super().__init__('https://api.coingecko.com/api/v3/', symbols=symbols, subscription=subscription, **kwargs)
-        self.__reset()
+    async def handle(self, data: bytes, timestamp: float, conn: AsyncConnection):
+        assert isinstance(conn, HTTPAsyncConn)
 
-    def __reset(self):
-        self.last_market_info_update = defaultdict(float)
+        try:
+            msg = json.loads(data, parse_float=Decimal)
+        except Exception as why:  # json.JSONDecodeError:
+            i = data.find(bytes('<div'))
+            if i > 0:
+                data = data[i:]
+            conn.sleep += 1
+            LOG.warning('%s: %r rate limit possibly exceeded => increase sleep +1 -> %s sec. Response: %s', why, conn.id, conn.sleep, data)
+            return
 
-    async def subscribe(self, connection: AsyncConnection):
-        pass
+        updated = await self._market_info(conn.ctx, msg, timestamp)
 
-    def connect(self) -> List[Tuple[AsyncConnection, Callable[[None], None], Callable[[str, float], None]]]:
-        addrs = []
-        for chan in self.channels if self.channels else self.subscription:
-            for pair in self.symbols if not self.subscription else self.subscription[chan]:
-                if chan == MARKET_INFO:
-                    addrs.append(f"{self.address}coins/{pair}?localization=false&tickers=false&market_data=true&community_data=true&developer_data=false&sparkline=false")
-        return [(AsyncConnection(addrs, self.id, delay=self.sleep_time * 2, sleep=self.sleep_time), self.subscribe, self.message_handler)]
+        # Adaptive sleep time
+        if updated:
+            conn.sleep = (9 * conn.sleep + 1) / 10  # Reduce (always greater than 1 second)
+        else:
+            conn.sleep += 0.01  # Increase slowly
 
-    async def message_handler(self, msg: str, conn, timestamp: float):
+    async def _market_info(self, ctx: dict, msg: dict, timestamp: float) -> bool:
+        """Data from /coins/{id}.
 
-        msg = json.loads(msg, parse_float=Decimal)
-        await self._market_info(msg, timestamp)
+        Doc: https://www.coingecko.com/api/documentations/v3#/operations/coins/get_coins__id_
 
-    async def _market_info(self, msg: dict, receipt_timestamp: float):
+        {'id': '01coin',
+         'symbol': 'zoc',
+         'name': '01coin',
+         'asset_platform_id': None,
+         'block_time_in_minutes': 0,
+         'hashing_algorithm': 'NeoScrypt',
+         'categories': ['Masternodes'],
+         'public_notice': None,
+         'additional_notices': [],
+         'description': {'en': ''},
+         'links': {'homepage': ['https://01coin.io/', '', ''],
+                   'blockchain_site': ['https://explorer.01coin.io/', 'https://zoc.ccore.online/', 'https://openchains.info/coin/01coin', '', ''],
+                   'official_forum_url': ['', '', ''],
+                   'chat_url': ['https://discordapp.com/invite/wq5xD6M', '', ''],
+                   'announcement_url': ['', ''],
+                   'twitter_screen_name': '01CoinTeam',
+                   'facebook_username': '01CoinTeam',
+                   'bitcointalk_thread_identifier': 3457534,
+                   'telegram_channel_identifier': 'ZOCCoinOfficial',
+                   'subreddit_url': 'https://www.reddit.com/r/01coin/',
+                   'repos_url': {'github': ['https://github.com/zocteam/zeroonecoin'], 'bitbucket': []}},
+         'image': {'thumb': 'https://assets.coingecko.com/coins/images/5720/thumb/F1nTlw9I_400x400.jpg?1547041588',
+                   'small': 'https://assets.coingecko.com/coins/images/5720/small/F1nTlw9I_400x400.jpg?1547041588',
+                   'large': 'https://assets.coingecko.com/coins/images/5720/large/F1nTlw9I_400x400.jpg?1547041588'},
+         'country_origin': '',
+         'genesis_date': None,
+         'sentiment_votes_up_percentage': Decimal('100.0'),
+         'sentiment_votes_down_percentage': Decimal('0.0'),
+         'market_cap_rank': 1775,
+         'coingecko_rank': 746,
+         'coingecko_score': Decimal('22.832'),
+         'developer_score': Decimal('45.036'),
+         'community_score': Decimal('14.885'),
+         'liquidity_score': Decimal('1.0'),
+         'public_interest_score': Decimal('0.0'),
+         'market_data': { 'current_price': {'aed': Decimal('0.01842256'), 'ars': Decimal('0.414901'), 'aud': Decimal('0.
+                          'roi': {'times': Decimal('-0.9101505090160869'), 'currency': 'usd', 'percentage': Decimal('-91.01505090160869')},
+                          'ath': {'aed': Decimal('0.12555'), 'ars': Decimal('1.27'), 'aud': Decimal('0.04813117'), 'bch'
+                          'ath_change_percentage': {'aed': Decimal('-85.37635'), 'ars': Decimal('-67.55522'), 'aud': Dec
+                          'ath_date': {'aed': datetime.datetime(2018, 10, 10, 17, 27, 38, 34, tzinfo=datetime.timezone.u
+                          'atl': {'aed': Decimal('0.00259466'), 'ars': Decimal('0.04442241'), 'aud': Decimal('0.00113298
+                          'atl_change_percentage': {'aed': Decimal('607.60663'), 'ars': Decimal('830.83003'), 'aud': Dec
+                          'atl_date': {'aed': datetime.datetime(2020, 3, 16, 10, 22, 30, 944, tzinfo=datetime.timezone.u
+                          'market_cap': {'aed': 195467, 'ars': 4402240, 'aud': 69833, 'bch': Decimal('172.456'), 'bdt':
+                          'market_cap_rank': 1775,
+                          'fully_diluted_valuation': {},
+                          'total_volume': {'aed': 49262, 'ars': 1109437, 'aud': Decimal('17596.23'), 'bch': Decimal('43.
+                          'high_24h': {'aed': Decimal('0.02026924'), 'ars': Decimal('0.456461'), 'aud': Decimal('0.00724
+                          'low_24h': {'aed': Decimal('0.0160679'), 'ars': Decimal('0.361171'), 'aud': Decimal('0.0057753
+                          'price_change_24h': Decimal('0.00064114'),
+                          'price_change_percentage_24h': Decimal('14.65599'),
+                          'price_change_percentage_7d': Decimal('24.97599'),
+                          'price_change_percentage_14d': Decimal('15.52352'),
+                          'price_change_percentage_30d': Decimal('-21.79181'),
+                          'price_change_percentage_60d': Decimal('31.1943'),
+                          'price_change_percentage_200d': Decimal('182.00787'),
+                          'price_change_percentage_1y': Decimal('153.21198'),
+                          'market_cap_change_24h': Decimal('6585.89'),
+                          'market_cap_change_percentage_24h': Decimal('14.12307'),
+                          'price_change_24h_in_currency': {'aed': Decimal('0.00235466'), 'ars': Decimal('0.053445'), 'au
+                          'price_change_percentage_1h_in_currency': {'aed': Decimal('-6.81616'), 'ars': Decimal('-6.8171
+                          'price_change_percentage_24h_in_currency': {'aed': Decimal('14.65443'), 'ars': Decimal('14.786
+                          'price_change_percentage_7d_in_currency': {'aed': Decimal('24.96748'), 'ars': Decimal('26.1088
+                          'price_change_percentage_14d_in_currency': {'aed': Decimal('15.52194'), 'ars': Decimal('17.271
+                          'price_change_percentage_30d_in_currency': {'aed': Decimal('-21.79287'), 'ars': Decimal('-19.0
+                          'price_change_percentage_60d_in_currency': {'aed': Decimal('31.19252'), 'ars': Decimal('40.039
+                          'price_change_percentage_200d_in_currency': {'aed': Decimal('182.00787'), 'ars': Decimal('240.
+                          'price_change_percentage_1y_in_currency': {'aed': Decimal('153.20329'), 'ars': Decimal('250.60
+                          'market_cap_change_24h_in_currency': {'aed': 24187, 'ars': 548535, 'aud': Decimal('8204.18'),
+                          'market_cap_change_percentage_24h_in_currency': {'aed': Decimal('14.12152'), 'ars': Decimal('1
+                          'total_supply': Decimal('65658824.0'),
+                          'max_supply': None,
+                          'circulating_supply': Decimal('10646360.834599'),
+                          'last_updated': datetime.datetime(2020, 12, 17, 20, 24, 16, 604, tzinfo=datetime.timezone.utc)},
+         'community_data': {'facebook_likes': None,
+                            'twitter_followers': 334,
+                            'reddit_average_posts_48h': Decimal('0.0'),
+                            'reddit_average_comments_48h': Decimal('0.0'),
+                            'reddit_subscribers': 15,
+                            'reddit_accounts_active_48h': 7,
+                            'telegram_channel_user_count': 151},
+         'public_interest_stats': {'alexa_rank': 4678489, 'bing_matches': None},
+         'status_updates': [],
+         'last_updated': datetime.datetime(2020, 12, 17, 20, 24, 16, 604, tzinfo=datetime.timezone.utc)}
         """
-        Data from /coins/{id}.
-        """
-        symbol = msg['symbol'].upper()
-        timestamp = timestamp_normalize(self.id, msg['last_updated'])
+        assert 'opt' in ctx
+        assert isinstance(ctx['opt'], str)
+        quote = ctx['opt']
 
-        if self.last_market_info_update[symbol] < timestamp:
-            self.last_market_info_update[symbol] = timestamp
-            # `None` and null data is systematically replaced with '-1' for digits and '' for string (empty string), for compatibility with Redis stream.
-            market_data = {}
-            for key, value in msg['market_data'].items():
-                if key not in ALL_MARKET_DATA:
+        try:
+            last = msg['last_updated']
+            if ('last' in ctx) and (last == ctx['last']):
+                return False  # Skip because already processed => Increase sleep time
+            ctx['last'] = last
+            if last:
+                market_ts = timestamp_normalize(self.id, last)
+            else:
+                market_ts = 0
+                LOG.info('%s: no last_updated for quote=%r - to be removed from HTTP polling', self.id, quote)  # TODO
+        except Exception as why:
+            LOG.warning('%s: %r - skip unexpected msg: %s', self.id, why, msg)
+            return False
+
+        mkt_data = msg.get('market_data', {})
+        kwargs = {**{k2: mkt_data[k1] for k1, k2 in MARKET_KEYS.items() if k1 in mkt_data},
+                  **{k2: msg[k1] for k1, k2 in ROOT_KEYS.items() if k1 in msg},
+                  **{COMMUNITY_KEYS.get(k, k): v for k, v in msg.get('community_data', {}).items() if v},
+                  **{INTEREST_KEYS.get(k, k): v for k, v in msg.get('public_interest_stats', {}).items() if v}}
+        if 'roi' in msg:
+            roi = msg.get('roi', {})
+            if 'percentage' in roi:
+                kwargs['roi'] = roi['percentage']
+
+        # if kwargs:
+        #     await self.callback(SCORE, feed=self.id,
+        #                         pair=quote,
+        #                         **kwargs,
+        #                         timestamp=market_ts,
+        #                         receipt_timestamp=timestamp)
+        bases = set()
+        for k in CCY_KEYS:
+            for b in mkt_data.get(k, {}):
+                bases.add(b)
+
+        # CoinGecko may send the base ccy in double: lower and upper case
+        low_up = dict()
+        for b in bases:
+            low_up[b.lower()] = b.upper()
+
+        for b, B in low_up.items():
+            kwargs = {}
+            for k1, k2 in CCY_KEYS.items():
+                data = mkt_data.get(k1)
+                if not data:
                     continue
-                if key in MARKET_DATA_VS_CURRENCY:
-                    for cur, price in value.items():
-                        if cur not in self.currencies[symbol]:
-                            continue
-                        market_data[f"{key}_{cur}"] = price
+                if b in data:
+                    v = data[b]
+                elif B in data:
+                    v = data[B]
                 else:
-                    market_data[key] = value
-            # 'last_updated' here is assumed to be specific for market data, so it is kept as well.
-            market_data['last_updated'] = timestamp_normalize(self.id, msg['market_data']['last_updated'])
-            community_data = {k: (v if v else -1) for k, v in msg['community_data'].items()}
-            public_interest_stats = {k: (v if v else -1) for k, v in msg['public_interest_stats'].items()}
-            # Only retain selected data, and remove as well `market_data`, `community_data` and `public_interest_stats`.
-            # These latter are added back in `data` to have it in the shape of a flatten dict.
-            data_s = {k: (v if v else '') for k, v in msg.items() if k in MARKET_INFO_FILTER_S}
-            data_d = {k: (v if v else -1) for k, v in msg.items() if k in MARKET_INFO_FILTER_D}
-            status = str(msg['status_updates'])
-            data = {**data_s, **data_d, **market_data, **community_data, **public_interest_stats}
-            # `list` data type is converted to string for compatibility with Redis stream.
-            data['status_updates'] = status
-            await self.callback(MARKET_INFO, feed=self.id,
-                                symbol=symbol,
-                                timestamp=timestamp,
-                                **data)
+                    continue
+                if v:
+                    kwargs[k2] = v
+            if kwargs:
+                await self.callback(MARKET_INFO, feed=self.id,
+                                    pair=f'{quote}{SYMBOL_SEP}{B}',
+                                    **kwargs,
+                                    timestamp=market_ts,
+                                    receipt_timestamp=timestamp)

--- a/cryptofeed/provider/whale_alert.py
+++ b/cryptofeed/provider/whale_alert.py
@@ -5,17 +5,17 @@ associated with this software.
 '''
 
 import asyncio
-import aiohttp
 import logging
-from time import time
-import json
-from json import JSONDecodeError
+import time
+from decimal import Decimal
+from typing import Dict, Iterable, Union
 
-from cryptofeed.defines import WHALE_ALERT, TRANSACTIONS
+from yapic import json
+
+from cryptofeed.connection import AsyncConnection
+from cryptofeed.defines import TRANSACTIONS, WHALE_ALERT
 from cryptofeed.feed import Feed
 from cryptofeed.standards import symbol_exchange_to_std
-from cryptofeed.exceptions import RestResponseError
-
 
 LOG = logging.getLogger('feedhandler')
 TO_FROM_DATA = ('address', 'owner_type', 'owner')
@@ -24,28 +24,30 @@ TO_FROM_DATA = ('address', 'owner_type', 'owner')
 class WhaleAlert(Feed):
 
     id = WHALE_ALERT
+    SLEEP_TIME = 6  # Free plan is one request every 6 seconds.
 
-    def __init__(self, **kwargs):
+    def __init__(self, sleep_time: float = 6, trans_min_value: float = 500000, max_history: Union[int, str] = 3600, **kwargs):
         """
         Parameters:
-            kwargs['sleep_time'] (float - optional):
+            sleep_time (float - optional):
                 Number of seconds to wait between 2 API requests. By default, is 6, as per free plan.
 
-            kwargs['trans_min_value'] (float - optional):
+            trans_min_value (float - optional):
                 Minimal transaction value to filter returned transactions from API. By default, is 500k$, as per free plan.
 
-            kwargs['key_id'] (string - optional):
-                API key to be used to connect. If not provided, that stored in 'feed_keys.yaml' will be used.
-
-            kwargs['max_history'] (string - optional):
+            max_history (string - optional):
                 Maximal allowed history, depending on your pricing plan. Format is of type '1H' (for 1 hour) or '1D' (for 1 day).
                 Maximal history can only be specified with hours or days. By default, is 1 hour, as per free plan.
 
+            kwargs['key_id'] (string - optional):
+                API key to be used to connect. If not provided, that stored in 'feed_keys.yaml' will be used.
         """
-        self.sleep_time = kwargs.pop('sleep_time') if 'sleep_time' in kwargs else 6                      # Free plan is one request every 6 seconds.
-        self.trans_min_value = kwargs.pop('trans_min_value') if 'trans_min_value' in kwargs else 500000  # Free plan is 500k$ transaction minimum value.
-        max_history = kwargs.pop('max_history') if 'max_history' in kwargs else 3600                     # Free plan is 1 hour transaction history.
         super().__init__('https://api.whale-alert.io/v1/', **kwargs)
+
+        WhaleAlert.SLEEP_TIME = sleep_time
+
+        self.trans_min_value = trans_min_value
+
         # Shamlessly inspired from bmoscon/cryptostore/aggregator/aggregator.py
         if isinstance(max_history, str):
             multiplier = 1
@@ -59,118 +61,182 @@ class WhaleAlert(Feed):
                     max_history = 86400 * multiplier
             else:
                 LOG.error("Format of 'max_history' {!s} is not understood.".format(max_history))
-            self.max_history = max_history
+            self.max_history: int = max_history
         else:
-            self.max_history = max_history
+            self.max_history: int = max_history
 
-        # `self.last_transaction_update` is voluntarily not reset in `__reset()` to avoid storing twice the same data after a reset.
+        self.key_id = kwargs.get('key_id')
+        if not self.key_id:
+            LOG.critical('WHALE_ALERT: No API key provided. Impossible to connect.')
+
+        self.skip_coins = set()
+
+        for chan in set(self.channels or self.subscription):
+            if chan == TRANSACTIONS:
+                break
+        else:
+            LOG.critical(f'%s: support the channel {TRANSACTIONS!r} only, but it is missing, cannot retrieve data', self.id)
+            raise ValueError(f'WHALE_ALERT: Please set the missing channel {TRANSACTIONS!r}')
+
+        # `self.last_trans_up` is voluntarily not reset in `__reset()` to avoid storing twice the same data after a reset.
         # dict({coin: (latest_cleared_timestamp, cursor, query_start_timestamp),...})
         # Whale Alert uses second-precise timestamps (not millisecond) which is why making chained calls is justified.
         # Making chained calls prevent having holes in the list of transactions.
         # To make a chained call, it is necessary to use same timestamp as that of the 1st call (`query_start_timestamp`),
         # and `cursor` given in previous response.
-        self.last_transaction_update = dict()
+        self.last_trans_up = {}
 
-    async def subscribe(self):
-        self.__reset()
-        return
+    async def subscribe(self, conn: AsyncConnection):
+        coins = set(self.symbols or self.subscription[TRANSACTIONS])
+        if len(coins) <= len(self.skip_coins):
+            LOG.warning('%s: reset skip_coins because the configured %s coins are less or equal to the %s skip_coins: %s',
+                        self.id, len(coins), len(self.skip_coins), self.skip_coins)
+            self.skip_coins = {}
 
-    def __reset(self):
-        pass
+    def addr_compute(self) -> Iterable[dict]:
+        """Provide dynamic URLs to retrieve TRANSACTIONS for each coin."""
+        coins = set(self.symbols or self.subscription[TRANSACTIONS])
+        while True:
+            LOG.info('WA: %r coins: %r', len(coins), coins)
+            LOG.info('WA: %r skip: %r', len(self.skip_coins), self.skip_coins)
+            coins.difference(self.skip_coins)
+            if not coins:
+                txt = f'{self.id}: no more coins. skip all: {self.skip_coins}'
+                LOG.error(txt)
+                raise txt
 
-    async def message_handler(self):
-        async def handle(session, coin, chan):
-            if chan == TRANSACTIONS:
-                await self._transactions(session, coin)
-            await asyncio.sleep(self.sleep_time)
+            for coin in coins:
+                LOG.info('WA: coin = %r', coin)
 
-        async with aiohttp.ClientSession() as session:
-            if self.subscription:
-                for chan in self.subscription:
-                    for coin in self.subscription[chan]:
-                        await handle(session, coin, chan)
-            else:
-                for chan in self.channels:
-                    for coin in self.symbols:
-                        await handle(session, coin, chan)
-        return
+                # Using 2s margin for the algo to issue the query and still being within `self.max_history`.
+                max_history_ts = int(time.time()) - self.max_history + 2
 
-    async def _transactions(self, session, coin):
-        """
-        Data from /transactions?api_key=_&min_value=_&start=_&currency=_
-        Query strategy seeks to prevent any missing data between 2 queries, even in case of simultaneous transactions,
-        by use of 'cursor' when appropriate ('chained calls').
-        """
-
-        receipt_timestamp = int(time())
-        last_trans_up = self.last_transaction_update
-        # Using 2s margin for the algo to issue the query and still being within `self.max_history`.
-        max_history_ts = receipt_timestamp - self.max_history + 2
-
-        # Initialize `cursor` and `query_start_ts`.
-        try:
-            latest_cleared_ts, cursor, query_start_ts = last_trans_up[coin]
-            if not cursor:
-                if latest_cleared_ts < max_history_ts:
-                    LOG.warning("{!s} - Possible hole in transaction data for coin {!s} due to impossibility to query far enough, back in time.".format(self.id, coin))
+                # Initialize `cursor` and `query_start_ts`.
+                try:
+                    latest_cleared_ts, cursor, query_start_ts = self.last_trans_up[coin]
+                    if not cursor:
+                        if latest_cleared_ts < max_history_ts:
+                            LOG.warning('%s %s: Possible hole in transaction data due to impossibility to query far enough, back in time.', self.id, coin)
+                            query_start_ts = max_history_ts
+                        else:
+                            query_start_ts = latest_cleared_ts
+                except Exception:  # this always occurs the first time
+                    cursor = ''
                     query_start_ts = max_history_ts
-                else:
-                    query_start_ts = latest_cleared_ts
-        except Exception:
-            cursor = ''
-            query_start_ts = max_history_ts
-            latest_cleared_ts = max_history_ts
+                    latest_cleared_ts = max_history_ts
 
-        query = f"{self.address}transactions?api_key={self.key_id}&min_value={self.trans_min_value}&start={query_start_ts}&currency={coin}&cursor={cursor}" \
-                if cursor else f"{self.address}transactions?api_key={self.key_id}&min_value={self.trans_min_value}&start={query_start_ts}&currency={coin}"
+                query = f"{self.address}transactions?api_key={self.key_id}&min_value={self.trans_min_value}&start={query_start_ts}&currency={coin}&cursor={cursor}" \
+                    if cursor else f"{self.address}transactions?api_key={self.key_id}&min_value={self.trans_min_value}&start={query_start_ts}&currency={coin}"
 
-        async with session.get(query) as response:
-            data = await response.read()
-            try:
-                data = json.loads(data)
-            except JSONDecodeError as jde:
-                raise Exception('Returned error: {!s}\nReturned response content from HTTP request: {!s}'.format(jde, data))
+                if __debug__:
+                    LOG.debug('%s %s: GET URL: %s', self.id, coin, query)
 
-            if data['result'] == 'error':
-                raise RestResponseError('Error message in response: {!s}'.format(data['message']))
+                yield {'addr': query, 'coin': coin, 'latest_cleared_ts': latest_cleared_ts, 'query_start_ts': query_start_ts}
 
-            # Keeping previous `latest_cleared_ts` in `max_trans_ts` in case there is no new transactions.
-            max_trans_ts = latest_cleared_ts
-            latest_cleared_ts = receipt_timestamp - 1200  # Leaving 20mn margin for Whale Alert to insert a new entry in their database.
-            if 'transactions' in data:
-                for transaction in data['transactions']:
-                    # Flattening the nested dicts.
-                    # 'Owner' is not provided if not known. Forcing it as '' into the dict so that DataFrame remains consistent in Cryptostore.
-                    to = transaction.pop('to')
-                    to = {('to_' + k): (to[k] if k in to else '') for k in TO_FROM_DATA}
-                    fro = transaction.pop('from')
-                    fro = {('from_' + k): (fro[k] if k in fro else '') for k in TO_FROM_DATA}
-                    del transaction['symbol']  # removing duplicate data with `pair` that is added
-                    await self.callback(TRANSACTIONS,
-                                        feed=self.id,
-                                        symbol=symbol_exchange_to_std(coin),
-                                        # `timestamp` is already with the correct format in `transaction` dict (in unit second).
-                                        **transaction, **to, **fro)
-                    max_trans_ts = transaction['timestamp'] if transaction['timestamp'] > max_trans_ts else max_trans_ts
+    async def handle(self, data, timestamp, conn: AsyncConnection):
+        """Data from /transactions?api_key=_&min_value=_&start=_&currency=_ Query strategy seeks to prevent any missing data between 2 queries, even in case of simultaneous transactions, by use of 'cursor' when appropriate ('chained calls').
 
-            # Comments regarding `latest_cleared_ts`:
-            # From doc. : "Some transactions might be reported with a small delay."
-            # From mail exchange with support: "That line is there as a disclaimer in case anything goes wrong.
-            # In general (99.99% of the time) transactions are added instantly."
-            # From experience, 40s delay is not uncommon.
-            # Hence the 20mn substracted from `receipt_time` before the `for` loop.
-            # Conditions to make a chained call next time (to make sure not to miss any transactions):
-            #  - latest transaction is no older than 20mn,
-            #  - data['count'] is 100.
-            # Otherwise `latest_cleared_ts` will be used for next call (not a chained call).
-            # Comments regarding `data['count']`:
-            # Number of results per query is limited to 100.
-            # If we have 100 results in the query, we are not certain the last result is the last transaction up to the receipt time or not.
-            # If it is lower than 100, we know there is no more transactions till the receipt time.
-            # This `latest_cleared_ts` will not be used as start ts for the next query (use of chained call).
-            if max_trans_ts > latest_cleared_ts or data['count'] == 100:
-                last_trans_up[coin] = (max_trans_ts, data['cursor'], query_start_ts)
-            else:
-                last_trans_up[coin] = (latest_cleared_ts, '', '')
+        https://docs.whale-alert.io/#transactions
 
-        return
+        No transaction:
+        {'result': 'success', 'cursor': '0-0-0', 'count': 0}
+
+        Two transactions:
+        {'result': 'success',
+         'cursor': '46b85a05-46b85a05-5fdb7e13',
+         'count': 22, 'transactions': [
+            {'blockchain': 'tron',
+             'symbol': 'usdt',
+             'id': '1186367644',
+             'transaction_type': 'transfer',
+             'hash': '4564fdc14b83c5dbf304995f5870f7113960c5640d3abb8872f3ed5adab218ee',
+             'from': {'address': 'TQdUk2rSNdKRsfT6HYaVQ4qGV7nhJckvBK', 'owner_type': 'unknown'},
+             'to': {'address': 'TXFBqBbqJommqZf7BV8NNYzePh97UmJodJ', 'owner': 'bitfinex', 'owner_type': 'exchange'},
+             'timestamp': 1608217245,
+             'amount': 500000,
+             'amount_usd': Decimal('502237.66'),
+             'transaction_count': 1},
+            {'blockchain': 'ethereum',
+             'symbol': 'usdt',
+             'id': '1186403033',
+             'transaction_type': 'transfer',
+             'hash': 'a0655ba695e25fa4d72105b138dc390ee59154c249945d66592a0bc0775f4ac4',
+             'from': {'address': 'aca7287116cfeba6acc652f85add29ebfb48b326', 'owner_type': 'unknown'},
+             'to': {'address': 'c398248f635d58d41669c925511a5bc4923f8797', 'owner': 'binance', 'owner_type': 'exchange'},
+             'timestamp': 1608217451,
+             'amount': 700000,
+             'amount_usd': Decimal('695020.4'),
+             'transaction_count': 1},
+        ]}
+        """
+        LOG.debug('WA: handle ctx = %r', conn.ctx)
+
+        msg = json.loads(data, parse_float=Decimal)
+
+        coin = conn.ctx['coin']
+
+        if msg['result'] == 'error':
+            self.skip_coins.add(coin)
+            LOG.warning('%s %s: Skip %s coins. Response: %r GET: %s', self.id, coin, len(self.skip_coins), msg.get('message'), conn.ctx['addr'])
+            if 'currency parameter' not in msg.get('message', ''):  # "invalid value for currency parameter" (bczero is listed but cannot be retrieved)
+                await asyncio.sleep(10 * WhaleAlert.SLEEP_TIME)
+            return
+
+        # Keeping previous `latest_cleared_ts` in `max_trans_ts` in case there is no new transactions.
+        max_trans_ts = conn.ctx['latest_cleared_ts']
+        latest_cleared_ts = int(timestamp) - 1200  # Leaving 20mn margin for Whale Alert to insert a new entry in their database.
+
+        pair = symbol_exchange_to_std(coin)
+
+        if 'transactions' not in msg:
+            LOG.debug("%s %s: No 'transactions' in response: %s", self.id, pair, msg)
+        else:
+            for transaction in msg['transactions']:
+
+                await self.callback(TRANSACTIONS,
+                                    feed=self.id,
+                                    pair=pair,
+                                    blk=transaction.get('blockchain'),
+                                    kind=transaction.get('transaction_type'),
+                                    qty=transaction.get('amount'),
+                                    usd=transaction.get('amount_usd'),
+                                    fr=self.owner(transaction.get('from', {})),
+                                    to=self.owner(transaction.get('to', {})),
+                                    timestamp=transaction['timestamp'],
+                                    receipt_timestamp=timestamp)
+
+                max_trans_ts = max(max_trans_ts, transaction['timestamp'])
+
+        # Comments regarding `latest_cleared_ts`:
+        # From doc. : "Some transactions might be reported with a small delay."
+        # From mail exchange with support: "That line is there as a disclaimer in case anything goes wrong.
+        # In general (99.99% of the time) transactions are added instantly."
+        # From experience, 40s delay is not uncommon.
+        # Hence the 20mn substracted from `time.time()` before the `for` loop.
+        # Conditions to make a chained call next time (to make sure not to miss any transactions):
+        #  - latest transaction is no older than 20mn,
+        #  - data['count'] is 100.
+        # Otherwise `latest_cleared_ts` will be used for next call (not a chained call).
+        # Comments regarding `data['count']`:
+        # Number of results per query is limited to 100.
+        # If we have 100 results in the query, we are not certain the last result is the last transaction up to the receipt time or not.
+        # If it is lower than 100, we know there is no more transactions till the receipt time.
+        # This `latest_cleared_ts` will not be used as start ts for the next query (use of chained call).
+        if (max_trans_ts > latest_cleared_ts) or (msg.get('count', 0) == 100):
+            query_start_ts = conn.ctx['query_start_ts']
+            self.last_trans_up[coin] = (max_trans_ts, msg['cursor'], query_start_ts)
+        else:
+            self.last_trans_up[coin] = (latest_cleared_ts, '', '')
+
+    @staticmethod
+    def owner(from_to: Dict[str, str]):
+        owner = from_to.get('owner')
+        if owner:
+            kind = from_to.get('owner_type')
+            if kind == 'exchange':
+                return f'{owner}.exch'
+            if kind:
+                return f'{owner}.{kind}'
+            return f'{owner}'
+        else:
+            return from_to.get('address')

--- a/cryptofeed/runner.py
+++ b/cryptofeed/runner.py
@@ -33,7 +33,7 @@ class Runner:
         return self.conn.id
 
     async def shutdown(self):
-        LOG.info('%s: shutdown runner max_retries: %r -> 0 (zero flags shutdown)', self.id, self.max_retries)
+        LOG.info('%s: shutdown runner max_retries: %r -> 0 (zero value means "shutdown")', self.id, self.max_retries)
         self.max_retries = 0  # Stop infinite loop
         await self.conn.close()
 

--- a/cryptofeed/runner.py
+++ b/cryptofeed/runner.py
@@ -1,0 +1,156 @@
+"""Copyright (C) 2020-2021  Cryptofeed contributors.
+
+Please see the LICENSE file for the terms and conditions
+associated with this software.
+"""
+import asyncio
+import logging
+import zlib
+from json import JSONDecodeError
+from typing import Callable, Optional
+
+import yapic.json._json
+
+from cryptofeed.connection import AsyncConnection
+from cryptofeed.defines import HUOBI, HUOBI_DM, OKCOIN, OKEX
+from cryptofeed.exceptions import ExhaustedRetries
+from cryptofeed.feed import Feed
+
+
+LOG = logging.getLogger('feedhandler')
+
+
+class Runner:
+
+    def __init__(self, feed: Feed, conn: AsyncConnection, timeout: float, max_retries: int):
+        self.feed: Feed = feed
+        self.conn: AsyncConnection = conn
+        self.timeout: float = timeout  # in seconds
+        self.max_retries: int = max_retries
+
+    @property
+    def id(self):
+        return self.conn.id
+
+    async def shutdown(self):
+        LOG.info('%s: shutdown runner max_retries: %r -> 0 (zero flags shutdown)', self.id, self.max_retries)
+        self.max_retries = 0  # Stop infinite loop
+        await self.conn.close()
+
+    async def run(self, do_handle: bool, capture_cb: Callable, log_msg: bool):
+        """Connect to exchange, subscribe and handle responses."""
+        LOG.info('%s: Start infinite loop handle=%s capture=%s log_msg=%s max_retries=%s',
+                 self.id, do_handle, not not capture_cb, log_msg, self.max_retries)
+        # To shutdown the loop: set max_retries=0 and close the socket
+        retries = delay = 1
+        while self.max_retries:
+            try:
+                async with self.conn.connect() as conn:
+                    keep = await self.feed.subscribe(conn)
+                    if conn.sent == 0 and not keep:
+                        LOG.warning('%s: nothing subscribed - close the connection', self.id)
+                        return
+                    if conn.sent > 0:
+                        LOG.info('%s: sent %s messages during subscription', self.id, conn.sent)
+
+                    task = asyncio.create_task(self._watch())
+                    task.set_name(f'watch_{self.id}')
+                    # TODO: Replace _watch() by argument timeout: ClientSession.get(timeout=120) & similar for WS
+                    #  /!\  Multiple _watch() of the same Runner may be running in parallel on successive disconnections
+
+                    await self._handle(do_handle, capture_cb, log_msg)
+
+                    # connection was successful, reset retry count and delay
+                    retries = delay = 1
+
+            except Exception as e:
+                if 0 < self.max_retries < retries:
+                    LOG.critical('%s: failed to reconnect after %d retries - exiting', self.id, retries)
+                    raise ExhaustedRetries() from e
+
+                if self.max_retries:
+                    LOG.exception('%s: encountered %r, reconnect in %.1f seconds', self.id, e, delay)
+                    await asyncio.sleep(delay)
+                    retries += 1
+                    delay *= 2
+
+                if self.max_retries == 0:
+                    LOG.warning('%s: encountered %r, but max_retries=0 - shutdown AsyncConnection.run()', self.id, e)
+                    return
+
+    async def _handle(self, do_handle: bool, capture_cb: Optional[Callable], log_msg: bool):
+        data = None
+        try:
+            if capture_cb and do_handle:
+                async for data, timestamp in self.conn.read():
+                    await capture_cb(data, timestamp, self.feed.id)  # TODO replace capture by callbacks
+                    try:
+                        await self.feed.handle(data, timestamp, self.conn)
+                    except JSONDecodeError or yapic.json.JsonDecodeError as why:
+                        LOG.warning('%s: %r - skip invalid JSON: %.500r', self.id, why, self.decompress(data))
+            elif capture_cb:
+                async for data, timestamp in self.conn.read():
+                    await capture_cb(data, timestamp, self.feed.id)
+            else:
+                async for data, timestamp in self.conn.read():
+                    try:
+                        await self.feed.handle(data, timestamp, self.conn)
+                    except JSONDecodeError or yapic.json.JsonDecodeError as why:
+                        LOG.warning('%s: %r - skip invalid JSON: %.500r', self.id, why, self.decompress(data))
+        except Exception as why:
+            LOG.error('%s: encountered %r - end of AsyncConnection._handle()', self.id, why)
+            if data is not None and log_msg:
+                LOG.error('%s: error handling %r', self.id, self.decompress(data))
+            # exception will be logged with traceback when connection handler
+            # retries the connection
+            raise
+
+    def decompress(self, data: bytes) -> bytes:
+        if self.feed.id in (HUOBI, HUOBI_DM):
+            return zlib.decompress(data, 16 + zlib.MAX_WBITS)
+        if self.feed.id in (OKCOIN, OKEX):
+            return zlib.decompress(data, -15)
+        return data
+
+    async def _watch(self):  # TODO: replace _watch() by timeout in ClientSession.get(timeout=120)
+        if self.timeout == 0:
+            LOG.info('%s: timeout=0, disable connection timeout watching', self.id)
+            return
+
+        timeout = last_log_timeout = high = low = self.timeout
+        self.conn.received = -1
+        LOG.info('%s: initial timeout: %d seconds (%.2f minutes)', self.id, self.timeout, self.timeout / 60)
+
+        while self.conn.is_open:
+            if self.conn.received == 0:
+                self.timeout = 30 + 2 * timeout  # Increase for next watch
+                LOG.warning('%s: reset connection, no msg within %d seconds (%.2f minutes) next timeout: %d s (%.2f m)',
+                            self.id, timeout, timeout / 60, self.timeout, self.timeout / 60)
+                try:
+                    await self.conn.close()
+                except Exception as why:
+                    LOG.warning('%s: cannot close because %r', self.id, why)
+                return
+
+            # Compute timeout to be between 20 messages (low frequency) and 1000 messages (high frequency)
+            if self.conn.received > 0:
+                freq = self.conn.received / timeout
+                target = 20 / freq + 20  # +20 seconds = security margin
+                if timeout > target:
+                    timeout = (target + 8 * timeout + high) / 10  # Average in favor of the greatest values
+                    low = min(timeout, low)
+                else:
+                    timeout = (timeout + 9 * target) / 10
+                    high = max(timeout, high)
+                if abs(last_log_timeout / timeout - 1) > 0.2:  # Only log when change is greater than 20%
+                    LOG.info('%s: adaptive timeout: %d -> %d seconds (%.2f msg/sec -> target %d s) min-max: %d-%d',
+                             self.id, last_log_timeout, timeout, freq, target, low, high)
+                    last_log_timeout = timeout
+
+            self.conn.received = 0  # Reset counter just before sleep
+            await asyncio.sleep(timeout)
+
+        freq = self.conn.received / timeout
+        self.timeout = 30 + timeout  # Increase for next watch
+        LOG.info('%s: connection closed - stop watching - %.2f msg/sec timeout: %d -> %d seconds min-max: %d-%d',
+                 self.id, freq, timeout, self.timeout, low, high)

--- a/cryptofeed/symbols.py
+++ b/cryptofeed/symbols.py
@@ -361,8 +361,7 @@ def okcoin_symbols() -> Dict[str, str]:
 
 
 def okex_symbols() -> Dict[str, str]:
-    # We will support soon OKEx options, and enable this following line
-    option_urls = []  # okex_compute_option_urls_from_underlyings()
+    option_urls = okex_compute_option_urls_from_underlyings()
     other_urls = ['https://www.okex.com/api/spot/v3/instruments',
                   'https://www.okex.com/api/swap/v3/instruments/ticker',
                   'https://www.okex.com/api/futures/v3/instruments/ticker']

--- a/cryptofeed/symbols.py
+++ b/cryptofeed/symbols.py
@@ -645,7 +645,7 @@ def coingecko_second_pass(intermediate: Dict[str, List[dict]]) -> Dict[str, List
             final[normalized].append(coins[0])
             continue
         set_normalized = False
-        for i in range(len(coins)):
+        for i, _ in enumerate(coins):
             if normalized == coins[i]['nn']:
                 coin = coins.pop(i)
                 final[normalized].append(coin)
@@ -664,7 +664,7 @@ def coingecko_second_pass(intermediate: Dict[str, List[dict]]) -> Dict[str, List
         if not rest:
             continue
         if not set_normalized:
-            rest.sort(key=lambda coin: len(coin['nn']), reverse=True)  # sort by the length of the normalized name
+            rest.sort(key=lambda c: len(c['nn']), reverse=True)  # sort by the length of the normalized name
             coin = rest.pop(0)
             final[normalized].append(coin)
         for coin in rest:
@@ -686,7 +686,7 @@ def coingecko_third_pass(final: Dict[str, List[dict]]) -> Dict[str, str]:
             symbols[normalized] = coins[0]['id']
             continue
         set_normalized = False
-        for i in range(len(coins)):
+        for i, _ in enumerate(coins):
             if normalized == coins[i]['nn']:
                 coin = coins.pop(i)
                 symbols[normalized] = coin['id']
@@ -705,7 +705,7 @@ def coingecko_third_pass(final: Dict[str, List[dict]]) -> Dict[str, str]:
         if not rest:
             continue
         if not set_normalized:
-            rest.sort(key=lambda coin: len(coin['nn']), reverse=True)  # sort by the length of the normalized name
+            rest.sort(key=lambda c: len(c['nn']), reverse=True)  # sort by the length of the normalized name
             coin = rest.pop(0)
             symbols[normalized] = coin['id']
         for coin in rest:

--- a/cryptofeed/util/split.py
+++ b/cryptofeed/util/split.py
@@ -1,0 +1,22 @@
+from typing import List
+
+
+def in_x_smaller_lists(large_list: list, number_of_lists: int) -> List[list]:
+    """
+    Split one large list into smaller ones.
+
+    See https://stackoverflow.com/q/752308#11574640
+    """
+    if not large_list:
+        return []
+    return [large_list[i::number_of_lists] for i in range(number_of_lists)]
+
+
+def list_by_max_items(large_list: list, max_items: int) -> List[list]:
+    """
+    Optimize splitting to get minimal number of smaller lists.
+
+    Each returned smaller list has about the same number of items that is less than or equal to max_items.
+    """
+    number_of_lists = max(1, len(large_list) // max_items)
+    return in_x_smaller_lists(large_list, number_of_lists)

--- a/docs/exchange.md
+++ b/docs/exchange.md
@@ -19,6 +19,7 @@ import logging
 
 from cryptofeed.feed import Feed
 from cryptofeed.defines import HUOBI
+from cryptofeed.connection import AsyncConnection
 
 
 LOG = logging.getLogger('feedhandler')
@@ -34,7 +35,7 @@ class Huobi(Feed):
     def __reset(self):
         pass
 
-    async def subscribe(self, websocket):
+    async def subscribe(self, conn: AsyncConnection):
         self.__reset()
 ```
 
@@ -67,75 +68,77 @@ We also save the websocket connection to a private data member of the class so w
 This also mean we'll need to add support for the various channel mappings in `standards.py`, add support for the symbol mappings in `symbols.py` and add the exchange import to `exchanges.py`.
 
 
-* `standards.py`
-    - ```python
-        _feed_to_exchange_map = {
-            ...
-            TRADES: {
-                ...
-                HUOBI: 'trade.detail'
-            },
-        ```
+### `standards.py`
 
-* `symbols.py`
-    - Per the documentation we can get a list of symbols from their REST api via `GET /v1/common/symbols`
-    - ```python
-      def huobi_symbols():
-            r = requests.get('https://api.huobi.com/v1/common/symbols').json()
-            return {'{}-{}'.format(e['base-currency'].upper(), e['quote-currency'].upper()) : '{}{}'.format(e['base-currency'], e['quote-currency']) for e in r['data']}
+```python
+_feed_to_exchange_map = {
+    ...
+    TRADES: {
+        ...
+        HUOBI: 'trade.detail'
+    },
+```
 
+### `symbols.py`
+Per the documentation we can get a list of symbols from their REST api via `GET /v1/common/symbols`
+```python
+def huobi_symbols():
+    r = requests.get('https://api.huobi.com/v1/common/symbols').json()
+    return {'{}-{}'.format(e['base-currency'].upper(), e['quote-currency'].upper()) : '{}{}'.format(e['base-currency'], e['quote-currency']) for e in r['data']}
 
-      _exchange_function_map = {
-           ...
-           HUOBI: huobi_symbols
-        }
-      ```
-* `exchanges.py`
-    - ```python
-      from cryptofeed.huobi.huobi import Huobi
-      ```
+_exchange_function_map = {
+   ...
+   HUOBI: huobi_symbols
+}
+```
+### `exchanges.py`
+
+```python
+from cryptofeed.huobi.huobi import Huobi
+```
 
 ## Message Handler
 Now that we can subscribe to trades, we can add the message handler (which is called by the feedhandler when messages are received on a websocket). Huobi's documentation informs us that messages sent via websocket are compressed, so we'll need to make sure we uncompress them before handling them. It also informs us that we'll need to respond to pings or be disconnected. Most websocket libraries will do this automatically, but they cannot interpret a ping correctly if the messages are compressed so we'll need to handle pings automatically. We also can see from the documentation that the feed and symbol are sent in the update so we'll need to parse those out to properly handle the message.
 
 
 ```python
-async def _trade(self, msg):
-        """
-        {
-            'ch': 'market.btcusd.trade.detail',
-            'ts': 1549773923965,
-            'tick': {
-                'id': 100065340982,
-                'ts': 1549757127140,
-                'data': [{'id': '10006534098224147003732', 'amount': Decimal('0.0777'), 'price': Decimal('3669.69'), 'direction': 'buy', 'ts': 1549757127140}]}}
-        """
-        for trade in msg['tick']['data']:
-            await self.callback(TRADES,
-                feed=self.id,
-                symbol=symbol_exchange_to_std(msg['ch'].split('.')[1]),
-                order_id=trade['id'],
-                side=BUY if trade['direction'] == 'buy' else SELL,
-                amount=Decimal(trade['amount']),
-                price=Decimal(trade['price']),
-                timestamp=trade['ts']
-            )
+async def _trade(self, msg, timestamp):
+    """
+    {
+        'ch': 'market.btcusd.trade.detail',
+        'ts': 1549773923965,
+        'tick': {
+            'id': 100065340982,
+            'ts': 1549757127140,
+            'data': [{'id': '10006534098224147003732', 'amount': Decimal('0.0777'), 'price': Decimal('3669.69'), 'direction': 'buy', 'ts': 1549757127140}]}}
+    """
+    for trade in msg['tick']['data']:
+        await self.callback(TRADES,
+            feed=self.id,
+            symbol=symbol_exchange_to_std(msg['ch'].split('.')[1]),
+            order_id=trade['id'],
+            side=BUY if trade['direction'] == 'buy' else SELL,
+            amount=Decimal(trade['amount']),
+            price=Decimal(trade['price']),
+            timestamp=trade['ts'],
+            receipt_timestamp=timestamp,
+        )
 
-    async def message_handler(self, msg, conn, timestamp):
-        # unzip message
-        msg = zlib.decompress(msg, 16+zlib.MAX_WBITS)
-        msg = json.loads(msg, parse_float=Decimal)
+async def message_handler(self, data, timestamp, conn):
+    # unzip message
+    data = zlib.decompress(data, 16+zlib.MAX_WBITS)
+    msg = json.loads(data, parse_float=Decimal)
 
-        # Huobi sends a ping evert 5 seconds and will disconnect us if we do not respond to it
-        if 'ping' in msg:
-            await conn.send(json.dumps({'pong': msg['ping']}))
-        elif 'status' in msg and msg['status'] == 'ok':
-            return
-        elif 'ch' in msg:
-            if 'trade' in msg['ch']:
-                await self._trade(msg)
-        else:
-            LOG.warning("%s: Invalid message type %s", self.id, msg)
+    # Huobi sends a ping evert 5 seconds and will disconnect us if we do not respond to it
+    if 'ping' in msg:
+        await conn.send(json.dumps({'pong': msg['ping']}))
+    elif 'status' in msg and msg['status'] == 'ok':
+        return
+    elif 'ch' in msg:
+        if 'trade' in msg['ch']:
+            await self._trade(msg, timestamp)
+    else:
+        LOG.warning("%s: Unexpected message type %s", self.ID, msg)
 ```
 
 The actual trade handler, `_trade`, simply parses out the relevant data and invokes the callback to deliver the update to the client.
@@ -147,38 +150,40 @@ Finally we'll add support for order books. There are other data feeds we could s
 Like we did with for the trades channel, we'll need to add a handler for the book data in the message handler, and add support for the subscription message in `standards.py`.
 
 
-* `standards.py`
-  - ```python
-      _feed_to_exchange_map = {
-        L2_BOOK: {
-            ...
-            HUOBI: 'depth.step0'
-    ```
-* `huobi.py`
-  - `message_handler`
-  - ```python
-      elif 'ch' in msg:
-          ....
-          elif 'depth' in msg['ch']:
-              await self._book(msg)
-    ```
-  - `_book`
-  - ```python
-      async def _book(self, msg):
-          symbol = symbol_exchange_to_std(msg['ch'].split('.')[1])
-          data = msg['tick']
-          self.l2_book[symbol] = {
-              BID: sd({
-                  Decimal(price): Decimal(amount)
-                  for price, amount in data['bids']
-              }),
-              ASK: sd({
-                  Decimal(price): Decimal(amount)
-                  for price, amount in data['asks']
-              })
-          }
+### `standards.py`
 
-          await self.book_callback(symbol, L2_BOOK, False, False, msg['ts'])
+```python
+_feed_to_exchange_map = {
+    L2_BOOK: {
+        ...
+        HUOBI: 'depth.step0'
+```
+
+### `huobi.py`
+- `message_handler`
+    ```python
+    elif 'ch' in msg:
+        ....
+        elif 'depth' in msg['ch']:
+            await self._book(msg)
+    ```
+- `_book`
+    ```python
+    async def _book(self, msg):
+        symbol = symbol_exchange_to_std(msg['ch'].split('.')[1])
+        data = msg['tick']
+        self.l2_book[symbol] = {
+            BID: sd({
+                Decimal(price): Decimal(amount)
+                for price, amount in data['bids']
+            }),
+            ASK: sd({
+                Decimal(price): Decimal(amount)
+                for price, amount in data['asks']
+            })
+        }
+
+        await self.book_callback(symbol, L2_BOOK, False, False, msg['ts'])
     ```
 
 According to the docs, for the book updates, the entire book is sent each time, so we just need to process the message in its entirety and call the `book_callback` method, defined in the parent `Feed` class. Its designed to handle the myriad of ways an update might take place, many of which Huobi does not support. Some exchanges supply only incremental updates (also called deltas), meaning a client can subscribe to a book delta, instead of getting the entire book each time. Huobi does not support this, so there is no delta processing to handle, but by convention the same method is used to process the book update.

--- a/examples/demo_bitmex_config.py
+++ b/examples/demo_bitmex_config.py
@@ -7,8 +7,9 @@ associated with this software.
 
 from cryptofeed import FeedHandler
 from cryptofeed.callback import BookCallback, FundingCallback, TradeCallback
-from cryptofeed.defines import FUNDING, L2_BOOK, OPEN_INTEREST, TRADES
+from cryptofeed.defines import BITMEX, FUNDING, L2_BOOK, OPEN_INTEREST, TRADES
 from cryptofeed.exchanges import Bitmex
+
 
 # ------------------------------------------------------------------------
 #
@@ -24,14 +25,6 @@ from cryptofeed.exchanges import Bitmex
 # ------------------------------------------------------------------------
 
 
-async def print_all(a=None, b=None, c=None, d=None, e=None, f=None, g=None, h=None, **kwargs):
-    print_all_kwargs(a=a, b=b, c=c, d=d, e=e, f=f, g=g, h=h, **kwargs)
-
-
-def print_all_kwargs(**kwargs):
-    print(kwargs)
-
-
 # To set API key and secret, you have three options:
 #
 # 1. Use the environment variables in the following format:
@@ -42,7 +35,7 @@ def print_all_kwargs(**kwargs):
 # 2. Create a YAML configuration file as the following 'config_example.yml'
 #
 #    log:
-#       filename: demo_bitmex.log
+#       filename: demo_bitmex_config.log
 #       level: DEBUG
 #    bitmex:
 #        key_id: XPIRzadE7dQoGoAiIUsRrbJk
@@ -51,12 +44,15 @@ def print_all_kwargs(**kwargs):
 # 3. Use a dict as the following example:
 config = {
     'log': {
-        'filename': 'demo_bitmex.log',
+        'filename': 'demo_bitmex_config.log',
         'level': 'DEBUG'},
     'bitmex': {
         'key_id': 'XPIRzadE7dQoGoAiIUsRrbJk',
         'key_secret': 'EJ3sgj1HKM_UfLn0YzQJI9fM2Z2TFwoIyO1v_47dMfiwJoB2'},
 }
+
+async def print_all(*args, **kwargs):
+    print(args, kwargs)
 
 
 def main():
@@ -72,9 +68,9 @@ def main():
     f.add_feed(Bitmex(config=config, symbols=bitmex_symbols, channels=[OPEN_INTEREST], callbacks={OPEN_INTEREST: print_all}))
     f.add_feed(Bitmex(config=config, symbols=bitmex_symbols, channels=[TRADES], callbacks={TRADES: TradeCallback(print_all)}))
 
-    # When using the following no need to pass config when using 'BITMEX'
-    f.add_feed('BITMEX', symbols=bitmex_symbols, channels=[FUNDING], callbacks={FUNDING: FundingCallback(print_all)})
-    f.add_feed('BITMEX', symbols=['XBTUSD'], channels=[L2_BOOK], callbacks={L2_BOOK: BookCallback(print_all)})
+    # When using the following no need to pass config=config when using 'BITMEX'
+    f.add_feed(BITMEX, symbols=bitmex_symbols, channels=[FUNDING], callbacks={FUNDING: FundingCallback(print_all)})
+    f.add_feed(BITMEX, symbols=['XBTUSD'], channels=[L2_BOOK], callbacks={L2_BOOK: BookCallback(print_all)})
 
     f.run()
 


### PR DESCRIPTION
This PR improves the new `AsyncConnection` design.

Major changes:
* Add new file `runner.py` implementing the class `Runner`. The `Runner` owns the main `message_handler` infinite loop ( and `_watch()`) that was previously the responsibility of `FeedHandler`. This simplifies the class `FeedHandler` and drops `uuid`.
* Add new file `split.py` to split large list into smaller ones. This simplifies the `Feed._address()` required by some exchanges.
* Rewrite COINGECKO and WHALE_ALERT because I have changed too much these files. I ma working on these files to bring similar behavior as previous versions. This is in WIP - Work In Progress...
* Add new channel=SCORE because of the COINGECKO rewriting: SCORE distinguishes scores/ranks from MARKET_INFO
* Replace `Feed.connections()` function by the existing mechanism `address: dict` in the `Feed.__init__()` (first argument). No need to pass `partial(subscribe,x)`
 and `message_handler()` callbacks. The `address: dict` (options and URLs) are used by the `FeedHandler` to create the `AsyncConnection`: each `AsyncConnection` keeps its option/address within its context. This connection context is then accessed by the `Feed` subclass to subscribe to the right pairs/channels.

The `FeedHandler` manages the following objects:
* `Feed` (exchange or provider)
* `AsyncConnection` (Websocket or HTTP)
* `Runner` (one `Runner` per `AsyncConnection`)

The `FeedHandler` has the responsibility to create the `Feed` sub-class, to create one or more `AsyncConnection` according to the `Feed.address` (`str` or `dict`, can be a mix of websocket and HTTP), and to create one `Runner` per `AsyncConnection`. Each `Feed` has one or more `AsyncConnection`. Each `Runner` runs only one `AsyncConnection`.

`Runner` knows `Feed` and `AsyncConnection`. But the `Feed` and its sub-classes do not know the `Runner`. The `Runner` pass the `AsyncConnection` when calling `Feed.subscribe() and `Feed.handle()`. The `Feed` sub-classes use the `AsyncConnection` to access the connection context and to send messages (websocket only). Notice I have renamed `message_handler()` -> `handle()` for consistency with `subscribe() != message_subscriber()`.

Once everything is created, the `FeedHandler` runs all the `Runner` asynchronously. The `Runner` infinite loop calls the `Feed.subscribe(conn)`, and loops over the `AsyncConnection.read()`. Each received message is passed to `Feed.handle(msg,timestamp,conn)`. The `Feed` sub-calss has access to `conn.ctx`, the connection context: no need to mange a `seqno_map[conn.id]`. The `conn.ctx` contains the `Feed.address` (and options) used to create the `AsyncConnection`.

All exchanges using websocket benefits this feature:
```py
# slow down the subscription batch by waiting for a response or for a half of a second before next send
try:
    msg = await asyncio.wait_for(self.socket.recv(), timeout=0.5)
    await self.handle(msg, time(), self)
except asyncio.exceptions.TimeoutError:
    pass
```

On shutdown signal, the `FeedHandler` closes the `AsyncConnection`, stops the `Runner` & `Feed`, and waits for termination of all backends before exiting. The `FeedHandler` runs this functions using AsyncIO to speed up the shutdown process. This is important because multiple backends may need to flush their data and the orchestrator (K8s/Docker) may kill Cryptofeed is it takes too much time to terminate. The backend flushing is faster, and `loop.run_until_complete(asyncio.gather(*flush_tasks))` detect all flushing tasks are completed.

Tested:
- during a couple of days
- one or all exchanges activated
- subscribing to many many pairs per `Feed`
- using backends requiring final flush on remote database

This PR improves the new design and simplifies the source code of some exchanges/providers.