### PR TITLE
Add support for private "orders" channel on FTX

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@
   * Feature: Add support for candles on Bittrex
   * Feature: Add support to authenticate private channels (e.g. USER_FILLS) on FTX
   * Feature: Support private rest api commands for FTX
+  * Feature: Add support for private "orders" channel on FTX
 
 ### 1.9.1 (2021-06-10)
   * Feature: add Bithumb exchange - l2 book and trades

--- a/cryptofeed/exchange/ftx.py
+++ b/cryptofeed/exchange/ftx.py
@@ -359,7 +359,7 @@ class FTX(Feed):
                             filled_size=Decimal(order['filledSize']),
                             remaining_size=Decimal(order['remainingSize']),
                             amount=Decimal(order['size']),
-                            timestamp=time(),
+                            timestamp=timestamp,
                             receipt_timestamp=timestamp,
                             )
 

--- a/cryptofeed/exchange/ftx.py
+++ b/cryptofeed/exchange/ftx.py
@@ -310,7 +310,7 @@ class FTX(Feed):
                 "type": "order"
             },
             "type": "update"
-            }
+        }
         """
         fill = msg['data']
         await self.callback(USER_FILLS, feed=self.id,
@@ -325,6 +325,29 @@ class FTX(Feed):
                             receipt_timestamp=timestamp)
 
     async def _order(self, msg: dict, timestamp: float):
+        """
+        example message:
+        {
+            "channel": "orders",
+            "data": {
+                "id": 24852229,
+                "clientId": null,
+                "market": "XRP-PERP",
+                "type": "limit",
+                "side": "buy",
+                "size": 42353.0,
+                "price": 0.2977,
+                "reduceOnly": false,
+                "ioc": false,
+                "postOnly": false,
+                "status": "closed",
+                "filledSize": 0.0,
+                "remainingSize": 0.0,
+                "avgFillPrice": 0.2978
+            },
+            "type": "update"
+        }
+        """
         order = msg['data']
         await self.callback(ORDER_INFO, feed=self.id,
                             symbol=self.exchange_symbol_to_std_symbol(order['market']),

--- a/cryptofeed/standards.py
+++ b/cryptofeed/standards.py
@@ -215,7 +215,8 @@ _feed_to_exchange_map = {
     },
     ORDER_INFO: {
         GEMINI: ORDER_INFO,
-        OKEX: ORDER_INFO
+        OKEX: ORDER_INFO,
+        FTX: 'orders',
     },
     USER_FILLS: {
         FTX: 'fills',

--- a/examples/demo_ftx.py
+++ b/examples/demo_ftx.py
@@ -8,7 +8,7 @@ from decimal import Decimal
 
 from cryptofeed import FeedHandler
 from cryptofeed.callback import TradeCallback
-from cryptofeed.defines import TRADES, USER_FILLS
+from cryptofeed.defines import ORDER_INFO, TRADES, USER_FILLS
 from cryptofeed.exchanges import FTX
 from cryptofeed.rest import Rest
 
@@ -30,12 +30,16 @@ async def fill(feed, symbol, order_id, trade_id, timestamp, side, amount, price,
     print(f'FILL Timestamp: {timestamp} Cryptofeed Receipt: {receipt_timestamp} Feed: {feed} Pair: {symbol} ID: {order_id} Side: {side} Amount: {amount} Price: {price}')
 
 
+async def order(feed, symbol, status, order_id, side, order_type, avg_fill_price, filled_size, remaining_size, amount, timestamp, receipt_timestamp):
+    print(f'ORDER Timestamp: {timestamp} Cryptofeed Receipt: {receipt_timestamp} Feed: {feed} Pair: {symbol} ID: {order_id} Side: {side} Amount: {amount} Avg Fill Price: {avg_fill_price} Filled Size: {filled_size} Remaining Size: {remaining_size} Status: {status}')
+
+
 def main():
     ftx = Rest(config='config.yaml')['ftx']
     print(ftx.ticker('ETH-USD'))
     print(ftx.orders(symbol='USDT-USD'))
     f = FeedHandler(config="config.yaml")
-    f.add_feed(FTX(config="config.yaml", symbols=['BTC-USD', 'BCH-USD', 'USDT-USD'], channels=[TRADES, USER_FILLS], callbacks={TRADES: TradeCallback(trade), USER_FILLS: fill}))
+    f.add_feed(FTX(config="config.yaml", symbols=['BTC-USD', 'BCH-USD', 'USDT-USD'], channels=[TRADES, USER_FILLS, ORDER_INFO], callbacks={TRADES: TradeCallback(trade), USER_FILLS: fill, ORDER_INFO: order}))
     f.run()
 
 


### PR DESCRIPTION
Since we now have the ability to subscribe to private authed channels on FTX, this PR adds the ability to subscribe to the "orders" channel. https://docs.ftx.com/?python#orders-2

- [x] - Tested
- [x] - Changelog updated
- [x] - Tests run and pass
- [x] - Flake8 run and all errors/warnings resolved
- [ ] - Contributors file updated (optional)
