### PR TITLE
Fix Broken add_feed() for Subscription with CANDLES

### DIFF
--- a/cryptofeed/exchange/binance.py
+++ b/cryptofeed/exchange/binance.py
@@ -55,10 +55,10 @@ class Binance(Feed):
         for chan in self.channels if not self.subscription else self.subscription:
             if normalize_channel(self.id, chan) == OPEN_INTEREST:
                 continue
-            if normalize_channel(self.id, chan) == CANDLES:
-                chan = f"{chan}{self.candle_interval}"
 
             for pair in self.symbols if not self.subscription else self.subscription[chan]:
+                if normalize_channel(self.id, chan) == CANDLES:
+                    chan = f"{chan}{self.candle_interval}"
                 pair = pair.lower()
                 stream = f"{pair}@{chan}/"
                 address += stream


### PR DESCRIPTION
When adding a feed to FeedHandler with `subscription` parameter (same as [Cryptofeed](https://github.com/bmoscon/cryptostore/blob/master/cryptostore/collector.py#L117)) to retrieve CANDLES data, the address construction routine fails with an exception. 

This PR fixes it by properly accessing the `self.subscription` variable and still use `self.candle_interval` to construct the stream address. 

- [x] - Tested
- [ ] - Changelog updated
- [x] - Tests run and pass
- [x] - Flake8 run and all errors/warnings resolved
- [ ] - Contributors file updated (optional)
