### PR TITLE
Authenticate private channels (USER_FILLS) for FTX

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -8,4 +8,4 @@ Cryptofeed was originally created by Bryant Moscon, but many others have contrib
 * [Ryan Tam](https://github.com/ryantam626) - <ryantam626@gmail.com>
 * [Yoh Plala](https://github.com/yohplala) - <yoh.plala@gmail.com>
 * [Alex](https://github.com/globophobe)
-
+* [Michael Zhao](https://github.com/dynamikey)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
   * Bugfix: #518 - fix aggregator example code
   * Update: Support Bittrex V3
   * Feature: Add support for candles on Bittrex
+  * Feature: Add support to authenticate private channels (e.g. USER_FILLS) on FTX
 
 ### 1.9.1 (2021-06-10)
   * Feature: add Bithumb exchange - l2 book and trades

--- a/cryptofeed/connection_handler.py
+++ b/cryptofeed/connection_handler.py
@@ -23,10 +23,11 @@ LOG = logging.getLogger('feedhandler')
 
 
 class ConnectionHandler:
-    def __init__(self, conn: AsyncConnection, subscribe: Awaitable, handler: Awaitable, retries: int, timeout=120, timeout_interval=30, exceptions=None, log_on_error=False):
+    def __init__(self, conn: AsyncConnection, subscribe: Awaitable, handler: Awaitable, authenticate: Awaitable, retries: int, timeout=120, timeout_interval=30, exceptions=None, log_on_error=False):
         self.conn = conn
         self.subscribe = subscribe
         self.handler = handler
+        self.authenticate = authenticate
         self.retries = retries
         self.exceptions = exceptions
         self.log_on_error = log_on_error
@@ -57,6 +58,7 @@ class ConnectionHandler:
                     retries = 0
                     rate_limited = 0
                     delay = 1
+                    await self.authenticate(connection)
                     await self.subscribe(connection)
                     if self.timeout != -1:
                         loop = asyncio.get_running_loop()

--- a/cryptofeed/defines.py
+++ b/cryptofeed/defines.py
@@ -62,6 +62,7 @@ CANDLES = 'candles'
 
 # Account Data / Authenticated Channels
 ORDER_INFO = 'order_info'
+USER_FILLS = 'user_fills'
 
 
 BUY = 'buy'

--- a/cryptofeed/exchange/bitfinex.py
+++ b/cryptofeed/exchange/bitfinex.py
@@ -350,7 +350,7 @@ class Bitfinex(Feed):
         def build(options: list):
             subscribe = partial(self.subscribe, options=options)
             conn = WSAsyncConn(self.address, self.id, **self.ws_defaults)
-            return conn, subscribe, self.message_handler
+            return conn, subscribe, self.message_handler, self.authenticate
 
         for channel in self.subscription:
             for pair in self.subscription[channel]:

--- a/cryptofeed/exchange/bybit.py
+++ b/cryptofeed/exchange/bybit.py
@@ -75,10 +75,10 @@ class Bybit(Feed):
 
         if any(pair[-4:] == 'USDT' for pair in self.normalized_symbols):
             subscribe = partial(self.subscribe, quote='USDT')
-            ret.append((WSAsyncConn(self.address['USDT'], self.id, **self.ws_defaults), subscribe, self.message_handler))
+            ret.append((WSAsyncConn(self.address['USDT'], self.id, **self.ws_defaults), subscribe, self.message_handler, self.authenticate))
         if any(pair[-3:] == 'USD' for pair in self.normalized_symbols):
             subscribe = partial(self.subscribe, quote='USD')
-            ret.append((WSAsyncConn(self.address['USD'], self.id, **self.ws_defaults), subscribe, self.message_handler))
+            ret.append((WSAsyncConn(self.address['USD'], self.id, **self.ws_defaults), subscribe, self.message_handler, self.authenticate))
 
         return ret
 

--- a/cryptofeed/exchange/ftx.py
+++ b/cryptofeed/exchange/ftx.py
@@ -57,8 +57,8 @@ class FTX(Feed):
     async def generate_token(self, conn: AsyncConnection):
         ts = int(time() * 1000)
         msg = {
-            'op': 'login', 
-            'args': 
+            'op': 'login',
+            'args':
             {
                 'key': self.key_id,
                 'sign': hmac.new(self.key_secret.encode(), f'{ts}websocket_login'.encode(), 'sha256').hexdigest(),
@@ -323,7 +323,7 @@ class FTX(Feed):
                             trade_id=fill['tradeId'],
                             timestamp=float(timestamp_normalize(self.id, fill['time'])),
                             receipt_timestamp=timestamp)
-    
+
     async def message_handler(self, msg: str, conn, timestamp: float):
         msg = json.loads(msg, parse_float=Decimal)
         if 'type' in msg:

--- a/cryptofeed/exchange/ftx.py
+++ b/cryptofeed/exchange/ftx.py
@@ -9,6 +9,7 @@ import asyncio
 from collections import defaultdict
 import logging
 from decimal import Decimal
+import hmac
 from time import time
 import zlib
 from typing import Dict, Iterable, Tuple
@@ -18,12 +19,12 @@ from sortedcontainers import SortedDict as sd
 from yapic import json
 
 from cryptofeed.connection import AsyncConnection
-from cryptofeed.defines import BID, ASK, BUY
+from cryptofeed.defines import BID, ASK, BUY, USER_FILLS
 from cryptofeed.defines import FTX as FTX_id
 from cryptofeed.defines import FUNDING, L2_BOOK, LIQUIDATIONS, OPEN_INTEREST, SELL, TICKER, TRADES, FILLED
 from cryptofeed.exceptions import BadChecksum
 from cryptofeed.feed import Feed
-from cryptofeed.standards import timestamp_normalize
+from cryptofeed.standards import is_authenticated_channel, normalize_channel, timestamp_normalize
 
 
 LOG = logging.getLogger('feedhandler')
@@ -53,6 +54,23 @@ class FTX(Feed):
         self.funding = {}
         self.open_interest = {}
 
+    async def generate_token(self, conn: AsyncConnection):
+        ts = int(time() * 1000)
+        msg = {
+            'op': 'login', 
+            'args': 
+            {
+                'key': self.key_id,
+                'sign': hmac.new(self.key_secret.encode(), f'{ts}websocket_login'.encode(), 'sha256').hexdigest(),
+                'time': ts,
+            }
+        }
+        await conn.write(json.dumps(msg))
+
+    async def authenticate(self, conn: AsyncConnection):
+        if self.requires_authentication:
+            await self.generate_token(conn)
+
     async def subscribe(self, conn: AsyncConnection):
         self.__reset()
         for chan in self.subscription:
@@ -62,6 +80,14 @@ class FTX(Feed):
                 continue
             if chan == OPEN_INTEREST:
                 asyncio.create_task(self._open_interest(symbols))  # TODO: use HTTPAsyncConn
+                continue
+            if is_authenticated_channel(normalize_channel(self.id, chan)):
+                await conn.write(json.dumps(
+                    {
+                        "channel": chan,
+                        "op": "subscribe"
+                    }
+                ))
                 continue
             for pair in symbols:
                 await conn.write(json.dumps(
@@ -263,17 +289,63 @@ class FTX(Feed):
                 raise BadChecksum
             await self.book_callback(self.l2_book[pair], L2_BOOK, pair, False, delta, float(msg['data']['time']), timestamp)
 
+    async def _fill(self, msg: dict, timestamp: float):
+        """
+        example message:
+        {
+            "channel": "fills",
+            "data": {
+                "fee": 78.05799225,
+                "feeRate": 0.0014,
+                "future": "BTC-PERP",
+                "id": 7828307,
+                "liquidity": "taker",
+                "market": "BTC-PERP",
+                "orderId": 38065410,
+                "tradeId": 19129310,
+                "price": 3723.75,
+                "side": "buy",
+                "size": 14.973,
+                "time": "2019-05-07T16:40:58.358438+00:00",
+                "type": "order"
+            },
+            "type": "update"
+            }
+        """
+        fill = msg['data']
+        await self.callback(USER_FILLS, feed=self.id,
+                            symbol=self.exchange_symbol_to_std_symbol(fill['market']),
+                            side=BUY if fill['side'] == 'buy' else SELL,
+                            amount=Decimal(fill['size']),
+                            price=Decimal(fill['price']),
+                            liquidity=fill['liquidity'],
+                            order_id=fill['id'],
+                            trade_id=fill['tradeId'],
+                            timestamp=float(timestamp_normalize(self.id, fill['time'])),
+                            receipt_timestamp=timestamp)
+    
     async def message_handler(self, msg: str, conn, timestamp: float):
         msg = json.loads(msg, parse_float=Decimal)
-        if 'type' in msg and msg['type'] == 'subscribed':
-            return
-        elif 'channel' in msg:
-            if msg['channel'] == 'orderbook':
-                await self._book(msg, timestamp)
-            elif msg['channel'] == 'trades':
-                await self._trade(msg, timestamp)
-            elif msg['channel'] == 'ticker':
-                await self._ticker(msg, timestamp)
+        if 'type' in msg:
+            if msg['type'] == 'subscribed':
+                if 'market' in msg:
+                    LOG.info('%s: Subscribed to %s channel for %s', self.id, msg['channel'], msg['market'])
+                else:
+                    LOG.info('%s: Subscribed to %s channel', self.id, msg['channel'])
+            elif msg['type'] == 'error':
+                LOG.error('%s: Received error message %s', self.id, msg)
+                raise Exception('Error from %s: %s', self.id, msg)
+            elif 'channel' in msg:
+                if msg['channel'] == 'orderbook':
+                    await self._book(msg, timestamp)
+                elif msg['channel'] == 'trades':
+                    await self._trade(msg, timestamp)
+                elif msg['channel'] == 'ticker':
+                    await self._ticker(msg, timestamp)
+                elif msg['channel'] == 'fills':
+                    await self._fill(msg, timestamp)
+                else:
+                    LOG.warning("%s: Invalid message type %s", self.id, msg)
             else:
                 LOG.warning("%s: Invalid message type %s", self.id, msg)
         else:

--- a/cryptofeed/exchange/kraken.py
+++ b/cryptofeed/exchange/kraken.py
@@ -80,7 +80,7 @@ class Kraken(Feed):
         def build(options: list):
             subscribe = partial(self.subscribe, options=options)
             conn = WSAsyncConn(self.address, self.id, **self.ws_defaults)
-            return conn, subscribe, self.message_handler
+            return conn, subscribe, self.message_handler, self.authenticate
 
         for chan in self.subscription:
             symbols = list(self.subscription[chan])

--- a/cryptofeed/exchange/okcoin.py
+++ b/cryptofeed/exchange/okcoin.py
@@ -260,9 +260,9 @@ class OKCoin(Feed):
         for channel in self.subscription:
             if is_authenticated_channel(channel):
                 for s in self.subscription[channel]:
-                    ret.append((WSAsyncConn(self.address, self.id, **self.ws_defaults), partial(self.user_order_subscribe, symbol=s), self.message_handler))
+                    ret.append((WSAsyncConn(self.address, self.id, **self.ws_defaults), partial(self.user_order_subscribe, symbol=s), self.message_handler, self.authenticate))
             else:
-                ret.append((WSAsyncConn(self.address, self.id, **self.ws_defaults), self.subscribe, self.message_handler))
+                ret.append((WSAsyncConn(self.address, self.id, **self.ws_defaults), self.subscribe, self.message_handler, self.authenticate))
 
         return ret
 

--- a/cryptofeed/feed.py
+++ b/cryptofeed/feed.py
@@ -164,13 +164,13 @@ class Feed:
             if not isinstance(callback, list):
                 self.callbacks[key] = [callback]
 
-    def _connect_builder(self, address: str, options: list, header=None, sub=None, handler=None):
+    def _connect_builder(self, address: str, options: list, header=None, sub=None, handler=None, auth=None):
         """
         Helper method for building a custom connect tuple
         """
         subscribe = partial(self.subscribe if not sub else sub, options=options)
         conn = WSAsyncConn(address, self.id, extra_headers=header, **self.ws_defaults)
-        return conn, subscribe, handler if handler else self.message_handler
+        return conn, subscribe, handler if handler else self.message_handler, auth if auth else self.authenticate
 
     async def _empty_subscribe(self, conn: AsyncConnection, **kwargs):
         return

--- a/cryptofeed/raw_data_collection.py
+++ b/cryptofeed/raw_data_collection.py
@@ -89,7 +89,7 @@ async def _playback(feed: str, filenames: list):
         f = functools.partial(internal_cb, cb_type=cb_type)
         handler.append(f)
 
-    for _, sub, handler in feed.connect():
+    for _, sub, handler, auth in feed.connect():
         await sub(ws)
 
     counter = 0

--- a/cryptofeed/standards.py
+++ b/cryptofeed/standards.py
@@ -16,7 +16,7 @@ from cryptofeed.defines import (BINANCE, BINANCE_DELIVERY, BINANCE_FUTURES, BINA
                                 BITHUMB, BITMAX, BITMEX,
                                 BITSTAMP, BITTREX, BLOCKCHAIN, BYBIT, CANDLES, COINBASE, COINGECKO,
                                 DERIBIT, EXX, FTX, FTX_US, GATEIO, GEMINI, HITBTC, HUOBI, HUOBI_DM, HUOBI_SWAP,
-                                KRAKEN, KRAKEN_FUTURES, KUCOIN, OKCOIN, OKEX, POLONIEX, PROBIT, UPBIT)
+                                KRAKEN, KRAKEN_FUTURES, KUCOIN, OKCOIN, OKEX, POLONIEX, PROBIT, UPBIT, USER_FILLS)
 from cryptofeed.defines import (FILL_OR_KILL, IMMEDIATE_OR_CANCEL, LIMIT, MAKER_OR_CANCEL, MARKET, UNSUPPORTED)
 from cryptofeed.defines import (FUNDING, FUTURES_INDEX, L2_BOOK, L3_BOOK, LIQUIDATIONS, OPEN_INTEREST, MARKET_INFO,
                                 TICKER, TRADES, ORDER_INFO)
@@ -217,6 +217,9 @@ _feed_to_exchange_map = {
         GEMINI: ORDER_INFO,
         OKEX: ORDER_INFO
     },
+    USER_FILLS: {
+        FTX: 'fills',
+    },
     CANDLES: {
         BINANCE: 'kline_',
         BINANCE_US: 'kline_',
@@ -306,4 +309,4 @@ def normalize_channel(exchange: str, feed: str) -> str:
 
 
 def is_authenticated_channel(channel: str) -> bool:
-    return channel in (ORDER_INFO)
+    return channel in (ORDER_INFO, USER_FILLS)

--- a/examples/demo_ftx.py
+++ b/examples/demo_ftx.py
@@ -1,0 +1,39 @@
+'''
+Copyright (C) 2017-2021  Bryant Moscon - bmoscon@gmail.com
+
+Please see the LICENSE file for the terms and conditions
+associated with this software.
+'''
+from decimal import Decimal
+
+from cryptofeed import FeedHandler
+from cryptofeed.callback import TradeCallback
+from cryptofeed.defines import TRADES, USER_FILLS
+from cryptofeed.exchanges import FTX
+
+
+# Examples of some handlers for different updates. These currently don't do much.
+# Handlers should conform to the patterns/signatures in callback.py
+# Handlers can be normal methods/functions or async. The feedhandler is paused
+# while the callbacks are being handled (unless they in turn await other functions or I/O)
+# so they should be as lightweight as possible
+async def trade(feed, symbol, order_id, timestamp, side, amount, price, receipt_timestamp):
+    assert isinstance(timestamp, float)
+    assert isinstance(side, str)
+    assert isinstance(amount, Decimal)
+    assert isinstance(price, Decimal)
+    print(f"TRADE Timestamp: {timestamp} Cryptofeed Receipt: {receipt_timestamp} Feed: {feed} Pair: {symbol} ID: {order_id} Side: {side} Amount: {amount} Price: {price}")
+
+
+async def fill(feed, symbol, order_id, trade_id, timestamp, side, amount, price, liquidity, receipt_timestamp):
+    print(f'FILL Timestamp: {timestamp} Cryptofeed Receipt: {receipt_timestamp} Feed: {feed} Pair: {symbol} ID: {order_id} Side: {side} Amount: {amount} Price: {price}')
+
+
+def main():
+    f = FeedHandler(config="config.yaml")
+    f.add_feed(FTX(config="config.yaml", symbols=['BTC-USD', 'BCH-USD', 'USDT-USD'], channels=[TRADES, USER_FILLS], callbacks={TRADES: TradeCallback(trade), USER_FILLS: fill}))
+    f.run()
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This PR lays out the groundwork to authenticate private channels for a particular websocket connection. FTX and Deribit are examples of exchanges that require authenticating a connection before a private channel can be subscribed to.

- [x] - Tested
- [x] - Changelog updated
- [x] - Tests run and pass - one test was failing (tests/integration/rest/test_rest.py::test_rest_bitmex was failing on a clean branch already)
- [x] - Flake8 run and all errors/warnings resolved
- [x] - Contributors file updated (optional)
