### PR TITLE
Added order book support for Kucoin v3

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -52,3 +52,7 @@ okex:
     key_id: null
     key_secret: null
     key_passphrase: null
+kucoin:
+    key_id: null
+    key_secret: null
+    key_passphrase: null

--- a/cryptofeed/auth/kucoin.py
+++ b/cryptofeed/auth/kucoin.py
@@ -1,0 +1,28 @@
+'''
+Copyright (C) 2017-2021  Bryant Moscon - bmoscon@gmail.com
+
+Please see the LICENSE file for the terms and conditions
+associated with this software.
+'''
+
+import time
+import hmac
+import base64
+import hashlib
+
+def generate_token(key_id:str, key_secret:str, key_passphrase:str, str_to_sign:str) -> dict:
+    # https://docs.kucoin.com/#authentication
+    
+    now = int(time.time() * 1000)    
+    str_to_sign = str(now) + str_to_sign
+    signature = base64.b64encode(
+        hmac.new(key_secret.encode('utf-8'), str_to_sign.encode('utf-8'), hashlib.sha256).digest())
+    
+    header = {
+        "KC-API-SIGN": signature.decode(),
+        "KC-API-TIMESTAMP": str(now),
+        "KC-API-KEY": key_id,
+        "KC-API-PASSPHRASE": key_passphrase,
+        "KC-API-KEY-VERSION": "3"
+    }
+    return header

--- a/cryptofeed/connection.py
+++ b/cryptofeed/connection.py
@@ -115,12 +115,12 @@ class HTTPAsyncConn(AsyncConnection):
             self.sent = 0
             self.received = 0
 
-    async def read(self, address: str) -> bytes:
+    async def read(self, address: str, header=None) -> bytes:
         if not self.is_open:
             await self._open()
 
         LOG.debug("%s: requesting data from %s", self.id, address)
-        async with self.conn.get(address) as response:
+        async with self.conn.get(address, headers=header) as response:
             data = await response.text()
             self.last_message = time.time()
             self.received += 1

--- a/cryptofeed/feed.py
+++ b/cryptofeed/feed.py
@@ -96,6 +96,7 @@ class Feed:
         self.ws_defaults = {'ping_interval': 10, 'ping_timeout': None, 'max_size': 2**23, 'max_queue': None, 'origin': self.origin}
         self.key_id = os.environ.get(f'CF_{self.id}_KEY_ID') or self.config[self.id.lower()].key_id
         self.key_secret = os.environ.get(f'CF_{self.id}_KEY_SECRET') or self.config[self.id.lower()].key_secret
+        self.key_passphrase = os.environ.get(f'CF_{self.id}_KEY_SECRET') or self.config[self.id.lower()].key_passphrase
         self._feed_config = defaultdict(list)
         self.http_conn = HTTPAsyncConn(self.id)
 

--- a/examples/demo_kucoin_authenticated.py
+++ b/examples/demo_kucoin_authenticated.py
@@ -1,0 +1,23 @@
+'''
+Copyright (C) 2017-2021  Bryant Moscon - bmoscon@gmail.com
+
+Please see the LICENSE file for the terms and conditions
+associated with this software.
+'''
+from cryptofeed import FeedHandler
+from cryptofeed.defines import KUCOIN, L2_BOOK
+
+
+async def book(**kwargs):
+    print(f"Book Update: {kwargs}")
+
+
+def main():
+    f = FeedHandler(config="config.yaml")
+    f.add_feed(KUCOIN, sandbox=True, subscription={L2_BOOK: ['BTC-USDT', 'ETH-USDT']}, callbacks={L2_BOOK: book})
+
+    f.run()
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
### Description of code - what bug does this fix / what feature does this add?

It fixes the bug discussed [here (issue #509)](https://github.com/bmoscon/cryptofeed/issues/509).
Kucoin v3 only allows getting order book data if authenticated (via api key). I added a kucoin.py file under auth, which generates the headers for an authenticated call (under a generate_token function).

I updated connection.py to accept headers in its read function.

I updated exchanges/kucoin.py to 'read' the newer url (v3) with the generated headers.

I added an example under examples/demo_kucoin_authenticated.py

- [x] - Tested *(by running demo_kucoin_authenticated.py and getting the expected result)*
- [ ] - Changelog updated
- [ ] - Tests run and pass *(Not sure how to run?)*
- [ ] - Flake8 run and all errors/warnings resolved
- [ ] - Contributors file updated (optional)
