### PR TITLE
SSL option for arctic callbacks

### DIFF
--- a/cryptofeed/backends/arctic.py
+++ b/cryptofeed/backends/arctic.py
@@ -14,7 +14,7 @@ from cryptofeed.defines import FUNDING, OPEN_INTEREST, TICKER, TRADES, LIQUIDATI
 
 
 class ArcticCallback:
-    def __init__(self, library, host='127.0.0.1', key=None, numeric_type=float, quota=0, **kwargs):
+    def __init__(self, library, host='127.0.0.1', key=None, numeric_type=float, quota=0, ssl=False, **kwargs):
         """
         library: str
             arctic library. Will be created if does not exist.
@@ -30,7 +30,7 @@ class ArcticCallback:
             lib_type in the kwargs. Default is VersionStore, but you can
             set to chunkstore with lib_type=arctic.CHUNK_STORE
         """
-        con = arctic.Arctic(host)
+        con = arctic.Arctic(host, ssl=ssl)
         if library not in con.list_libraries():
             lib_type = kwargs.get('lib_type', arctic.VERSION_STORE)
             con.initialize_library(library, lib_type=lib_type)


### PR DESCRIPTION
### Description of code - what bug does this fix / what feature does this add?
When you create an arctic callback instance it is actually not possible to enable SSL option.
This PR add an ssl boolean argument to the arctic callback.

Using kwargs seems not possible as it is used further in the code. 
Additional work could be needed to support other options.

- [x] - Tested
- [ ] - Changelog updated
- [ ] - Tests run and pass
- [ ] - Flake8 run and all errors/warnings resolved
- [ ] - Contributors file updated (optional)
