### PR TITLE
Victoriametrics backend

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,7 @@
   * Bugfix: Allow user specified max depths on Kraken
   * Feature: Add backend queue support to ZMQ backend
   * Feature: Add backend queue support to Socket backends
+  * Feature: Add VictoriaMetrics support via backend
 
 ### 1.7.0 (2021-02-15)
   * Feature: Use UVLoop if installed (not available on windows)
@@ -89,7 +90,7 @@
 ### 1.6.1 (2020-11-12)
   * Feature: New kwarg for exchange feed - `snapshot_interval` - used to control number of snapshot updates sent to client
   * Feature: Support for rabbitmq message routing
-  * Feature: Support for raw file playback. Will be useful for testing features and building out new test suites for cryptofeed. 
+  * Feature: Support for raw file playback. Will be useful for testing features and building out new test suites for cryptofeed.
   * Feature: Arctic library quota can be configured, new default is unlimited
   * Feature: New exchange: Probit
   * Bugfix: Correctly store receipt timestamp in mongo backend
@@ -97,7 +98,7 @@
   * Bugfix: Open Interest data on FTX erroneously had timestamps set to None
   * Update: Binance Jersey shutdown - feed removed
   * Bugfix: Fixed open interest channel for Binance Delivery
-  
+
 ### 1.6.0 (2020-09-28)
   * Feature: Validate FTX book checksums (optionally enabled)
   * Bugfix: Subscribing only to open interest on Binance futures gave connection errors
@@ -314,7 +315,7 @@
 
 ### 0.17.3 (2018-11-17)
   * Feature #41: Rework trading pairs to generate them dynamically (as opposed to hard coded)
-  * Feature: When book depth configured Redis, ZMQ and UDP backends only report book changes when changed occurred in 
+  * Feature: When book depth configured Redis, ZMQ and UDP backends only report book changes when changed occurred in
              depth window
   * Feature: TCP socket backend support
   * Feature: UDS backend support
@@ -352,7 +353,7 @@
   * Added some docstrings
   * Feature: Add exchanges by name to feedhandler. Easier to instantiate a feedhandler from config
   * Logging improvements
-  * Bugfix: non-gathered futures were suppressing exceptions when multiple feeds are configured. Changed to tasks 
+  * Bugfix: non-gathered futures were suppressing exceptions when multiple feeds are configured. Changed to tasks
   * Redis backend uses a connection pool
 
 ### 0.14.0 (2018-09-04)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,7 @@
   * Feature: Use separate tasks (fed by async queue) for backend writing. Redis now uses this method
   * Bugfix: Allow user specified max depths on Kraken
   * Feature: Add backend queue support to ZMQ backend
+  * Feature: Add backend queue support to Socket backends
 
 ### 1.7.0 (2021-02-15)
   * Feature: Use UVLoop if installed (not available on windows)

--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ Supported Backends:
 * RabbitMQ
 * PostgreSQL
 * GCP Pub/Sub
+* [VictoriaMetrics](https://github.com/VictoriaMetrics/VictoriaMetrics)
 
 
 ## Installation
@@ -154,11 +155,11 @@ Cryptofeed can be installed from PyPi. (It's recommended that you install in a v
 Cryptofeed has optional dependencies, depending on the backends used. You can install them individually, or all at once. To install Cryptofeed along with all its optional dependencies in one bundle:
 
     pip install cryptofeed[all]
-    
+
 If you wish to clone the repository and install from source, run this command from the root of the cloned repository
 
     python setup.py install
-    
+
 Alternatively, you can install in 'edit' mode (also called development mode):
 
     python setup.py develop

--- a/cryptofeed/backends/victoriametrics.py
+++ b/cryptofeed/backends/victoriametrics.py
@@ -1,0 +1,87 @@
+'''
+Copyright (C) 2017-2021  Bryant Moscon - bmoscon@gmail.com
+
+Please see the LICENSE file for the terms and conditions
+associated with this software.
+'''
+import logging
+
+from cryptofeed.backends.backend import (BackendQueue, BackendBookCallback, BackendBookDeltaCallback, BackendFundingCallback,
+                                         BackendOpenInterestCallback, BackendTickerCallback, BackendTradeCallback,
+                                         BackendLiquidationsCallback, BackendMarketInfoCallback, BackendTransactionsCallback)
+from cryptofeed.backends.socket import SocketCallback
+
+from typing import Optional
+
+
+LOG = logging.getLogger('feedhandler')
+
+
+class VictoriaMetricsCallback(SocketCallback):
+    def __init__(self, addr: str, port: int, key: Optional[str] = None, **kwargs):
+        """
+        Parent class for VictoriaMetrics callbacks
+
+        VictoriaMetrics support multiple protocol for data ingestion.
+        In the following implementation we present data in InfluxDB Line Protocol format.
+
+        influxDB schema
+        ---------------
+        MEASUREMENT | TAGS | FIELDS
+
+        Measurement: Data Feed-Exchange (configurable)
+        TAGS: symbol
+        FIELDS: timestamp, amount, price, other funding specific fields
+
+        InfluxDB Line Protocol to VictoriaMetrics storage
+        -------------------------------------------------
+        Please note that Field names are mapped to time series names prefixed with
+        {measurement}{separator} value, where {separator} equals to _ by default.
+        It can be changed with -influxMeasurementFieldSeparator command-line flag.
+
+        For example, the following Influx line:
+            foo,tag1=value1,tag2=value2 field1=12,field2=40
+
+        is converted into the following Prometheus data points:
+            foo_field1{tag1="value1", tag2="value2"} 12
+            foo_field2{tag1="value1", tag2="value2"} 40
+
+        Ref: https://github.com/VictoriaMetrics/VictoriaMetrics#how-to-send-data-from-influxdb-compatible-agents-such-as-telegraf
+
+        Parameters
+        ----------
+        addr: str
+          Address for connection. Should be in the format:
+          <protocol>://<address>
+          Example:
+          tcp://127.0.0.1
+          udp://127.0.0.1
+         port: int
+           port for connection.
+         key: str
+           key to use when writing data
+        """
+        super().__init__(addr, port=port, key=key, numeric_type=float, **kwargs)
+
+    async def write(self, feed, symbol, timestamp, receipt_timestamp, data):
+        # Convert data to InfluxDB Line Protocol format
+        d = ''
+        t = ''
+        for key, value in data.items():
+            if key in {'timestamp', 'feed', 'symbol', 'receipt_timestamp'}:
+                continue
+            # VictoriaMetrics does not support discrete data as values,
+            # convert strings to InfluxDB tags.
+            if isinstance(value, str):
+                t += f'{key}={value},'
+            else:
+                d += f'{key}={value},'
+        d = d[:-1]
+        t = t[:-1]
+
+        update = f'{self.key},feed={feed},symbol={symbol},{t} {d},timestamp={timestamp},receipt_timestamp={receipt_timestamp}\n'
+        await self.queue.put(update)
+
+
+class TradeVictoriaMetrics(VictoriaMetricsCallback, BackendTradeCallback):
+    default_key = 'trades'

--- a/cryptofeed/backends/victoriametrics.py
+++ b/cryptofeed/backends/victoriametrics.py
@@ -6,11 +6,11 @@ associated with this software.
 '''
 import logging
 
-from cryptofeed.backends.backend import (BackendQueue, BackendBookCallback, BackendBookDeltaCallback, BackendFundingCallback,
+from cryptofeed.backends.backend import (BackendBookCallback, BackendBookDeltaCallback, BackendFundingCallback,
                                          BackendOpenInterestCallback, BackendTickerCallback, BackendTradeCallback,
                                          BackendLiquidationsCallback, BackendMarketInfoCallback, BackendTransactionsCallback)
 from cryptofeed.backends.socket import SocketCallback
-
+from cryptofeed.defines import BID, ASK
 from typing import Optional
 
 
@@ -25,7 +25,7 @@ class VictoriaMetricsCallback(SocketCallback):
         VictoriaMetrics support multiple protocol for data ingestion.
         In the following implementation we present data in InfluxDB Line Protocol format.
 
-        influxDB schema
+        InfluxDB schema
         ---------------
         MEASUREMENT | TAGS | FIELDS
 
@@ -39,14 +39,14 @@ class VictoriaMetricsCallback(SocketCallback):
         {measurement}{separator} value, where {separator} equals to _ by default.
         It can be changed with -influxMeasurementFieldSeparator command-line flag.
 
-        For example, the following Influx line:
+        For example, the following InfluxDB line:
             foo,tag1=value1,tag2=value2 field1=12,field2=40
 
         is converted into the following Prometheus data points:
             foo_field1{tag1="value1", tag2="value2"} 12
             foo_field2{tag1="value1", tag2="value2"} 40
 
-        Ref: https://github.com/VictoriaMetrics/VictoriaMetrics#how-to-send-data-from-influxdb-compatible-agents-such-as-telegraf
+        Ref: Ref: https://github.com/VictoriaMetrics/VictoriaMetrics#how-to-send-data-from-influxdb-compatible-agents-such-as-telegraf
 
         Parameters
         ----------
@@ -71,17 +71,69 @@ class VictoriaMetricsCallback(SocketCallback):
             if key in {'timestamp', 'feed', 'symbol', 'receipt_timestamp'}:
                 continue
             # VictoriaMetrics does not support discrete data as values,
-            # convert strings to InfluxDB tags.
+            # convert strings to VictoriaMetricsDB tags.
             if isinstance(value, str):
-                t += f'{key}={value},'
+                t += f',{key}={value}'
             else:
                 d += f'{key}={value},'
-        d = d[:-1]
-        t = t[:-1]
 
-        update = f'{self.key},feed={feed},symbol={symbol},{t} {d},timestamp={timestamp},receipt_timestamp={receipt_timestamp}\n'
+        update = f'{self.key},feed={feed},symbol={symbol}{t} {d}timestamp={timestamp},receipt_timestamp={receipt_timestamp}\n'
         await self.queue.put(update)
+
+
+class VictoriaMetricsBookCallback(VictoriaMetricsCallback):
+    default_key = 'book'
+
+    async def _write_rows(self, start, data, timestamp, receipt_timestamp):
+        msg = []
+        ts = int(timestamp * 1000000000)
+        for side in (BID, ASK):
+            for price, val in data[side].items():
+                if isinstance(val, dict):
+                    for order_id, amount in val.items():
+                        msg.append(f'{start},side={side} id={order_id},receipt_timestamp={receipt_timestamp},timestamp={timestamp},price={price},amount={amount} {ts}')
+                        ts += 1
+                else:
+                    msg.append(f'{start},side={side} receipt_timestamp={receipt_timestamp},timestamp={timestamp},price={price},amount={val} {ts}')
+                    ts += 1
+        await self.queue.put('\n'.join(msg) + '\n')
 
 
 class TradeVictoriaMetrics(VictoriaMetricsCallback, BackendTradeCallback):
     default_key = 'trades'
+
+
+class FundingVictoriaMetrics(VictoriaMetricsCallback, BackendFundingCallback):
+    default_key = 'funding'
+
+
+class BookVictoriaMetrics(VictoriaMetricsBookCallback, BackendBookCallback):
+    async def write(self, feed, symbol, timestamp, receipt_timestamp, data):
+        start = f"{self.key},feed={feed},symbol={symbol},delta=False"
+        await self._write_rows(start, data, timestamp, receipt_timestamp)
+
+
+class BookDeltaVictoriaMetrics(VictoriaMetricsBookCallback, BackendBookDeltaCallback):
+    async def write(self, feed, symbol, timestamp, receipt_timestamp, data):
+        start = f"{self.key},feed={feed},symbol={symbol},delta=True"
+        await self._write_rows(start, data, timestamp, receipt_timestamp)
+
+
+class TickerVictoriaMetrics(VictoriaMetricsCallback, BackendTickerCallback):
+    default_key = 'ticker'
+
+
+class OpenInterestVictoriaMetrics(VictoriaMetricsCallback, BackendOpenInterestCallback):
+    default_key = 'open_interest'
+
+
+class LiquidationsVictoriaMetrics(VictoriaMetricsCallback, BackendLiquidationsCallback):
+    default_key = 'liquidations'
+
+
+class MarketInfoVictoriaMetrics(VictoriaMetricsCallback, BackendMarketInfoCallback):
+    default_key = 'market_info'
+
+
+class TransactionsVictoriaMetrics(VictoriaMetricsCallback, BackendTransactionsCallback):
+    default_key = 'transactions'

--- a/cryptofeed/backends/victoriametrics.py
+++ b/cryptofeed/backends/victoriametrics.py
@@ -6,7 +6,7 @@ associated with this software.
 '''
 import logging
 
-from cryptofeed.backends.backend import (BackendBookCallback, BackendBookDeltaCallback, BackendFundingCallback,
+from cryptofeed.backends.backend import (BackendBookCallback, BackendBookDeltaCallback, BackendCandlesCallback, BackendFundingCallback,
                                          BackendOpenInterestCallback, BackendTickerCallback, BackendTradeCallback,
                                          BackendLiquidationsCallback, BackendMarketInfoCallback, BackendTransactionsCallback)
 from cryptofeed.backends.socket import SocketCallback
@@ -137,3 +137,7 @@ class MarketInfoVictoriaMetrics(VictoriaMetricsCallback, BackendMarketInfoCallba
 
 class TransactionsVictoriaMetrics(VictoriaMetricsCallback, BackendTransactionsCallback):
     default_key = 'transactions'
+
+
+class CandlesVictoriaMetrics(VictoriaMetricsCallback, BackendCandlesCallback):
+    default_key = 'candles'

--- a/examples/demo_victoriametrics.py
+++ b/examples/demo_victoriametrics.py
@@ -5,9 +5,9 @@ Please see the LICENSE file for the terms and conditions
 associated with this software.
 '''
 from cryptofeed import FeedHandler
-from cryptofeed.backends.victoriametrics import TradeVictoriaMetrics, TickerVictoriaMetrics, BookVictoriaMetrics, BookDeltaVictoriaMetrics
-from cryptofeed.defines import TRADES, TICKER, L2_BOOK, BOOK_DELTA
-from cryptofeed.exchanges import Coinbase
+from cryptofeed.backends.victoriametrics import TradeVictoriaMetrics, TickerVictoriaMetrics, BookVictoriaMetrics, BookDeltaVictoriaMetrics, CandlesVictoriaMetrics
+from cryptofeed.defines import TRADES, TICKER, L2_BOOK, BOOK_DELTA, CANDLES
+from cryptofeed.exchanges import Coinbase, Binance
 
 
 def main():
@@ -18,6 +18,7 @@ def main():
     f.add_feed(Coinbase(channels=[TRADES], symbols=['BTC-USD'], callbacks={TRADES: TradeVictoriaMetrics(addr, port, 'demo-trades')}))
     f.add_feed(Coinbase(channels=[TICKER], symbols=['BTC-USD'], callbacks={TICKER: TickerVictoriaMetrics(addr, port, 'demo-tickers')}))
     f.add_feed(Coinbase(channels=[L2_BOOK], symbols=['BTC-USD'], callbacks={L2_BOOK: BookVictoriaMetrics(addr, port, 'demo-book'), BOOK_DELTA: BookDeltaVictoriaMetrics(addr, port, 'demo-book')}))
+    f.add_feed(Binance(channels=[CANDLES], symbols=['BTC-USDT'], callbacks={CANDLES: CandlesVictoriaMetrics(addr, port, 'demo-candles')}))
 
     f.run()
 

--- a/examples/demo_victoriametrics.py
+++ b/examples/demo_victoriametrics.py
@@ -5,8 +5,8 @@ Please see the LICENSE file for the terms and conditions
 associated with this software.
 '''
 from cryptofeed import FeedHandler
-from cryptofeed.backends.victoriametrics import TradeVictoriaMetrics
-from cryptofeed.defines import TRADES
+from cryptofeed.backends.victoriametrics import TradeVictoriaMetrics, TickerVictoriaMetrics, BookVictoriaMetrics, BookDeltaVictoriaMetrics
+from cryptofeed.defines import TRADES, TICKER, L2_BOOK, BOOK_DELTA
 from cryptofeed.exchanges import Coinbase
 
 
@@ -16,6 +16,8 @@ def main():
 
     f = FeedHandler()
     f.add_feed(Coinbase(channels=[TRADES], symbols=['BTC-USD'], callbacks={TRADES: TradeVictoriaMetrics(addr, port, 'demo-trades')}))
+    f.add_feed(Coinbase(channels=[TICKER], symbols=['BTC-USD'], callbacks={TICKER: TickerVictoriaMetrics(addr, port, 'demo-tickers')}))
+    f.add_feed(Coinbase(channels=[L2_BOOK], symbols=['BTC-USD'], callbacks={L2_BOOK: BookVictoriaMetrics(addr, port, 'demo-book'), BOOK_DELTA: BookDeltaVictoriaMetrics(addr, port, 'demo-book')}))
 
     f.run()
 

--- a/examples/demo_victoriametrics.py
+++ b/examples/demo_victoriametrics.py
@@ -1,0 +1,24 @@
+'''
+Copyright (C) 2018-2021  Bryant Moscon - bmoscon@gmail.com
+
+Please see the LICENSE file for the terms and conditions
+associated with this software.
+'''
+from cryptofeed import FeedHandler
+from cryptofeed.backends.victoriametrics import TradeVictoriaMetrics
+from cryptofeed.defines import TRADES
+from cryptofeed.exchanges import Coinbase
+
+
+def main():
+    addr = 'tcp://localhost'
+    port = 8189
+
+    f = FeedHandler()
+    f.add_feed(Coinbase(channels=[TRADES], symbols=['BTC-USD'], callbacks={TRADES: TradeVictoriaMetrics(addr, port, 'demo-trades')}))
+
+    f.run()
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
### VictoriaMetrics Backend

This PR aims to add support for VictoriaMetrics backend storage.

VictoriaMetrics supports multiple protocols for data ingestion.
In this implementation we format data in InfluxDB Line Protocol and send it over TCP/UDP sockets.

All Callback classes have been implemented: trades, tickers, funding, order book, open interest, liquidations, market info, transactions. For Order Book processing and serialisation, VictoriaMetrics backend classes borrow the same implementation as the InfluxDB backend.

A demo script is included to test the new VictoriaMetrics backend. This script has been tested with VictoriaMetrics v1.55.1 docker image with CL option `-influxListenAddr :TCP_PORT`


- [x] - Tested
- [x] - Changelog updated
- [x] - Tests run with one failure on Bitmex REST API (code not changed by this PR)
- [x] - Flake8 run and all errors/warnings resolved
- [ ] - Contributors file updated (optional)
