### PR TITLE
support for authenticated channel on Okex (and by default OKCoin)

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -44,3 +44,11 @@ binance_futures:
 binance_delivery:
     key_id: null
     key_secret: null
+okcoin:
+    key_id: null
+    key_secret: null
+    key_passphrase: null
+okex:
+    key_id: null
+    key_secret: null
+    key_passphrase: null

--- a/cryptofeed/auth/okcoin.py
+++ b/cryptofeed/auth/okcoin.py
@@ -1,0 +1,36 @@
+'''
+Copyright (C) 2017-2021  Bryant Moscon - bmoscon@gmail.com
+
+Please see the LICENSE file for the terms and conditions
+associated with this software.
+'''
+import base64
+import hmac
+import requests
+from dateutil.parser import parse
+
+def get_server_time():
+    url = "https://www.okex.com/api/general/v3/time"
+    response = requests.get(url)
+    if response.status_code == 200:
+        return response.json()['iso']
+    else:
+        return ""
+
+def server_timestamp():
+    server_time = get_server_time()
+    parsed_t = parse(server_time)
+    timestamp = parsed_t.timestamp()
+    return timestamp
+
+def create_sign(timestamp: str, key_secret: str):
+    message = timestamp + 'GET' + '/users/self/verify'
+    mac = hmac.new(bytes(key_secret, encoding='utf8'), bytes(message, encoding='utf-8'), digestmod='sha256')
+    d = mac.digest()
+    sign = base64.b64encode(d)
+    return sign
+
+def generate_token(key_id: str, key_secret: str) -> dict:
+    timestamp = str(server_timestamp())
+    sign = create_sign(timestamp, key_secret)
+    return timestamp, sign

--- a/cryptofeed/exchange/okcoin.py
+++ b/cryptofeed/exchange/okcoin.py
@@ -4,19 +4,25 @@ Copyright (C) 2017-2021  Bryant Moscon - bmoscon@gmail.com
 Please see the LICENSE file for the terms and conditions
 associated with this software.
 '''
+import asyncio
+import time
+
 from decimal import Decimal
 from itertools import islice
 import logging
+import websockets
 import zlib
+from typing import List, Tuple, Callable
 
 from sortedcontainers import SortedDict as sd
 from yapic import json
 
+from cryptofeed.auth.okcoin import generate_token
 from cryptofeed.connection import AsyncConnection
-from cryptofeed.defines import ASK, BID, BUY, FUNDING, L2_BOOK, OKCOIN, OPEN_INTEREST, SELL, TICKER, TRADES, LIQUIDATIONS
+from cryptofeed.defines import ASK, BID, BUY, FUNDING, L2_BOOK, OKCOIN, OPEN_INTEREST, SELL, TICKER, TRADES, LIQUIDATIONS, ORDER_INFO
 from cryptofeed.exceptions import BadChecksum
 from cryptofeed.feed import Feed
-from cryptofeed.standards import symbol_exchange_to_std, timestamp_normalize
+from cryptofeed.standards import symbol_exchange_to_std, timestamp_normalize, is_authenticated_channel
 from cryptofeed.symbols import get_symbol_separator
 from cryptofeed.util import split
 
@@ -70,6 +76,7 @@ class OKCoin(Feed):
         for chunk in split.list_by_max_items(symbol_channels, 33):
             LOG.info("%s: Subscribe to %s args from %r to %r", self.id, len(chunk), chunk[0], chunk[-1])
             request = {"op": "subscribe", "args": chunk}
+            print('request is:', request)
             await conn.send(json.dumps(request))
 
     @staticmethod
@@ -85,14 +92,15 @@ class OKCoin(Feed):
 
     def get_channel_symbol_combinations(self):
         for chan in set(self.channels or self.subscription):
-            if chan == LIQUIDATIONS:
-                continue
-            for symbol in set(self.symbols or self.subscription[chan]):
-                instrument_type = self.instrument_type(symbol)
-                if instrument_type != 'swap' and 'funding' in chan:
-                    continue  # No funding for spot, futures and options
-                yield f"{chan.format(instrument_type)}:{symbol}"
-
+            if not is_authenticated_channel(chan):
+                if chan == LIQUIDATIONS:
+                    continue
+                for symbol in set(self.symbols or self.subscription[chan]):
+                    instrument_type = self.instrument_type(symbol)
+                    if instrument_type != 'swap' and 'funding' in chan:
+                        continue  # No funding for spot, futures and options
+                    yield f"{chan.format(instrument_type)}:{symbol}"
+            
     async def _ticker(self, msg: dict, timestamp: float):
         """
         {'table': 'spot/ticker', 'data': [{'instrument_id': 'BTC-USD', 'last': '3977.74', 'best_bid': '3977.08', 'best_ask': '3978.73', 'open_24h': '3978.21', 'high_24h': '3995.43', 'low_24h': '3961.02', 'base_volume_24h': '248.245', 'quote_volume_24h': '988112.225861', 'timestamp': '2019-03-22T22:26:34.019Z'}]}
@@ -181,6 +189,30 @@ class OKCoin(Feed):
                 if self.checksum_validation and self.__calc_checksum(pair) != (update['checksum'] & 0xFFFFFFFF):
                     raise BadChecksum
                 await self.book_callback(self.l2_book[pair], L2_BOOK, pair, False, delta, timestamp_normalize(self.id, update['timestamp']), timestamp)
+                
+    
+    async def _order(self, msg: dict, timestamp: float):
+        if msg['data'][0]['status'] == "open":
+            status = "active"
+        else:
+            status = msg['data'][0]['status']
+
+        keys = ('filled_size', 'size', 'price', 'filled_notional')
+        data = {k: Decimal(msg['data'][0][k]) for k in keys if k in msg['data'][0]}
+
+        await self.callback(ORDER_INFO, feed=self.id,
+                            symbol=symbol_exchange_to_std(msg['data'][0]['instrument_id'].upper()),  # This uses the REST endpoint format (lower case)
+                            status=status,
+                            order_id=msg['data'][0]['order_id'],
+                            side=BUY if msg['data'][0]['side'].lower() == 'buy' else SELL,
+                            order_type=msg['data'][0]['order_type'],
+                            timestamp=msg['data'][0]['timestamp'].timestamp(),
+                            receipt_timestamp=timestamp,
+                            **data
+                            )
+        
+    async def _login(self, msg: dict, timestamp: float):
+        print(f"Login result: {msg}")
 
     async def message_handler(self, msg: str, conn, timestamp: float):
 
@@ -193,6 +225,12 @@ class OKCoin(Feed):
                 LOG.error("%s: Error: %s", self.id, msg)
             elif msg['event'] == 'subscribe':
                 pass
+            elif msg['event'] == 'login':
+                if msg['success'] == True:
+                    LOG.info('%s: Websocket authenticated successfully', self.id)
+                elif msg['success'] == False:
+                    LOG.info('%s: Websocket authentication failure', self.id)
+                await self._login(msg, timestamp)
             else:
                 LOG.warning("%s: Unhandled event %s", self.id, msg)
         elif 'table' in msg:
@@ -204,7 +242,30 @@ class OKCoin(Feed):
                 await self._book(msg, timestamp)
             elif 'swap/funding_rate' in msg['table']:
                 await self._funding(msg, timestamp)
+            elif 'spot/order' in msg['table']:
+                await self._order(msg, timestamp)
             else:
                 LOG.warning("%s: Unhandled message %s", self.id, msg)
         else:
             LOG.warning("%s: Unhandled message %s", self.id, msg)
+    
+    def connect(self) -> List[Tuple[AsyncConnection, Callable[[None], None], Callable[[str, float], None]]]:
+        ret = []
+        for channel in self.subscription or self.channels:
+            if is_authenticated_channel(channel):
+                ret.append((AsyncConnection(self.address, self.id, **self.ws_defaults), self.auth_subscribe, self.message_handler))
+            else:
+                ret.append((AsyncConnection(self.address, self.id, **self.ws_defaults), self.subscribe, self.message_handler))
+
+        return ret
+    
+    async def auth_subscribe(self, conn: AsyncConnection, options=None):
+        self.__reset()
+        timestamp, sign = generate_token(self.key_id, self.key_secret)            
+        login_param = {"op": "login", "args": [self.key_id, self.config.okex.key_passphrase, timestamp, sign.decode("utf-8")]}
+        login_str = json.dumps(login_param)
+        await conn.send(login_str)
+        await asyncio.sleep(5)
+        sub_param = {"op": "subscribe", "args": ["spot/order:BTC-USDT"]}
+        sub_str = json.dumps(sub_param)
+        await conn.send(sub_str)

--- a/cryptofeed/exchange/okcoin.py
+++ b/cryptofeed/exchange/okcoin.py
@@ -77,7 +77,6 @@ class OKCoin(Feed):
         for chunk in split.list_by_max_items(symbol_channels, 33):
             LOG.info("%s: Subscribe to %s args from %r to %r", self.id, len(chunk), chunk[0], chunk[-1])
             request = {"op": "subscribe", "args": chunk}
-            print('request is:', request)
             await conn.send(json.dumps(request))
 
     @staticmethod
@@ -251,11 +250,9 @@ class OKCoin(Feed):
         ret = []
         for channel in self.subscription or self.channels:
             if is_authenticated_channel(channel):
-                if channel in self.subscription:
-                    ret.append((AsyncConnection(self.address, self.id, **self.ws_defaults), partial(self.user_order_subscribe, symbol=self.subscription.get(channel).pop()), self.message_handler))
-                else:
-                    for symbol in self.symbols:
-                        ret.append((AsyncConnection(self.address, self.id, **self.ws_defaults), partial(self.user_order_subscribe, symbol=symbol), self.message_handler))
+                syms = self.symbols or self.subscription[channel]
+                for s in syms:
+                    ret.append((AsyncConnection(self.address, self.id, **self.ws_defaults), partial(self.user_order_subscribe, symbol=s), self.message_handler))
             else:
                 ret.append((AsyncConnection(self.address, self.id, **self.ws_defaults), self.subscribe, self.message_handler))
 

--- a/cryptofeed/standards.py
+++ b/cryptofeed/standards.py
@@ -252,7 +252,8 @@ _feed_to_exchange_map = {
         BYBIT: 'instrument_info.100ms'
     },
     ORDER_INFO: {
-        GEMINI: ORDER_INFO
+        GEMINI: ORDER_INFO,
+        OKEX: ORDER_INFO
     },
     CANDLES: {
         BINANCE: 'kline_'

--- a/cryptofeed/symbols.py
+++ b/cryptofeed/symbols.py
@@ -379,7 +379,7 @@ def okcoin_symbols() -> Dict[str, str]:
         raise_failure_explanation('OKCOIN', why, {"": r})
 
 
-def okex_symbols() -> Dict[str, str]:
+def okex_symbols(*args) -> Dict[str, str]:
     option_urls = okex_compute_option_urls_from_underlyings()
     other_urls = ['https://www.okex.com/api/spot/v3/instruments',
                   'https://www.okex.com/api/swap/v3/instruments/ticker',

--- a/examples/demo_okex_authenticated.py
+++ b/examples/demo_okex_authenticated.py
@@ -1,0 +1,22 @@
+'''
+Copyright (C) 2017-2021  Bryant Moscon - bmoscon@gmail.com
+
+Please see the LICENSE file for the terms and conditions
+associated with this software.
+'''
+from cryptofeed import FeedHandler
+from cryptofeed.defines import OKEX, ORDER_INFO
+from cryptofeed.callback import OrderInfoCallback
+
+
+async def order(**kwargs):
+    print(f"Order Update: {kwargs}")
+
+
+def main():
+    f = FeedHandler(config="config.yaml")
+    f.add_feed(OKEX, channels=[ORDER_INFO], symbols=['BTC-USDT'], callbacks={ORDER_INFO: OrderInfoCallback(order)})
+    f.run()
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
### Description of code - what bug does this fix / what feature does this add?

- [ ] - Adds websocket authentication for Okex and, by default, OKCoin
- [ ] - Handles separately required login and subscription
- [ ] - Only implemented for `spot/order` channel and hardcoded for symbol `BTC-USDT` at present (see: `auth_subscribe` function in cryptofeed/exchange/okcoin)
- [ ] - see the working example in `examples/demo_okex_authenticated.py`