### PR TITLE
bugfix: add_feed_running kwargs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
   * Feature: simplify and cleanup parts of Poloniex
   * Feature: add `symbols` class method to all exchanges to get list of supported trading pairs
   * Feature: Clean up internal class attributes in Feed class
+  * Feature: Add graceful stop and shutdown methods for Feeds
   * Feature: Add ledger endpoint to Kraken Rest module, add ability to optionally filter by symbol, or all symbols, for historical trades
   * Docs: Update documentation regarding adding a new exchange to cryptofeed
   * Bugfix: Reset delay after connection is successful

--- a/cryptofeed/feedhandler.py
+++ b/cryptofeed/feedhandler.py
@@ -105,7 +105,7 @@ class FeedHandler:
             if a string is used for the feed, kwargs will be passed to the
             newly instantiated object
         """
-        self.add_feed(feed, *kwargs)
+        self.add_feed(feed, **kwargs)
 
         if loop is None:
             loop = asyncio.get_event_loop()


### PR DESCRIPTION
### Description of code - what bug does this fix / what feature does this add?

- Missing `*` in the `add_feed_running()` kwargs.

- Minor changelog addition to celebrate the graceful Feed `stop` and `shutdown` methods which were introduced since the last 1.9.0 release (as part of the connection refactor). Useful for people running older versions who may consider upgrading for this (see https://github.com/bmoscon/cryptofeed/issues/493).

-----

- [x] - Tested
- [x] - Changelog updated
- [ ] - Tests run and pass
- [x] - Flake8 run and all errors/warnings resolved
- [ ] - Contributors file updated (optional)
