### PR TITLE
Removing 'Decimal' from coingecko feed, and minor bugfix 

### DIFF
--- a/cryptofeed/provider/coingecko.py
+++ b/cryptofeed/provider/coingecko.py
@@ -5,7 +5,6 @@ Please see the LICENSE file for the terms and conditions
 associated with this software.
 '''
 from collections import defaultdict
-from decimal import Decimal
 import string
 from typing import Dict, Tuple, Callable, List
 
@@ -88,7 +87,7 @@ class Coingecko(Feed):
 
     async def message_handler(self, msg: str, conn, timestamp: float):
 
-        msg = json.loads(msg, parse_float=Decimal)
+        msg = json.loads(msg)
         await self._market_info(msg, timestamp)
 
     async def _market_info(self, msg: dict, receipt_timestamp: float):
@@ -111,7 +110,7 @@ class Coingecko(Feed):
                             continue
                         market_data[f"{key}_{cur}"] = price
                 else:
-                    market_data[key] = value
+                    market_data[key] = value if value else -1
             # 'last_updated' here is assumed to be specific for market data, so it is kept as well.
             market_data['last_updated'] = timestamp_normalize(self.id, msg['market_data']['last_updated'])
             community_data = {k: (v if v else -1) for k, v in msg['community_data'].items()}


### PR DESCRIPTION
Removing 'Decimal' from coingecko feed, and minor bugfix in case of 'None' data in MARKET_DATA.

### Description of code - what bug does this fix / what feature does this add?

- [x] - Tested
- [ ] - Changelog updated
- [x] - Tests run and pass
- [x] - Flake8 run and all errors/warnings resolved
- [ ] - Contributors file updated (optional)


@bmoscon 
On the opposite to what I proposed in slack, I removed use of `Decimal` from `coingecko.py` script.
It appeared that `Decimal` when used with `msg = json.loads(msg, parse_float=Decimal)` is not applied to data located in nested dicts.
`Decimal` was thus applied only partially.
I had the choice:
- either to complete the implementation, + complete list of keys (as there are not all listed in the begining of `coingecko.py` script, only those at the root of `msg` are) + implement the way back from `Decimal`to `float` in `backend.py`.
- or simply remove use of `Decimal` when calling `json.loads()`

I opted for the 2nd, much simpler to implement, and I fail to see any interest in managing float data as `Decimal` for data that will not be used directly to trade, only as indicators.

With this, I could check that cryptostore is running ok now.
(I could see there was one bug in the new `coingecko.py` implementation that was not in the initial implementation, that I also solved)

Please, do not hesitate to share your feedbacks.
Have a good evening,
Bests,

