### PR TITLE
Get information about size increment from FTX symbol data

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,7 @@
   * Exchange: New exchange - dYdX
   * Bugfix: Issue #531 - Gemini symbol generation included closed symbols
   * Feature: Allow user to override the score used in Redis ZSETs
+  * Update: Get information about size increment from FTX symbol data
 
 ### 1.9.1 (2021-06-10)
   * Feature: add Bithumb exchange - l2 book and trades

--- a/cryptofeed/exchange/ftx.py
+++ b/cryptofeed/exchange/ftx.py
@@ -45,6 +45,7 @@ class FTX(Feed):
             symbol = d['name']
             ret[normalized] = symbol
             info['tick_size'][normalized] = d['priceIncrement']
+            info['quantity_step'][normalized] = d['sizeIncrement']
         return ret, info
 
     def __init__(self, subaccount=None, **kwargs):


### PR DESCRIPTION
This change will give the user more info about the symbol's quantity step on FTX. This tends to be useful for placing orders etc.

- [x] - Tested
- [x] - Changelog updated
- [x] - Tests run and pass; 2 failing tests before and after
- [x] - Flake8 run and all errors/warnings resolved
- [ ] - Contributors file updated (optional)
