### PR TITLE
fix: Kraken Futures std symbol

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,7 @@
   * Feature: Binance US candle support
   * Feature: Kraken Candle support
   * Update: Remove deprecated channel mapping from Kraken, use channel name from message instead
+  * Bugfix: change Kraken Futures to use the standard symbol to be consistent with the rest of the library
 
 ### 1.9.0 (2021-04-25)
   * Bugfix: Fix Binance subscriptions when subscribing to more than one candle

--- a/cryptofeed/exchange/kraken_futures.py
+++ b/cryptofeed/exchange/kraken_futures.py
@@ -224,17 +224,19 @@ class KrakenFutures(Feed):
             else:
                 LOG.warning("%s: Invalid message type %s", self.id, msg)
         else:
+            # As per Kraken support: websocket product_id is uppercase version of the REST API symbols
+            pair = self.exchange_symbol_to_std_symbol(msg['product_id'].lower())
             if msg['feed'] == 'trade':
-                await self._trade(msg, msg['product_id'], timestamp)
+                await self._trade(msg, pair, timestamp)
             elif msg['feed'] == 'trade_snapshot':
                 return
             elif msg['feed'] == 'ticker_lite':
-                await self._ticker(msg, msg['product_id'], timestamp)
+                await self._ticker(msg, pair, timestamp)
             elif msg['feed'] == 'ticker':
-                await self._funding(msg, msg['product_id'], timestamp)
+                await self._funding(msg, pair, timestamp)
             elif msg['feed'] == 'book_snapshot':
-                await self._book_snapshot(msg, msg['product_id'], timestamp)
+                await self._book_snapshot(msg, pair, timestamp)
             elif msg['feed'] == 'book':
-                await self._book(msg, msg['product_id'], timestamp)
+                await self._book(msg, pair, timestamp)
             else:
                 LOG.warning("%s: Invalid message type %s", self.id, msg)

--- a/examples/demo_kraken_futures.py
+++ b/examples/demo_kraken_futures.py
@@ -33,7 +33,7 @@ async def oi(feed, symbol, open_interest, timestamp, receipt_timestamp):
 def main():
     fh = FeedHandler()
 
-    sub = {OPEN_INTEREST: ['PI_XBTUSD', 'PI_ETHUSD'], TRADES: ['PI_XBTUSD'], TICKER: ['PI_XBTUSD', 'PI_ETHUSD'], L2_BOOK: ['PI_ETHUSD', 'PI_XBTUSD'], FUNDING: ['PI_XBTUSD']}
+    sub = {OPEN_INTEREST: ['PI-BTC-USD', 'PI-ETH-USD'], TRADES: ['PI-BTC-USD'], TICKER: ['PI-BTC-USD', 'PI-ETH-USD'], L2_BOOK: ['PI-ETH-USD', 'PI-XRP-USD'], FUNDING: ['PI-BTC-USD']}
     fh.add_feed(KrakenFutures(subscription=sub, callbacks={OPEN_INTEREST: oi, FUNDING: funding, TICKER: TickerCallback(ticker), TRADES: TradeCallback(trade), L2_BOOK: BookCallback(book)}))
 
     fh.run()


### PR DESCRIPTION
### Description of code - what bug does this fix / what feature does this add?
- Fixed Kraken Futures to transform the websocket symbol into the cryptofeed standard symbol (this was being forgotten before because the `examples/demo_kraken_futures.py` was incorrectly passing in the exchange symbol).
- Fixed Kraken Futures websocket symbols to match the REST API symbols. Currently KrakenFutures transform their websocket `product_id` to uppercase despite the symbols endpoint all being lowercase. This is undocumented but Kraken support confirmed this.

Even in the [sample data for Kraken Futures](cryptofeed/sample_data/KRAKEN_FUTURES.ws.46.0) this can be observed:
```
wss://futures.kraken.com/ws/v1 <- 1618678101.4928598: {"event":"subscribe","feed":"trade","product_ids":["pi_bchusd","fi_bchusd_210625","fi_xbtusd_210430","fi_xrpusd_210625","fi_ethusd_210924","fi_xbtusd_210924","fi_ethusd_21
1618678101.603026: {"event":"subscribed","feed":"trade","product_ids":["PI_BCHUSD"]}
```

- REST API symbols: https://futures.kraken.com/derivatives/api/v3/instruments `symbol | "pi_xbtusd"`
- vs WEBSOCKET product_id: https://support.kraken.com/hc/en-us/articles/360022839771-Trade `"product_id": "PI_XBTUSD"`

This will be a breaking change if anyone is using the non-std symbols in their callbacks. This is unlikely as it is inconsistent with the remainder of the lib and they will have probably noticed!

- [x] - Tested
- [x] - Changelog updated
- [x] - Tests run and pass
- [ ] - Flake8 run and all errors/warnings resolved
- [ ] - Contributors file updated (optional)
