### PR TITLE
Initial commit of async queue feeding separate backend task

### DIFF
--- a/cryptofeed/backends/backend.py
+++ b/cryptofeed/backends/backend.py
@@ -4,10 +4,28 @@ Copyright (C) 2017-2021  Bryant Moscon - bmoscon@gmail.com
 Please see the LICENSE file for the terms and conditions
 associated with this software.
 '''
+import asyncio
+from asyncio.queues import Queue
+from contextlib import asynccontextmanager
 from decimal import Decimal
 
 from cryptofeed.backends._util import book_convert, book_delta_convert
 from cryptofeed.defines import BID, ASK
+
+
+class BackendQueue:
+    def start(self, loop: asyncio.AbstractEventLoop):
+        self.queue = Queue()
+        loop.create_task(self.writer())
+
+    async def writer(self):
+        raise NotImplementedError
+
+    @asynccontextmanager
+    async def read_queue(self):
+        update = await self.queue.get()
+        yield update
+        self.queue.task_done()
 
 
 class BackendBookCallback:

--- a/cryptofeed/backends/redis.py
+++ b/cryptofeed/backends/redis.py
@@ -5,14 +5,15 @@ Please see the LICENSE file for the terms and conditions
 associated with this software.
 '''
 import aioredis
+
 from yapic import json
 
-from cryptofeed.backends.backend import (BackendBookCallback, BackendBookDeltaCallback, BackendFundingCallback,
+from cryptofeed.backends.backend import (BackendQueue, BackendBookCallback, BackendBookDeltaCallback, BackendFundingCallback,
                                          BackendOpenInterestCallback, BackendTickerCallback, BackendTradeCallback,
                                          BackendLiquidationsCallback, BackendMarketInfoCallback, BackendTransactionsCallback)
 
 
-class RedisCallback:
+class RedisCallback(BackendQueue):
     def __init__(self, host='127.0.0.1', port=6379, socket=None, key=None, numeric_type=float, **kwargs):
         """
         setting key lets you override the prefix on the
@@ -28,16 +29,28 @@ class RedisCallback:
 class RedisZSetCallback(RedisCallback):
     async def write(self, feed: str, symbol: str, timestamp: float, receipt_timestamp: float, data: dict):
         data = json.dumps(data)
-        if self.redis is None:
-            self.redis = await aioredis.create_redis_pool(self.conn_str)
-        await self.redis.zadd(f"{self.key}-{feed}-{symbol}", timestamp, data, exist=self.redis.ZSET_IF_NOT_EXIST)
+        await self.queue.put({'feed': feed, 'symbol': symbol, 'timestamp': timestamp, 'receipt_timestamp': receipt_timestamp, 'data': data})
+
+    async def writer(self):
+        while True:
+            if self.redis is None:
+                self.redis = await aioredis.create_redis_pool(self.conn_str)
+
+            async with self.read_queue() as update:
+                await self.redis.zadd(f"{self.key}-{update['feed']}-{update['symbol']}", update['timestamp'], update['data'], exist=self.redis.ZSET_IF_NOT_EXIST)
 
 
 class RedisStreamCallback(RedisCallback):
     async def write(self, feed: str, symbol: str, timestamp: float, receipt_timestamp: float, data: dict):
-        if self.redis is None:
-            self.redis = await aioredis.create_redis_pool(self.conn_str)
-        await self.redis.xadd(f"{self.key}-{feed}-{symbol}", data)
+        await self.queue.put({'feed': feed, 'symbol': symbol, 'timestamp': timestamp, 'receipt_timestamp': receipt_timestamp, 'data': data})
+
+    async def writer(self):
+        while True:
+            if self.redis is None:
+                self.redis = await aioredis.create_redis_pool(self.conn_str)
+
+            async with self.read_queue() as update:
+                await self.redis.xadd(f"{self.key}-{update['feed']}-{update['symbol']}", update['data'])
 
 
 class TradeRedis(RedisZSetCallback, BackendTradeCallback):

--- a/cryptofeed/backends/redis.py
+++ b/cryptofeed/backends/redis.py
@@ -5,7 +5,6 @@ Please see the LICENSE file for the terms and conditions
 associated with this software.
 '''
 import aioredis
-
 from yapic import json
 
 from cryptofeed.backends.backend import (BackendQueue, BackendBookCallback, BackendBookDeltaCallback, BackendFundingCallback,

--- a/cryptofeed/feed.py
+++ b/cryptofeed/feed.py
@@ -270,3 +270,12 @@ class Feed:
                     LOG.info('%s: stopping backend %s', self.id, cb_name)
                     await callback.stop()
         LOG.info('%s: feed shutdown completed', self.id)
+
+    def start(self, loop):
+        for callbacks in self.callbacks.values():
+            for callback in callbacks:
+                if hasattr(callback, 'start'):
+                    cb_name = callback.__class__.__name__ if hasattr(callback, '__class__') else callback.__name__
+                    LOG.info('%s: starting backend task %s', self.id, cb_name)
+                    # Backends start tasks to write messages
+                    callback.start(loop)

--- a/cryptofeed/feedhandler.py
+++ b/cryptofeed/feedhandler.py
@@ -255,6 +255,7 @@ class FeedHandler:
                 conn.set_raw_data_callback(self.raw_message_capture)
                 loop.create_task(self._connect(conn, sub, handler))
                 self.timeout[conn.uuid] = timeout
+                feed.start(loop)
 
         if not start_loop:
             return

--- a/cryptofeed/rest/bitmex.py
+++ b/cryptofeed/rest/bitmex.py
@@ -20,7 +20,8 @@ from sortedcontainers import SortedDict as sd
 
 from cryptofeed.defines import BID, ASK, BITMEX, BUY, SELL
 from cryptofeed.rest.api import API, request_retry
-from cryptofeed.standards import timestamp_normalize
+from cryptofeed.standards import timestamp_normalize, symbol_std_to_exchange, symbol_exchange_to_std
+
 
 
 S3_ENDPOINT = 'https://s3-eu-west-1.amazonaws.com/public.bitmex.com/data/{}/{}.csv.gz'
@@ -123,7 +124,7 @@ class Bitmex(API):
     def _trade_normalization(self, trade: dict) -> dict:
         return {
             'timestamp': timestamp_normalize(self.ID, trade['timestamp']),
-            'symbol': trade['symbol'],
+            'symbol': symbol_exchange_to_std(trade['symbol']),
             'id': trade['trdMatchID'],
             'feed': self.ID,
             'side': BUY if trade['side'] == 'Buy' else SELL,
@@ -133,6 +134,8 @@ class Bitmex(API):
 
     def ticker(self, symbol, start=None, end=None, retry=None, retry_wait=10):
         # return list(self._get('quote', symbol, start, end, retry, retry_wait))
+        symbol = symbol_std_to_exchange(symbol, self.ID)
+
         for data in self._scrape_s3(symbol, 'quote', start, end):
             yield data
 
@@ -153,6 +156,8 @@ class Bitmex(API):
             'foreignNotional': 1900
         }
         """
+        symbol = symbol_std_to_exchange(symbol, self.ID)
+
         d = dt.utcnow().date()
         d -= timedelta(days=1)
         rest_end_date = pd.Timestamp(dt(d.year, d.month, d.day))
@@ -180,7 +185,7 @@ class Bitmex(API):
     def _funding_normalization(self, funding: dict) -> dict:
         return {
             'timestamp': funding['timestamp'],
-            'symbol': funding['symbol'],
+            'symbol': symbol_exchange_to_std(funding['symbol']),
             'feed': self.ID,
             'interval': funding['fundingInterval'],
             'rate': funding['fundingRate'],
@@ -202,7 +207,7 @@ class Bitmex(API):
 
     def l2_book(self, symbol: str, retry=None, retry_wait=10):
         ret = {symbol: {BID: sd(), ASK: sd()}}
-        data = next(self._get('orderBook/L2', symbol, None, None, retry, retry_wait))
+        data = next(self._get('orderBook/L2', symbol_std_to_exchange(symbol, self.ID), None, None, retry, retry_wait))
         for update in data:
             side = ASK if update['side'] == 'Sell' else BID
             ret[symbol][side][update['price']] = update['size']
@@ -212,7 +217,7 @@ class Bitmex(API):
         vals = data.split(",")
         return {
             'timestamp': pd.Timestamp(vals[0].replace("D", "T")).timestamp(),
-            'symbol': vals[1],
+            'symbol': symbol_exchange_to_std(vals[1]),
             'id': vals[6],
             'feed': self.ID,
             'side': BUY if vals[2] == 'Buy' else SELL,

--- a/cryptofeed/rest/rest.py
+++ b/cryptofeed/rest/rest.py
@@ -28,7 +28,7 @@ class Rest:
     The rest class is a common interface for accessing the individual exchanges
 
     r = Rest()
-    r.bitmex.trades('XBTUSD', '2018-01-01', '2018-01-01')
+    r.bitmex.trades('BTC-USD', '2018-01-01', '2018-01-01')
 
     The Rest class optionally takes two exchange-related parameters, config, and sandbox.
     In the config file the api key and secrets can be specified. Sandbox enables sandbox

--- a/examples/demo_arctic.py
+++ b/examples/demo_arctic.py
@@ -12,7 +12,7 @@ from cryptofeed.exchanges import Bitfinex, Bitmex, Coinbase
 
 def main():
     f = FeedHandler()
-    f.add_feed(Bitmex(channels=[TRADES, FUNDING], symbols=['XBTUSD'], callbacks={TRADES: TradeArctic('cryptofeed-test'), FUNDING: FundingArctic('cryptofeed-test')}))
+    f.add_feed(Bitmex(channels=[TRADES, FUNDING], symbols=['BTC-USD'], callbacks={TRADES: TradeArctic('cryptofeed-test'), FUNDING: FundingArctic('cryptofeed-test')}))
     f.add_feed(Bitfinex(channels=[TRADES], symbols=['BTC-USD'], callbacks={TRADES: TradeArctic('cryptofeed-test')}))
     f.add_feed(Coinbase(channels=[TICKER], symbols=['BTC-USD'], callbacks={TICKER: TickerArctic('cryptofeed-test')}))
     f.run()

--- a/examples/demo_bitmex_config.py
+++ b/examples/demo_bitmex_config.py
@@ -74,7 +74,7 @@ def main():
 
     # When using the following no need to pass config when using 'BITMEX'
     f.add_feed('BITMEX', symbols=bitmex_symbols, channels=[FUNDING], callbacks={FUNDING: FundingCallback(print_all)})
-    f.add_feed('BITMEX', symbols=['XBTUSD'], channels=[L2_BOOK], callbacks={L2_BOOK: BookCallback(print_all)})
+    f.add_feed('BITMEX', symbols=['BTC-USD'], channels=[L2_BOOK], callbacks={L2_BOOK: BookCallback(print_all)})
 
     f.run()
 

--- a/examples/demo_book_delta.py
+++ b/examples/demo_book_delta.py
@@ -74,7 +74,7 @@ class DeltaBook(object):
 
 def main():
     f = FeedHandler()
-    f.add_feed(Bitmex(max_depth=100, book_interval=1000, symbols=['XBTUSD'], channels=[L2_BOOK], callbacks=DeltaBook("Bitmex").L2))
+    f.add_feed(Bitmex(max_depth=100, book_interval=1000, symbols=['BTC-USD'], channels=[L2_BOOK], callbacks=DeltaBook("Bitmex").L2))
     f.add_feed(Bitfinex(symbols=['BTC-USD'], channels=[L3_BOOK], callbacks=DeltaBook("Bitfinex-L3").L3))
     f.add_feed(Bitfinex(max_depth=100, symbols=['BTC-USD'], channels=[L2_BOOK], callbacks=DeltaBook("Bitfinex-L2").L2))
     f.add_feed(Coinbase(symbols=['BTC-USD'], channels=[L3_BOOK], callbacks=DeltaBook("Coinbase-L3").L3))

--- a/examples/demo_check_trade_timestamps.py
+++ b/examples/demo_check_trade_timestamps.py
@@ -86,7 +86,7 @@ def main():
     exch_sym_map = {}
     exch_sym_map['Binance'] = ['BTC-USDT', 'BTC-USDC', 'BTC-TUSD']
     exch_sym_map['Bitfinex'] = ['BTC-USD']
-    exch_sym_map['BitMEX'] = ['XBTUSD']
+    exch_sym_map['BitMEX'] = ['BTC-USD']
     exch_sym_map['Bitstamp'] = ['BTC-USD']
     exch_sym_map['Bybit'] = ['BTC-USD']
     exch_sym_map['Coinbase'] = ['BTC-USD']

--- a/examples/demo_elastic.py
+++ b/examples/demo_elastic.py
@@ -27,7 +27,7 @@ def main():
     f = FeedHandler()
 
     f.add_feed(Coinbase(channels=[L2_BOOK, TRADES], symbols=['BTC-USD'], callbacks={L2_BOOK: BookElastic('http://localhost:9200', numeric_type=float), BOOK_DELTA: BookDeltaElastic('http://localhost:9200', numeric_type=float), TRADES: TradeElastic('http://localhost:9200', numeric_type=float)}))
-    f.add_feed(Bitmex(channels=[FUNDING], symbols=['XBTUSD'], callbacks={FUNDING: FundingElastic('http://localhost:9200', numeric_type=float)}))
+    f.add_feed(Bitmex(channels=[FUNDING], symbols=['BTC-USD'], callbacks={FUNDING: FundingElastic('http://localhost:9200', numeric_type=float)}))
 
     f.run()
 

--- a/examples/demo_influxdb.py
+++ b/examples/demo_influxdb.py
@@ -13,7 +13,7 @@ from cryptofeed.exchanges import Bitmex, Coinbase
 def main():
 
     f = FeedHandler()
-    f.add_feed(Bitmex(channels=[FUNDING, L2_BOOK], symbols=['XBTUSD'], callbacks={FUNDING: FundingInflux('http://localhost:8086', 'example', create_db=True), L2_BOOK: BookInflux('http://localhost:8086', 'example', create_db=True, numeric_type=float), BOOK_DELTA: BookDeltaInflux('http://localhost:8086', 'example', create_db=True, numeric_type=float)}))
+    f.add_feed(Bitmex(channels=[FUNDING, L2_BOOK], symbols=['BTC-USD'], callbacks={FUNDING: FundingInflux('http://localhost:8086', 'example', create_db=True), L2_BOOK: BookInflux('http://localhost:8086', 'example', create_db=True, numeric_type=float), BOOK_DELTA: BookDeltaInflux('http://localhost:8086', 'example', create_db=True, numeric_type=float)}))
     f.add_feed(Coinbase(channels=[TRADES], symbols=['BTC-USD'], callbacks={TRADES: TradeInflux('http://localhost:8086', 'example', create_db=True)}))
     f.add_feed(Coinbase(channels=[L2_BOOK], symbols=['BTC-USD'], callbacks={L2_BOOK: BookInflux('http://localhost:8086', 'example', create_db=True, numeric_type=float), BOOK_DELTA: BookDeltaInflux('http://localhost:8086', 'example', create_db=True, numeric_type=float)}))
     f.add_feed(Coinbase(channels=[TICKER], symbols=['BTC-USD'], callbacks={TICKER: TickerInflux('http://localhost:8086', 'example', create_db=True, numeric_type=float)}))
@@ -35,7 +35,7 @@ def main():
     bookdelta_influx = BookDeltaInflux(ADDR, org=ORG, bucket=BUCKET, token=TOKEN, numeric_type=float)
     ticker_influx = TickerInflux(ADDR, org=ORG, bucket=BUCKET, token=TOKEN, numeric_type=float)
 
-    f.add_feed(Bitmex(channels=[FUNDING, L2_BOOK],symbols=['XBTUSD'], callbacks={FUNDING: funding_influx, L2_BOOK: book_influx, BOOK_DELTA: bookdelta_influx}))
+    f.add_feed(Bitmex(channels=[FUNDING, L2_BOOK],symbols=['BTC-USD'], callbacks={FUNDING: funding_influx, L2_BOOK: book_influx, BOOK_DELTA: bookdelta_influx}))
     f.add_feed(Coinbase(channels=[TRADES], symbols=['BTC-USD'], callbacks={TRADES: trade_influx}))
     f.add_feed(Coinbase(channels=[L2_BOOK], symbols=['BTC-USD'], callbacks={L2_BOOK: book_influx, BOOK_DELTA: bookdelta_influx}))
     f.add_feed(Coinbase(channels=[TICKER], symbols=['BTC-USD'], callbacks={TICKER: ticker_influx}))

--- a/examples/demo_liquidations.py
+++ b/examples/demo_liquidations.py
@@ -12,7 +12,7 @@ def main():
 
     f = FeedHandler()
     # Liquidations happen not frequently, disable feed timeout
-    f.add_feed(Bitmex(channels=[LIQUIDATIONS], symbols=['XBTUSD'], callbacks={LIQUIDATIONS: LiquidationCallback(liquidations)}), timeout=-1)
+    f.add_feed(Bitmex(channels=[LIQUIDATIONS], symbols=['BTC-USD'], callbacks={LIQUIDATIONS: LiquidationCallback(liquidations)}), timeout=-1)
     f.run()
 
 

--- a/examples/demo_open_interest.py
+++ b/examples/demo_open_interest.py
@@ -11,7 +11,7 @@ from cryptofeed.exchanges import Bitmex
 
 def main():
     f = FeedHandler()
-    f.add_feed(Bitmex(symbols=['XBTUSD'], channels=[TRADES, OPEN_INTEREST], callbacks={
+    f.add_feed(Bitmex(symbols=['BTC-USD'], channels=[TRADES, OPEN_INTEREST], callbacks={
                OPEN_INTEREST: OpenInterestArctic('cryptofeed-test2'), TRADES: TradeArctic('cryptofeed-test2')}))
 
     f.run()

--- a/examples/demo_redis.py
+++ b/examples/demo_redis.py
@@ -12,8 +12,7 @@ from cryptofeed.exchanges import Bitfinex, Bitmex, Coinbase, Gemini
 
 def main():
     f = FeedHandler()
-    f.add_feed(Bitmex(channels=[TRADES, FUNDING, OPEN_INTEREST], symbols=['XBTUSD'], callbacks={
-               TRADES: TradeRedis(), FUNDING: FundingRedis(), OPEN_INTEREST: OpenInterestRedis()}))
+    f.add_feed(Bitmex(channels=[TRADES, FUNDING, OPEN_INTEREST], symbols=['BTC-USD'], callbacks={TRADES: TradeRedis(), FUNDING: FundingRedis(), OPEN_INTEREST: OpenInterestRedis()}))
     f.add_feed(Bitfinex(channels=[TRADES], symbols=['BTC-USD'], callbacks={TRADES: TradeRedis()}))
     f.add_feed(Coinbase(channels=[TRADES], symbols=['BTC-USD'], callbacks={TRADES: TradeRedis()}))
     f.add_feed(Coinbase(max_depth=10, channels=[L2_BOOK], symbols=['BTC-USD'], callbacks={L2_BOOK: BookRedis()}))

--- a/examples/demo_renko.py
+++ b/examples/demo_renko.py
@@ -19,7 +19,7 @@ async def renko(data=None):
 
 def main():
     f = FeedHandler()
-    f.add_feed(Bitmex(symbols=['XBTUSD'], channels=[TRADES], callbacks={
+    f.add_feed(Bitmex(symbols=['BTC-USD'], channels=[TRADES], callbacks={
                TRADES: RenkoFixed(Callback(renko), brick_size=3)}))
 
     f.run()

--- a/tests/integration/rest/test_rest.py
+++ b/tests/integration/rest/test_rest.py
@@ -9,7 +9,7 @@ def test_rest_bitmex():
     ret = []
     end = pd.Timestamp.now()
     start = end - pd.Timedelta(minutes=2)
-    for data in r.bitmex.trades('XBTUSD', start=start, end=end):
+    for data in r.bitmex.trades('BTC-USD', start=start, end=end):
         ret.extend(data)
 
     assert len(ret) > 0

--- a/tools/book_test.py
+++ b/tools/book_test.py
@@ -49,7 +49,7 @@ async def book(feed, symbol, book, timestamp):
 def main():
     f = FeedHandler()
 
-    f.add_feed(Bitmex(symbols=['XBTUSD'], channels=[L2_BOOK], callbacks={L2_BOOK: BookCallback(book)}))
+    f.add_feed(Bitmex(symbols=['BTC-USD'], channels=[L2_BOOK], callbacks={L2_BOOK: BookCallback(book)}))
     f.run()
 
 


### PR DESCRIPTION
Create separate async task for backends. Tasks receive messages to write via async queue. This allows read and write to happen on separate tasks, leading to increased throughput and reduced latency
