### PR TITLE
Standardize for-loop over channels and symbols

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,6 +24,7 @@
   * Feature: Support Bitmex authentication using personal API key and secret
   * Feature: Print the origin of the configuration (filename, dict) for better developer experience
   * Bugfix: Add guard against non-supported asyncio add_signal_handler() on windows platforms
+  * Feature: Simplify source code by standardization iterations over channels and symbols
 
 ### 1.6.2 (2020-12-25)
   * Feature: Support for Coingecko aggregated data per coin, to be used with a new data channel 'profile'

--- a/cryptofeed/exchange/binance.py
+++ b/cryptofeed/exchange/binance.py
@@ -10,7 +10,7 @@ from collections import defaultdict
 from datetime import datetime
 from decimal import Decimal
 from time import time
-from typing import Dict, Iterable
+from typing import Dict, Iterable, Union
 
 import aiohttp
 from sortedcontainers import SortedDict as sd

--- a/cryptofeed/exchange/binance_delivery.py
+++ b/cryptofeed/exchange/binance_delivery.py
@@ -20,6 +20,7 @@ class BinanceDelivery(Binance):
 
     def __init__(self, depth=1000, **kwargs):
         super().__init__(depth=depth, **kwargs)
+        # overwrite values previously set by the super class Binance
         self.ws_endpoint = 'wss://dstream.binance.com'
         self.rest_endpoint = 'https://dapi.binance.com/dapi/v1'
         self.address = self._address()

--- a/cryptofeed/exchange/binance_futures.py
+++ b/cryptofeed/exchange/binance_futures.py
@@ -20,6 +20,7 @@ class BinanceFutures(Binance):
 
     def __init__(self, depth=1000, **kwargs):
         super().__init__(depth=depth, **kwargs)
+        # overwrite values previously set by the super class Binance
         self.ws_endpoint = 'wss://fstream.binance.com'
         self.rest_endpoint = 'https://fapi.binance.com/fapi/v1'
         self.address = self._address()

--- a/cryptofeed/exchange/binance_us.py
+++ b/cryptofeed/exchange/binance_us.py
@@ -18,6 +18,7 @@ class BinanceUS(Binance):
 
     def __init__(self, depth=1000, **kwargs):
         super().__init__(depth=depth, **kwargs)
+        # overwrite values previously set by the super class Binance
         self.ws_endpoint = 'wss://stream.binance.us:9443'
         self.rest_endpoint = 'https://api.binance.us/api/v1'
         self.address = self._address()

--- a/cryptofeed/exchange/bitcoincom.py
+++ b/cryptofeed/exchange/bitcoincom.py
@@ -10,6 +10,7 @@ from decimal import Decimal
 from sortedcontainers import SortedDict as sd
 from yapic import json
 
+from cryptofeed.connection import AsyncConnection
 from cryptofeed.defines import BID, ASK, BITCOINCOM, BUY, L2_BOOK, SELL, TICKER, TRADES
 from cryptofeed.exceptions import MissingSequenceNumber
 from cryptofeed.feed import Feed
@@ -30,11 +31,11 @@ class BitcoinCom(Feed):
         self.l2_book = {}
         self.seq_no = {}
 
-    async def subscribe(self, websocket):
+    async def subscribe(self, conn: AsyncConnection):
         self.__reset()
-        for chan in self.channels if self.channels else self.subscription:
-            for pair in self.symbols if self.symbols else self.subscription[chan]:
-                await websocket.send(json.dumps(
+        for chan in set(self.channels or self.subscription):
+            for pair in set(self.symbols or self.subscription[chan]):
+                await conn.send(json.dumps(
                     {
                         "method": chan,
                         "params": {

--- a/cryptofeed/exchange/bitflyer.py
+++ b/cryptofeed/exchange/bitflyer.py
@@ -169,11 +169,11 @@ class Bitflyer(Feed):
         else:
             LOG.warning("%s: Invalid message type %s", self.id, msg)
 
-    async def subscribe(self, conn: AsyncConnection, **kwargs):
+    async def subscribe(self, conn: AsyncConnection):
         self.__reset()
 
-        for chan in self.channels if self.channels else self.subscription:
-            for pair in self.symbols if self.symbols else self.subscription[chan]:
+        for chan in set(self.channels or self.subscription):
+            for pair in set(self.symbols or self.subscription[chan]):
                 if chan.startswith('lightning_board'):
                     # need to subscribe to snapshots too if subscribed to L2_BOOKS
                     await conn.send(json.dumps({"method": "subscribe", "params": {"channel": f'lightning_board_snapshot_{pair}'}}))

--- a/cryptofeed/exchange/bitstamp.py
+++ b/cryptofeed/exchange/bitstamp.py
@@ -151,18 +151,18 @@ class Bitstamp(Feed):
                     amount = Decimal(update[1])
                     self.l2_book[std_pair][side][price] = amount
 
-    async def subscribe(self, websocket):
+    async def subscribe(self, conn: AsyncConnection):
         snaps = []
         self.last_update_id = {}
-        for channel in self.channels if not self.subscription else self.subscription:
-            for pair in self.symbols if not self.subscription else self.subscription[channel]:
-                await websocket.send(
+        for chan in set(self.channels or self.subscription):
+            for pair in set(self.symbols or self.subscription[chan]):
+                await conn.send(
                     json.dumps({
                         "event": "bts:subscribe",
                         "data": {
-                            "channel": "{}_{}".format(channel, pair)
+                            "channel": f"{chan}_{pair}"
                         }
                     }))
-                if 'diff_order_book' in channel:
+                if 'diff_order_book' in chan:
                     snaps.append(pair)
         await self._snapshot(snaps)

--- a/cryptofeed/exchange/bitstamp.py
+++ b/cryptofeed/exchange/bitstamp.py
@@ -12,6 +12,7 @@ import aiohttp
 from sortedcontainers import SortedDict as sd
 from yapic import json
 
+from cryptofeed.connection import AsyncConnection
 from cryptofeed.defines import BID, ASK, BITSTAMP, BUY, L2_BOOK, L3_BOOK, SELL, TRADES
 from cryptofeed.feed import Feed
 from cryptofeed.standards import feed_to_exchange, symbol_exchange_to_std, timestamp_normalize

--- a/cryptofeed/exchange/deribit.py
+++ b/cryptofeed/exchange/deribit.py
@@ -25,8 +25,8 @@ class Deribit(Feed):
         instruments = self.get_instruments()
         pairs = None
         if self.subscription:
-            config_instruments = list(self.subscription.values())
-            pairs = [pair for inner in config_instruments for pair in inner]
+            subscribing_instruments = list(self.subscription.values())
+            pairs = [pair for inner in subscribing_instruments for pair in inner]
 
         for pair in set(self.symbols or pairs):
             if pair not in instruments:

--- a/cryptofeed/exchange/exx.py
+++ b/cryptofeed/exchange/exx.py
@@ -10,6 +10,7 @@ from decimal import Decimal
 from sortedcontainers import SortedDict as sd
 from yapic import json
 
+from cryptofeed.connection import AsyncConnection
 from cryptofeed.defines import BID, ASK, BUY
 from cryptofeed.defines import EXX as EXX_id
 from cryptofeed.defines import L2_BOOK, SELL, TRADES
@@ -157,11 +158,11 @@ class EXX(Feed):
         else:
             LOG.warning("%s: Invalid message type %s", self.id, msg)
 
-    async def subscribe(self, websocket):
+    async def subscribe(self, conn: AsyncConnection):
         self.__reset()
-        for channel in self.channels if not self.subscription else self.subscription:
-            for pair in self.symbols if not self.subscription else self.subscription[channel]:
-                await websocket.send(json.dumps({"dataType": f"1_{channel}_{pair}",
-                                                 "dataSize": 50,
-                                                 "action": "ADD"
-                                                 }))
+        for chan in set(self.channels or self.subscription):
+            for pair in set(self.symbols or self.subscription[chan]):
+                await conn.send(json.dumps({"dataType": f"1_{chan}_{pair}",
+                                            "dataSize": 50,
+                                            "action": "ADD"
+                                            }))

--- a/cryptofeed/exchange/gemini.py
+++ b/cryptofeed/exchange/gemini.py
@@ -10,6 +10,7 @@ from decimal import Decimal
 from sortedcontainers import SortedDict as sd
 from yapic import json
 
+from cryptofeed.connection import AsyncConnection
 from cryptofeed.defines import BID, ASK, BUY, GEMINI, L2_BOOK, SELL, TRADES
 from cryptofeed.feed import Feed
 from cryptofeed.standards import symbol_exchange_to_std, timestamp_normalize
@@ -83,9 +84,9 @@ class Gemini(Feed):
         else:
             LOG.warning('%s: Invalid message type %s', self.id, msg)
 
-    async def subscribe(self, websocket):
+    async def subscribe(self, conn: AsyncConnection):
         pairs = self.symbols if not self.subscription else list(set.union(*list(self.subscription.values())))
         self.__reset(pairs)
 
-        await websocket.send(json.dumps({"type": "subscribe",
-                                         "subscriptions": [{"name": "l2", "symbols": pairs}]}))
+        await conn.send(json.dumps({"type": "subscribe",
+                                    "subscriptions": [{"name": "l2", "symbols": pairs}]}))

--- a/cryptofeed/exchange/hitbtc.py
+++ b/cryptofeed/exchange/hitbtc.py
@@ -118,5 +118,5 @@ class HitBTC(Feed):
                         "params": {
                             "symbol": pair
                         },
-                        "id": conn.id
+                        "id": conn.uuid
                     }))

--- a/cryptofeed/exchange/huobi.py
+++ b/cryptofeed/exchange/huobi.py
@@ -11,6 +11,7 @@ from decimal import Decimal
 from sortedcontainers import SortedDict as sd
 from yapic import json
 
+from cryptofeed.connection import AsyncConnection
 from cryptofeed.defines import BID, ASK, BUY, HUOBI, L2_BOOK, SELL, TRADES
 from cryptofeed.feed import Feed
 from cryptofeed.standards import symbol_exchange_to_std, timestamp_normalize
@@ -104,13 +105,13 @@ class Huobi(Feed):
         else:
             LOG.warning("%s: Invalid message type %s", self.id, msg)
 
-    async def subscribe(self, websocket):
+    async def subscribe(self, conn: AsyncConnection):
         self.__reset()
         client_id = 0
-        for chan in self.channels if self.channels else self.subscription:
-            for pair in self.symbols if self.symbols else self.subscription[chan]:
+        for chan in set(self.channels or self.subscription):
+            for pair in set(self.symbols or self.subscription[chan]):
                 client_id += 1
-                await websocket.send(json.dumps(
+                await conn.send(json.dumps(
                     {
                         "sub": f"market.{pair}.{chan}",
                         "id": client_id

--- a/cryptofeed/exchange/huobi_swap.py
+++ b/cryptofeed/exchange/huobi_swap.py
@@ -1,11 +1,12 @@
-import logging
 import asyncio
+import logging
 import time
 from decimal import Decimal
 
 import aiohttp
 from yapic import json
 
+from cryptofeed.connection import AsyncConnection
 from cryptofeed.defines import HUOBI_SWAP, FUNDING
 from cryptofeed.exchange.huobi_dm import HuobiDM
 from cryptofeed.feed import Feed
@@ -47,14 +48,14 @@ class HuobiSwap(HuobiDM):
 
                         await asyncio.sleep(0.1)
 
-    async def subscribe(self, websocket):
+    async def subscribe(self, conn: AsyncConnection):
         chans = list(self.channels)
-        cfg = dict(self.subscription)
-        if FUNDING in self.channels or FUNDING in self.subscription:
+        sub = dict(self.subscription)
+        if FUNDING in (self.channels or self.subscription):
             loop = asyncio.get_event_loop()
             loop.create_task(self._funding(self.symbols if FUNDING in self.channels else self.subscription[FUNDING]))
             self.channels.remove(FUNDING) if FUNDING in self.channels else self.subscription.pop(FUNDING)
 
-        await super().subscribe(websocket)
+        await super().subscribe(conn)
         self.channels = chans
-        self.subscription = cfg
+        self.subscription = sub

--- a/cryptofeed/exchange/kraken.py
+++ b/cryptofeed/exchange/kraken.py
@@ -11,6 +11,7 @@ import zlib
 from sortedcontainers import SortedDict as sd
 from yapic import json
 
+from cryptofeed.connection import AsyncConnection
 from cryptofeed.defines import BID, ASK, BUY, KRAKEN, L2_BOOK, SELL, TICKER, TRADES
 from cryptofeed.exceptions import BadChecksum
 from cryptofeed.feed import Feed
@@ -43,14 +44,14 @@ class Kraken(Feed):
 
         return str(zlib.crc32(combined.encode()))
 
-    async def subscribe(self, websocket):
+    async def subscribe(self, conn: AsyncConnection):
         self.__reset()
         if self.subscription:
             for chan in self.subscription:
                 sub = {"name": chan}
                 if 'book' in chan:
                     sub['depth'] = self.book_depth
-                await websocket.send(json.dumps({
+                await conn.send(json.dumps({
                     "event": "subscribe",
                     "pair": list(self.subscription[chan]),
                     "subscription": sub
@@ -60,7 +61,7 @@ class Kraken(Feed):
                 sub = {"name": chan}
                 if 'book' in chan:
                     sub['depth'] = self.book_depth
-                await websocket.send(json.dumps({
+                await conn.send(json.dumps({
                     "event": "subscribe",
                     "pair": self.symbols,
                     "subscription": sub

--- a/cryptofeed/exchange/kraken_futures.py
+++ b/cryptofeed/exchange/kraken_futures.py
@@ -11,6 +11,7 @@ import requests
 from sortedcontainers import SortedDict as sd
 from yapic import json
 
+from cryptofeed.connection import AsyncConnection
 from cryptofeed.defines import BID, ASK, BUY, FUNDING, KRAKEN_FUTURES, L2_BOOK, OPEN_INTEREST, SELL, TICKER, TRADES
 from cryptofeed.exceptions import MissingSequenceNumber
 from cryptofeed.feed import Feed
@@ -26,11 +27,11 @@ class KrakenFutures(Feed):
     def __init__(self, **kwargs):
         super().__init__('wss://futures.kraken.com/ws/v1', **kwargs)
 
+        # TODO: the same verification (below) is done in Bitmex and Kraken => share this code in a common function in super class Feed
         instruments = self.get_instruments()
         if self.subscription:
             config_instruments = list(self.subscription.values())
-            self.symbols = [
-                pair for inner in config_instruments for pair in inner]
+            self.symbols = set(pair for inner in config_instruments for pair in inner)
 
         for pair in self.symbols:
             if pair not in instruments:
@@ -48,14 +49,14 @@ class KrakenFutures(Feed):
         r = requests.get('https://futures.kraken.com/derivatives/api/v3/instruments').json()
         return {e['symbol'].upper(): e['symbol'].upper() for e in r['instruments']}
 
-    async def subscribe(self, websocket):
+    async def subscribe(self, conn: AsyncConnection):
         self.__reset()
-        for chan in self.channels if self.channels else self.subscription:
-            await websocket.send(json.dumps(
+        for chan in set(self.channels or self.subscription):
+            await conn.send(json.dumps(
                 {
                     "event": "subscribe",
                     "feed": chan,
-                    "product_ids": self.symbols if not self.subscription else list(self.subscription[chan])
+                    "product_ids": list(self.symbols or self.subscription[chan])
                 }
             ))
 

--- a/cryptofeed/exchange/kraken_futures.py
+++ b/cryptofeed/exchange/kraken_futures.py
@@ -30,8 +30,8 @@ class KrakenFutures(Feed):
         # TODO: the same verification (below) is done in Bitmex and Kraken => share this code in a common function in super class Feed
         instruments = self.get_instruments()
         if self.subscription:
-            config_instruments = list(self.subscription.values())
-            self.symbols = set(pair for inner in config_instruments for pair in inner)
+            subscribing_instruments = list(self.subscription.values())
+            self.symbols = set(pair for inner in subscribing_instruments for pair in inner)
 
         for pair in self.symbols:
             if pair not in instruments:

--- a/cryptofeed/exchange/okex.py
+++ b/cryptofeed/exchange/okex.py
@@ -6,14 +6,19 @@ associated with this software.
 '''
 import asyncio
 from decimal import Decimal
+import logging
 import time
 
 import aiohttp
 import requests
 from yapic import json
 
+from cryptofeed.connection import AsyncConnection
 from cryptofeed.defines import OKEX, LIQUIDATIONS, BUY, SELL
 from cryptofeed.exchange.okcoin import OKCoin
+
+
+LOG = logging.getLogger("feedhandler")
 
 
 class OKEx(OKCoin):
@@ -89,8 +94,8 @@ class OKEx(OKCoin):
                     await asyncio.sleep(0.1)
                 await asyncio.sleep(60)
 
-    async def subscribe(self, websocket):
+    async def subscribe(self, conn: AsyncConnection):
         if LIQUIDATIONS in self.subscription or LIQUIDATIONS in self.channels:
             pairs = self.subscription[LIQUIDATIONS] if LIQUIDATIONS in self.subscription else self.symbols
-            asyncio.create_task(self._liquidations(pairs))
-        await super().subscribe(websocket)
+            asyncio.create_task(self._liquidations(pairs))  # TODO: use HTTPAsyncConn
+        return await super().subscribe(conn)

--- a/cryptofeed/exchange/probit.py
+++ b/cryptofeed/exchange/probit.py
@@ -10,6 +10,7 @@ from decimal import Decimal
 from sortedcontainers import SortedDict as sd
 from yapic import json
 
+from cryptofeed.connection import AsyncConnection
 from cryptofeed.defines import BID, ASK, BUY, PROBIT, L2_BOOK, SELL, TRADES
 from cryptofeed.feed import Feed
 from cryptofeed.standards import symbol_exchange_to_std, timestamp_normalize
@@ -166,23 +167,23 @@ class Probit(Feed):
             await self._l2_update(msg, timestamp)
         # Probit has a 'ticker' channel, but it provide OHLC-last data, not BBO px.
 
-    async def subscribe(self, websocket):
+    async def subscribe(self, conn: AsyncConnection):
         self.__reset()
 
         if self.subscription:
             for chan in self.subscription:
                 for pair in self.subscription[chan]:
-                    await websocket.send(json.dumps({"type": "subscribe",
-                                                     "channel": "marketdata",
-                                                     "filter": [chan],
-                                                     "interval": 100,
-                                                     "market_id": pair,
-                                                     }))
+                    await conn.send(json.dumps({"type": "subscribe",
+                                                "channel": "marketdata",
+                                                "filter": [chan],
+                                                "interval": 100,
+                                                "market_id": pair,
+                                                }))
         else:
             for pair in self.symbols:
-                await websocket.send(json.dumps({"type": "subscribe",
-                                                 "channel": "marketdata",
-                                                 "filter": list(self.channels),
-                                                 "interval": 100,
-                                                 "market_id": pair,
-                                                 }))
+                await conn.send(json.dumps({"type": "subscribe",
+                                            "channel": "marketdata",
+                                            "filter": list(self.channels),
+                                            "interval": 100,
+                                            "market_id": pair,
+                                            }))


### PR DESCRIPTION
### Simplify source code by standardization iterations over channels and symbols

Hi Bryant. I have extracted these changes from my huge PR about AsyncConnection refactoring. My objective is to reduce that last huge PR. Hope you appreciate.

This feature have been tested on another branch with much more changes.
However I have just tested this branch using `examples/demo.py`.
Please could you test it using other configurations?

- [ ] - Tested
- [x] - Changelog updated
- [ ] - Tests run and pass
- [ ] - Flake8 run and all errors/warnings resolved
- [ ] - Contributors file updated (optional)
