### PR TITLE
Update GCP Pub/Sub backend with google_cloud_pubsub >= 2.4.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,7 @@ setup(
     ],
     extras_require={
         "arctic": ["arctic"],
-        "gcp_pubsub": ["google_cloud_pubsub~=2.2.0", "gcloud_aio_pubsub"],
+        "gcp_pubsub": ["google_cloud_pubsub>=2.4.1", "gcloud_aio_pubsub"],
         "kafka": ["aiokafka>=0.7.0"],
         "mongo": ["motor"],
         "postgres": ["asyncpg"],
@@ -84,7 +84,7 @@ setup(
         "zmq": ["pyzmq"],
         "all": [
             "arctic",
-            "google_cloud_pubsub",
+            "google_cloud_pubsub>=2.4.1",
             "gcloud_aio_pubsub"
             "aiokafka>=0.7.0",
             "motor",


### PR DESCRIPTION
2.4.1 resolves the SSL issue in the Pub/Sub emulator

Closes dependabot https://github.com/bmoscon/cryptofeed/pull/457

### Description of code - what bug does this fix / what feature does this add?

- [x] - Tested with GCP Pub/Sub locally with emulator
- [x] - Flake8 run and all errors/warnings resolved