### PR TITLE
Improve Feed shutdown and event loop closing

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,6 +27,7 @@
   * Feature: Simplify source code by standardization iterations over channels and symbols
   * Bugfix: Remove remaining character "*" in book_test.py
   * Bugfix: Fix return type of the function book_flatten()
+  * Feature: Shutdown multiple backends asynchronously, and close the event loop properly
 
 ### 1.6.2 (2020-12-25)
   * Feature: Support for Coingecko aggregated data per coin, to be used with a new data channel 'profile'

--- a/cryptofeed/feed.py
+++ b/cryptofeed/feed.py
@@ -27,6 +27,10 @@ class Feed:
 
     def __init__(self, address: Union[dict, str], symbols=None, channels=None, subscription=None, config: Union[Config, dict, str] = None, callbacks=None, max_depth=None, book_interval=1000, snapshot_interval=False, checksum_validation=False, cross_check=False, origin=None):
         """
+        address: str, or dict
+            address to be used to create the connection.
+            The address protocol (wss or https) will be used to determine the connection type.
+            Use a "str" to pass one single address, or a dict of option/address
         max_depth: int
             Maximum number of levels per side to return in book updates
         book_interval: int
@@ -236,8 +240,13 @@ class Feed:
         """
         raise NotImplementedError
 
-    async def stop(self):
+    async def shutdown(self):
+        LOG.info('%s: feed shutdown starting...', self.id)
         for callbacks in self.callbacks.values():
             for callback in callbacks:
                 if hasattr(callback, 'stop'):
+                    cb_name = callback.__class__.__name__ if hasattr(callback, '__class__') else callback.__name__
+                    LOG.info('%s: stopping backend %s', self.id, cb_name)
                     await callback.stop()
+        LOG.info('%s: feed shutdown completed', self.id)
+

--- a/cryptofeed/feedhandler.py
+++ b/cryptofeed/feedhandler.py
@@ -209,12 +209,15 @@ class FeedHandler:
             LOG.critical(txt)
             raise ValueError(txt)
 
-        try:
-            import uvloop
-            asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
-            LOG.info('FH: uvloop activated')
-        except Exception as why:  # ImportError
-            LOG.info('FH: no uvloop because %r', why)
+        # The user managing the ASyncIO loop themselves sets start_loop=False => they decide to enable uvloop if they want to
+        # therefore, the FeedHandler attempts to enable uvloop only when start_loop==True
+        if start_loop:
+            try:
+                import uvloop
+                asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
+                LOG.info('FH: uvloop activated')
+            except Exception as why:  # ImportError
+                LOG.info('FH: no uvloop because %r', why)
 
         loop = asyncio.get_event_loop()
         # Good to enable when debugging or without code change: export PYTHONASYNCIODEBUG=1)

--- a/cryptofeed/feedhandler.py
+++ b/cryptofeed/feedhandler.py
@@ -118,7 +118,7 @@ class FeedHandler:
         self.last_msg = defaultdict(lambda: None)
         self.timeout_interval = timeout_interval
         self.log_messages_on_error = log_messages_on_error
-        self.raw_message_capture = raw_message_capture
+        self.raw_message_capture = raw_message_capture  # TODO: create/append callbacks to do raw_message_capture
         self.handler_enabled = handler_enabled
         self.config = Config(config=config)
 
@@ -205,18 +205,19 @@ class FeedHandler:
             be called from the main/parent thread's event loop
         """
         if len(self.feeds) == 0:
-            LOG.error('No feeds specified')
-            raise ValueError("No feeds specified")
+            txt = f'FH: No feed specified. Please specify at least one feed among {list(_EXCHANGES.keys())}'
+            LOG.critical(txt)
+            raise ValueError(txt)
 
-        if start_loop:
-            try:
-                import uvloop
-                asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
-            except ImportError:
-                pass
+        try:
+            import uvloop
+            asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
+            LOG.info('FH: uvloop activated')
+        except Exception as why:  # ImportError
+            LOG.info('FH: no uvloop because %r', why)
 
         loop = asyncio.get_event_loop()
-        # Good to enable when debugging
+        # Good to enable when debugging or without code change: export PYTHONASYNCIODEBUG=1)
         # loop.set_debug(True)
 
         if install_signal_handlers:
@@ -227,21 +228,49 @@ class FeedHandler:
                 loop.create_task(self._connect(conn, sub, handler))
                 self.timeout[conn.uuid] = timeout
 
-        if start_loop:
-            try:
-                loop.run_forever()
-            except SystemExit:
-                LOG.info("System Exit received - shutting down")
-            except Exception:
-                LOG.error("Unhandled exception", exc_info=True)
-            finally:
-                self.stop(loop=loop)
+        if not start_loop:
+            return
+
+        try:
+            loop.run_forever()
+        except SystemExit:
+            LOG.info('FH: System Exit received - shutting down')
+        except Exception as why:
+            LOG.exception('FH: Unhandled %r - shutting down', why)
+        finally:
+            self.stop(loop=loop)
 
     def stop(self, loop=None):
         if not loop:
             loop = asyncio.get_event_loop()
+
+        LOG.info('FH: create the tasks to properly shutdown the backends (data flush)')
+        shutdown_tasks = []
         for feed, _ in self.feeds:
-            loop.run_until_complete(feed.stop())
+            task = loop.create_task(feed.shutdown())
+            task.set_name(f'shutdown_feed_{feed.id}')
+            shutdown_tasks.append(task)
+
+        LOG.info('FH: wait %s backend tasks until termination', len(shutdown_tasks))
+        try:
+            loop.run_until_complete(asyncio.gather(*shutdown_tasks))
+        finally:
+            pass
+
+        LOG.info('FH: stop the AsyncIO loop: wait for the current batch of callbacks and then exit')
+        loop.stop()
+
+        LOG.info('FH: last AsyncIO loop run')
+        try:
+            loop.run_forever()
+        finally:
+            pass
+
+        LOG.info('FH: shutdown asynchronous generators')
+        loop.run_until_complete(loop.shutdown_asyncgens())
+
+        LOG.info('FH: close the AsyncIO loop')
+        loop.close()
 
     async def _watch(self, connection):
         if self.timeout[connection.uuid] == -1:


### PR DESCRIPTION
### Shutdown multiple backends asynchronously <br> and close the event loop properly

This feature has been successfully tested using another branch with much more changes (on Linux).
Please Bryant, could you test this branch on your Mac?

- [ ] - Tested
- [x] - Changelog updated
- [ ] - Tests run and pass
- [ ] - Flake8 run and all errors/warnings resolved
- [ ] - Contributors file updated (optional)
