### PR TITLE
Add guard against non-supported asyncio add_signal_handler() on windows platforms

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,7 +16,8 @@
   * Breaking change: Feed object `config` renamed `subscription`
   * Feature: Configuration passed from feedhandler to exchanges
   * Breaking change: most use of `pair` and `pairs` changed to `symbol` and `symbols` to be more consistent with actual usage. pairs.py renamed to symbols.py
-
+  * Bugfix: Add guard against non-supported asyncio add_signal_handler() on windows platforms
+    
 ### 1.6.2 (2020-12-25)
   * Feature: Support for Coingecko aggregated data per coin, to be used with a new data channel 'profile'
   * Feature: Support for Whale Alert on-chain transaction data per coin, to be used with a new data channel 'transactions'

--- a/cryptofeed/feedhandler.py
+++ b/cryptofeed/feedhandler.py
@@ -7,7 +7,7 @@ associated with this software.
 import asyncio
 import logging
 from signal import SIGTERM, SIGINT, SIGABRT
-
+import sys
 try:
     # unix / macos only
     from signal import SIGHUP
@@ -83,6 +83,8 @@ def setup_signal_handlers(loop):
     """
     This must be run from the loop in the main thread
     """
+    if sys.platform.startswith('win'):
+        return # Signal Handlers supported on Win platforms
     def handle_stop_signals():
         raise SystemExit
 

--- a/cryptofeed/feedhandler.py
+++ b/cryptofeed/feedhandler.py
@@ -84,7 +84,7 @@ def setup_signal_handlers(loop):
     This must be run from the loop in the main thread
     """
     if sys.platform.startswith('win'):
-        return # Signal Handlers supported on Win platforms
+        return # Signal Handlers NOT supported on Win platforms
     def handle_stop_signals():
         raise SystemExit
 

--- a/cryptofeed/feedhandler.py
+++ b/cryptofeed/feedhandler.py
@@ -6,6 +6,7 @@ associated with this software.
 '''
 import asyncio
 import logging
+import signal
 from signal import SIGTERM, SIGINT, SIGABRT
 import sys
 try:
@@ -83,13 +84,15 @@ def setup_signal_handlers(loop):
     """
     This must be run from the loop in the main thread
     """
-    if sys.platform.startswith('win'):
-        return # Signal Handlers NOT supported on Win platforms
-    def handle_stop_signals():
+    def handle_stop_signals(*args):
         raise SystemExit
-
-    for signal in SIGNALS:
-        loop.add_signal_handler(signal, handle_stop_signals)
+    if sys.platform.startswith('win'):
+        # NOTE: asyncio loop.add_signal_handler() not supported on windows
+        for sig in SIGNALS:
+            signal.signal(sig, handle_stop_signals)
+    else:
+        for sig in SIGNALS:
+            loop.add_signal_handler(sig, handle_stop_signals)
 
 
 class FeedHandler:


### PR DESCRIPTION
### Description of code - what bug does this fix / what feature does this add?

Windows does not support asyncio loop.add_signal_handler() (See: https://docs.python.org/3/library/asyncio-platforms.html)

Get a NotImplementedError when running from windows.

This PR just adds a simple check if we are on a windows platform to avoid adding signal handles.

- [x] - Tested
- [x] - Changelog updated
- [ ] - Tests run and pass
- [ ] - Flake8 run and all errors/warnings resolved
- [ ] - Contributors file updated (optional)
