### PR TITLE
Get API KEY ID from env. var or from Config

### DIFF
--- a/cryptofeed/feed.py
+++ b/cryptofeed/feed.py
@@ -5,6 +5,7 @@ Please see the LICENSE file for the terms and conditions
 associated with this software.
 '''
 from collections import defaultdict
+import os
 from typing import Tuple, Callable, Union, List
 
 from cryptofeed.callback import Callback
@@ -57,7 +58,7 @@ class Feed:
         self.origin = origin
         self.checksum_validation = checksum_validation
         self.ws_defaults = {'ping_interval': 10, 'ping_timeout': None, 'max_size': 2**23, 'max_queue': None, 'origin': self.origin}
-        key_id = self.config[self.id.lower()].key_id
+        key_id = os.environ.get(f'CF_{self.id}_KEY_ID') or self.config[self.id.lower()].key_id
         load_exchange_symbol_mapping(self.id, key_id=key_id)
 
         if subscription is not None and (symbols is not None or channels is not None):


### PR DESCRIPTION
### Give flexibility to use Config or env. var. to pass secrets

The environment variable format is: `CF_{exchange-name}_KEY_ID`

The env. var. has a higher priority.

This feature will be explained in documentation if this PR would be merged.

This is a tiny one-line change consistent with the other PR about Bitmex authentication.
No feedback is provided to trace the origin of the used API KEY ID (env. var. or Config).

To be more consistent across source code, I can create another PR to move all related Config/env.var. values is a generic function in Config, with the same behavior. But this enhancement would be a future PR. First let's implement it in a KISS fashion.

- [ ] - Tested
- [ ] - Changelog updated
- [ ] - Tests run and pass
- [ ] - Flake8 run and all errors/warnings resolved
- [ ] - Contributors file updated (optional)
