### PR TITLE
Support Kline/Candlestick stream for Binance Coin-margined Futures

### DIFF
--- a/cryptofeed/exchange/binance_delivery.py
+++ b/cryptofeed/exchange/binance_delivery.py
@@ -66,5 +66,7 @@ class BinanceDelivery(Binance):
             await self._liquidations(msg, timestamp)
         elif msg_type == 'markPriceUpdate':
             await self._funding(msg, timestamp)
+        elif msg_type == 'kline':
+            await self._candle(msg, timestamp)
         else:
             LOG.warning("%s: Unexpected message received: %s", self.id, msg)

--- a/cryptofeed/standards.py
+++ b/cryptofeed/standards.py
@@ -210,6 +210,7 @@ _feed_to_exchange_map = {
     CANDLES: {
         BINANCE: 'kline_',
         BINANCE_FUTURES: 'kline_',
+        BINANCE_DELIVERY: 'kline_',
         HUOBI: 'kline',
         GATEIO: 'spot.candlesticks',
         KUCOIN: '/market/candles'


### PR DESCRIPTION
Support Kline/Candlestick stream for [Binance Coin-margined Futures](https://binance-docs.github.io/apidocs/delivery/en/#kline-candlestick-streams).

An example of use:

```python3
from cryptofeed import FeedHandler
from cryptofeed.defines import CANDLES
from cryptofeed.exchanges import BinanceDelivery

async def candle_callback(feed, symbol, start, stop, interval, trades, open_price, close_price, high_price, low_price, volume, closed, timestamp, receipt_timestamp):
    print(f"Candle: {timestamp} {receipt_timestamp} Feed: {feed} Symbol: {symbol} Start: {start} Stop: {stop} Interval: {interval} Trades: {trades} Open: {open_price} Close: {close_price} High: {high_price} Low: {low_price} Volume: {volume} Candle Closed? {closed}")

def main():
    config = {'log': {'filename': 'demo.log', 'level': 'INFO'}}
    f = FeedHandler(config=config)
    pairs = ["DOGE-USD_PERP"]
    f.add_feed(BinanceDelivery(symbols=pairs, channels=[CANDLES], callbacks={CANDLES: candle_callback}))

    f.run()

if __name__ == '__main__':
    main()
```
