### PR TITLE
Fix FTX rest api return value

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@
   * Bugfix: #528 - Fix standardisation of Deribit's symbols when passed to callbacks
   * Feature: Add support for private "orders" channel on FTX
   * Feature: Add support for subaccounts in feeds and REST API for FTX
+  * Bugfix: Fix FTX rest api return value
 
 ### 1.9.1 (2021-06-10)
   * Feature: add Bithumb exchange - l2 book and trades

--- a/cryptofeed/rest/ftx.py
+++ b/cryptofeed/rest/ftx.py
@@ -77,8 +77,8 @@ class FTX(API):
 
         return {'symbol': symbol,
                 'feed': self.ID,
-                'bid': data['result']['bid'],
-                'ask': data['result']['ask']
+                'bid': data['bid'],
+                'ask': data['ask']
                 }
 
     def l2_book(self, symbol: str, retry=None, retry_wait=0):
@@ -87,11 +87,11 @@ class FTX(API):
         return {
             BID: sd({
                 u[0]: u[1]
-                for u in data['result']['bids']
+                for u in data['bids']
             }),
             ASK: sd({
                 u[0]: u[1]
-                for u in data['result']['asks']
+                for u in data['asks']
             })
         }
 


### PR DESCRIPTION
Since we return 'result' from the returned result's json, we need to avoid accessing the 'result' of 'result'.

- [x] - Tested
- [x] - Changelog updated
- [x] - Tests run and pass
- [x] - Flake8 run and all errors/warnings resolved
- [ ] - Contributors file updated (optional)
