### PR TITLE
fix: reset delay after reconnection succeeds

### DIFF
--- a/cryptofeed/connection_handler.py
+++ b/cryptofeed/connection_handler.py
@@ -56,6 +56,7 @@ class ConnectionHandler:
                     # connection was successful, reset retry count and delay
                     retries = 0
                     rate_limited = 0
+                    delay = 1
                     await self.subscribe(connection)
                     if self.timeout != -1:
                         loop = asyncio.get_running_loop()


### PR DESCRIPTION
### Description of code - what bug does this fix / what feature does this add?

I added a code to reset delay parameter after reconnection succeeds in connection_handler.py. I thought this should be fixed to reduce reconnection delay after large number of reconnections made (reconnection delay increases by a power of 2).
Please correct me if the original code was intentional. Thanks.

- [X] - Tested
- [ ] - Changelog updated
- [X] - Tests run and pass (except test_bitmex_rest)
- [X] - Flake8 run and all errors/warnings resolved
- [ ] - Contributors file updated (optional)
