### PR TITLE
Gracefully close the ASyncIO loop

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,6 +30,7 @@
   * Feature: Shutdown multiple backends asynchronously, and close the event loop properly
   * Bugfix: Repair the Bitfinex FUNDING
   * Feature: Speedup the handling of Bitfinex messages by reducing intermediate mappings
+  * Bugfix: Cancel the pending tasks to gracefully/properly close the ASyncIO loop
 
 ### 1.6.2 (2020-12-25)
   * Feature: Support for Coingecko aggregated data per coin, to be used with a new data channel 'profile'

--- a/cryptofeed/feedhandler.py
+++ b/cryptofeed/feedhandler.py
@@ -244,6 +244,8 @@ class FeedHandler:
             self.stop(loop=loop)
             self.close(loop=loop)
 
+        LOG.info('FH: leaving run()')
+
     def stop(self, loop=None):
         """Shutdown the Feed backends asynchronously."""
         if not loop:

--- a/cryptofeed/feedhandler.py
+++ b/cryptofeed/feedhandler.py
@@ -7,14 +7,15 @@ associated with this software.
 import asyncio
 import logging
 import signal
-from signal import SIGTERM, SIGINT, SIGABRT
+from signal import SIGABRT, SIGINT, SIGTERM
 import sys
+
 try:
     # unix / macos only
     from signal import SIGHUP
-    SIGNALS = (SIGTERM, SIGINT, SIGABRT, SIGHUP)
+    SIGNALS = (SIGABRT, SIGINT, SIGTERM, SIGHUP)
 except ImportError:
-    SIGNALS = (SIGTERM, SIGINT, SIGABRT)
+    SIGNALS = (SIGABRT, SIGINT, SIGTERM)
 
 import zlib
 from collections import defaultdict


### PR DESCRIPTION
### Cancel the pending tasks to gracefully/properly close the ASyncIO loop

Yes you are right Briant about the verbose closing errors: I have the same on Linux/Ubuntu.
This fix is inspired from https://github.com/cjrh/aiorun/blob/master/aiorun.py :+1:

Please perform more tests on your side.

- [x] - Tested with `PYTHONPATH=. python3 -m pipenv run python3 examples/demo.py`
- [x] - Changelog updated
- [ ] - Tests run and pass
- [ ] - Flake8 run and all errors/warnings resolved
- [ ] - Contributors file updated (optional)

Note: The other PR about connection-refactoring goes further by closing the websockets.

For your information, below is the exception I got sometimes with this PR:

```
Future exception was never retrieved
future: <Future finished exception=ConnectionClosedError('code = 1006 (connection closed abnormally [internal]), no reason')>
Traceback (most recent call last):
  File "/home/o/.local/share/virtualenvs/cryptofeed-github-lKWY6iE3/lib/python3.8/site-packages/websockets/protocol.py", line 827, in transfer_data
    message = await self.read_message()
  File "/home/o/.local/share/virtualenvs/cryptofeed-github-lKWY6iE3/lib/python3.8/site-packages/websockets/protocol.py", line 895, in read_message
    frame = await self.read_data_frame(max_size=self.max_size)
  File "/home/o/.local/share/virtualenvs/cryptofeed-github-lKWY6iE3/lib/python3.8/site-packages/websockets/protocol.py", line 971, in read_data_frame
    frame = await self.read_frame(max_size)
  File "/home/o/.local/share/virtualenvs/cryptofeed-github-lKWY6iE3/lib/python3.8/site-packages/websockets/protocol.py", line 1047, in read_frame
    frame = await Frame.read(
  File "/home/o/.local/share/virtualenvs/cryptofeed-github-lKWY6iE3/lib/python3.8/site-packages/websockets/framing.py", line 105, in read
    data = await reader(2)
  File "/usr/lib/python3.8/asyncio/streams.py", line 723, in readexactly
    await self._wait_for_data('readexactly')
  File "/usr/lib/python3.8/asyncio/streams.py", line 517, in _wait_for_data
    await self._waiter
asyncio.exceptions.CancelledError

The above exception was the direct cause of the following exception:

websockets.exceptions.ConnectionClosedError: code = 1006 (connection closed abnormally [internal]), no reason
Future exception was never retrieved
future: <Future finished exception=ConnectionClosedError('code = 1006 (connection closed abnormally [internal]), no reason')>
Traceback (most recent call last):
  File "/home/o/.local/share/virtualenvs/cryptofeed-github-lKWY6iE3/lib/python3.8/site-packages/websockets/protocol.py", line 827, in transfer_data
    message = await self.read_message()
  File "/home/o/.local/share/virtualenvs/cryptofeed-github-lKWY6iE3/lib/python3.8/site-packages/websockets/protocol.py", line 895, in read_message
    frame = await self.read_data_frame(max_size=self.max_size)
  File "/home/o/.local/share/virtualenvs/cryptofeed-github-lKWY6iE3/lib/python3.8/site-packages/websockets/protocol.py", line 971, in read_data_frame
    frame = await self.read_frame(max_size)
  File "/home/o/.local/share/virtualenvs/cryptofeed-github-lKWY6iE3/lib/python3.8/site-packages/websockets/protocol.py", line 1047, in read_frame
    frame = await Frame.read(
  File "/home/o/.local/share/virtualenvs/cryptofeed-github-lKWY6iE3/lib/python3.8/site-packages/websockets/framing.py", line 105, in read
    data = await reader(2)
  File "/usr/lib/python3.8/asyncio/streams.py", line 723, in readexactly
    await self._wait_for_data('readexactly')
  File "/usr/lib/python3.8/asyncio/streams.py", line 517, in _wait_for_data
    await self._waiter
asyncio.exceptions.CancelledError

The above exception was the direct cause of the following exception:

websockets.exceptions.ConnectionClosedError: code = 1006 (connection closed abnormally [internal]), no reason
```