### PR TITLE
Support private rest api commands for FTX

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -8,4 +8,4 @@ Cryptofeed was originally created by Bryant Moscon, but many others have contrib
 * [Ryan Tam](https://github.com/ryantam626) - <ryantam626@gmail.com>
 * [Yoh Plala](https://github.com/yohplala) - <yoh.plala@gmail.com>
 * [Alex](https://github.com/globophobe)
-* [Michael Zhao](https://github.com/dynamikey)
+* [Michael Zhao](https://github.com/dynamikey) - <mr_michaelzhao@hotmail.com>

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@
   * Update: Support Bittrex V3
   * Feature: Add support for candles on Bittrex
   * Feature: Add support to authenticate private channels (e.g. USER_FILLS) on FTX
+  * Feature: Support private rest api commands for FTX
 
 ### 1.9.1 (2021-06-10)
   * Feature: add Bithumb exchange - l2 book and trades

--- a/cryptofeed/defines.py
+++ b/cryptofeed/defines.py
@@ -87,6 +87,13 @@ CANCELLED = 'cancelled'
 UNFILLED = 'unfilled'
 
 
+# HTTP methods
+GET = 'GET'
+DELETE = 'DELETE'
+PUT = 'PUT'
+POST = 'POST'
+
+
 """
 L2 Orderbook Layout
     * BID and ASK are SortedDictionaries

--- a/cryptofeed/rest/api.py
+++ b/cryptofeed/rest/api.py
@@ -92,7 +92,7 @@ class API:
     def cancel_order(self, order_id: str):
         raise NotImplementedError
 
-    def orders(self):
+    def orders(self, sumbol: str = None):
         """
         Return outstanding orders
         """
@@ -111,6 +111,9 @@ class API:
         raise NotImplementedError
 
     def balances(self):
+        raise NotImplementedError
+
+    def positions(self, **kwargs):
         raise NotImplementedError
 
     def ledger(self, aclass=None, asset=None, ledger_type=None, start=None, end=None):

--- a/cryptofeed/rest/ftx.py
+++ b/cryptofeed/rest/ftx.py
@@ -4,14 +4,17 @@ Copyright (C) 2017-2021  Bryant Moscon - bmoscon@gmail.com
 Please see the LICENSE file for the terms and conditions
 associated with this software.
 '''
+from decimal import Decimal
+import hmac
 import logging
-from time import sleep
+from time import sleep, time
+from typing import Any, Dict, List, Optional
 
 import pandas as pd
 import requests
 from sortedcontainers.sorteddict import SortedDict as sd
 
-from cryptofeed.defines import BID, ASK, BUY
+from cryptofeed.defines import BID, ASK, BUY, DELETE, GET, LIMIT, POST
 from cryptofeed.defines import FTX as FTX_ID
 from cryptofeed.defines import SELL
 from cryptofeed.exchanges import FTX as FTXEx
@@ -26,16 +29,38 @@ class FTX(API):
     ID = FTX_ID
     info = FTXEx()
     api = "https://ftx.com/api"
+    session = requests.Session()
 
-    def _get(self, command: str, params=None, retry=None, retry_wait=0):
-        url = f"{self.api}{command}"
+    def _get(self, endpoint: str, params: Optional[Dict[str, Any]] = None, retry=None, retry_wait=0, auth=False):
+        return self._send_request(endpoint, GET, params=params, retry=retry, retry_wait=retry_wait, auth=auth)
 
+    def _post(self, endpoint: str, params: Optional[Dict[str, Any]] = None, retry=None, retry_wait=0, auth=False):
+        return self._send_request(endpoint, POST, json=params, retry=retry, retry_wait=retry_wait, auth=auth)
+
+    def _delete(self, endpoint: str, params: Optional[Dict[str, Any]] = None, retry=None, retry_wait=0, auth=False):
+        return self._send_request(endpoint, DELETE, json=params, retry=retry, retry_wait=retry_wait, auth=auth)
+
+    def _send_request(self, endpoint: str, http_method=GET, retry=None, retry_wait=0, auth=False, **kwargs):
         @request_retry(self.ID, retry, retry_wait)
         def helper():
-            resp = requests.get(url, params={} if not params else params)
-            self._handle_error(resp, LOG)
-            return resp.json()
+            request = requests.Request(method=http_method, url=self.api + endpoint, **kwargs)
+            if auth:
+                self._sign_request(request)
+            r = self.session.send(request.prepare())
+            self._handle_error(r, LOG)
+            return r.json()
         return helper()
+
+    def _sign_request(self, request: requests.Request) -> None:
+        ts = int(time() * 1000)
+        prepared = request.prepare()
+        signature_payload = f'{ts}{prepared.method}{prepared.path_url}'.encode()
+        if prepared.body:
+            signature_payload += prepared.body
+        signature = hmac.new(self.config.key_secret.encode(), signature_payload, 'sha256').hexdigest()
+        request.headers['FTX-KEY'] = self.config.key_id
+        request.headers['FTX-SIGN'] = signature
+        request.headers['FTX-TS'] = str(ts)
 
     def ticker(self, symbol: str, retry=None, retry_wait=0):
         sym = self.info.std_symbol_to_exchange_symbol(symbol)
@@ -49,7 +74,7 @@ class FTX(API):
 
     def l2_book(self, symbol: str, retry=None, retry_wait=0):
         sym = self.info.std_symbol_to_exchange_symbol(symbol)
-        data = self._get(f"/markets/{sym}/orderbook", {'depth': 100}, retry=retry, retry_wait=retry_wait)
+        data = self._get(f"/markets/{sym}/orderbook", params={'depth': 100}, retry=retry, retry_wait=retry_wait)
         return {
             BID: sd({
                 u[0]: u[1]
@@ -112,6 +137,31 @@ class FTX(API):
 
             data = [self._funding_normalization(x, symbol) for x in data]
             return data
+
+    def place_order(self, symbol: str, side: str, amount: Decimal, price: Decimal, order_type: str = LIMIT,
+                    reduce_only: bool = False, ioc: bool = False, post_only: bool = False, client_id: str = None) -> dict:
+        sym = self.info.std_symbol_to_exchange_symbol(symbol)
+        return self._post('/orders', params={
+            'market': sym,
+            'side': side,
+            'price': price,
+            'size': amount,
+            'type': order_type,
+            'reduceOnly': reduce_only,
+            'ioc': ioc,
+            'postOnly': post_only,
+            'clientId': client_id,
+        }, auth=True)
+
+    def cancel_order(self, order_id: str) -> dict:
+        return self._delete(f'/orders/{order_id}', auth=True)
+
+    def orders(self, symbol: str) -> List[dict]:
+        sym = self.info.std_symbol_to_exchange_symbol(symbol)
+        return self._get('/orders', params={'market': sym}, auth=True)
+
+    def positions(self, show_avg_price: bool = False) -> List[dict]:
+        return self._get('/positions', params={'showAvgPrice': show_avg_price}, auth=True)
 
     @staticmethod
     def _dedupe(data, last):

--- a/examples/demo_ftx.py
+++ b/examples/demo_ftx.py
@@ -10,6 +10,7 @@ from cryptofeed import FeedHandler
 from cryptofeed.callback import TradeCallback
 from cryptofeed.defines import TRADES, USER_FILLS
 from cryptofeed.exchanges import FTX
+from cryptofeed.rest import Rest
 
 
 # Examples of some handlers for different updates. These currently don't do much.
@@ -30,6 +31,9 @@ async def fill(feed, symbol, order_id, trade_id, timestamp, side, amount, price,
 
 
 def main():
+    ftx = Rest(config='config.yaml')['ftx']
+    print(ftx.ticker('ETH-USD'))
+    print(ftx.orders(symbol='USDT-USD'))
     f = FeedHandler(config="config.yaml")
     f.add_feed(FTX(config="config.yaml", symbols=['BTC-USD', 'BCH-USD', 'USDT-USD'], channels=[TRADES, USER_FILLS], callbacks={TRADES: TradeCallback(trade), USER_FILLS: fill}))
     f.run()


### PR DESCRIPTION
This feature adds support to authenticate each private rest api command by signing the request. The additional code is loosely based on the example provided by FTX.

- [x] - Tested
- [x] - Changelog updated
- [x] - Tests run and pass - 2 tests were already failing on a clean copy
- [x] - Flake8 run and all errors/warnings resolved
- [x] - Contributors file updated (optional)
