### PR TITLE
Deribit authenticated channels feeds

### DIFF
--- a/cryptofeed/callback.py
+++ b/cryptofeed/callback.py
@@ -113,3 +113,11 @@ class AccBalancesCallback(Callback):
 
 class AccTransactionsCallback(Callback):
     pass
+
+
+class UserFillsCallback(Callback):
+    pass
+
+class L1BookCallback(Callback):
+    pass
+

--- a/cryptofeed/defines.py
+++ b/cryptofeed/defines.py
@@ -50,6 +50,7 @@ COINGECKO = 'COINGECKO'
 
 
 # Market Data
+L1_BOOK = 'l1_book'
 L2_BOOK = 'l2_book'
 L3_BOOK = 'l3_book'
 BOOK_DELTA = 'book_delta'

--- a/cryptofeed/exchange/bybit.py
+++ b/cryptofeed/exchange/bybit.py
@@ -55,7 +55,7 @@ class Bybit(Feed):
         return ret, info
 
     def __init__(self, **kwargs):
-        super().__init__({'USD': 'wss://stream.bybit.com/realtime', 'USDT': 'wss://stream.bybit.com/realtime_public', 'USDT_PRIV': 'wss://stream.bybit.com/realtime_private'}, **kwargs)
+        super().__init__({'USD': 'wss://stream.bybit.com/realtime', 'USDT': 'wss://stream.bybit.com/realtime_public'}, **kwargs)
 
     def __reset(self, quote=None):
         if quote is None:

--- a/cryptofeed/standards.py
+++ b/cryptofeed/standards.py
@@ -232,10 +232,12 @@ _feed_to_exchange_map = {
         BITCOINCOM: 'subscribeReports',
         HITBTC: 'subscribeReports',
         DERIBIT: 'user.orders',
+        BYBIT: 'order',
     },
     USER_FILLS: {
         FTX: 'fills',
         DERIBIT: 'user.trades',
+        BYBIT: 'execution',
     },
     CANDLES: {
         BEQUANT: 'subscribeCandles',

--- a/cryptofeed/standards.py
+++ b/cryptofeed/standards.py
@@ -17,7 +17,7 @@ from cryptofeed.defines import (BEQUANT, BINANCE, BINANCE_DELIVERY, BINANCE_FUTU
                                 DERIBIT, DYDX, EXX, FTX, FTX_US, GATEIO, GEMINI, HITBTC, HUOBI, HUOBI_DM, HUOBI_SWAP,
                                 KRAKEN, KRAKEN_FUTURES, KUCOIN, OKCOIN, OKEX, POLONIEX, PROBIT, ACC_TRANSACTIONS, UPBIT, USER_FILLS)
 from cryptofeed.defines import (FILL_OR_KILL, IMMEDIATE_OR_CANCEL, LIMIT, MAKER_OR_CANCEL, MARKET, UNSUPPORTED)
-from cryptofeed.defines import (ACC_BALANCES, FUNDING, FUTURES_INDEX, L2_BOOK, L3_BOOK, LIQUIDATIONS, OPEN_INTEREST, MARKET_INFO,
+from cryptofeed.defines import (ACC_BALANCES, FUNDING, FUTURES_INDEX, L1_BOOK, L2_BOOK, L3_BOOK, LIQUIDATIONS, OPEN_INTEREST, MARKET_INFO,
                                 TICKER, TRADES, ORDER_INFO)
 from cryptofeed.exceptions import UnsupportedDataFeed, UnsupportedTradingOption
 
@@ -45,6 +45,9 @@ def timestamp_normalize(exchange, ts):
 
 
 _feed_to_exchange_map = {
+    L1_BOOK: {
+        DERIBIT: 'quote'
+    },    
     L2_BOOK: {
         DYDX: 'v3_orderbook',
         BEQUANT: 'subscribeOrderbook',
@@ -228,9 +231,11 @@ _feed_to_exchange_map = {
         BEQUANT: 'subscribeReports',
         BITCOINCOM: 'subscribeReports',
         HITBTC: 'subscribeReports',
+        DERIBIT: 'user.orders',
     },
     USER_FILLS: {
         FTX: 'fills',
+        DERIBIT: 'user.trades',
     },
     CANDLES: {
         BEQUANT: 'subscribeCandles',
@@ -256,6 +261,7 @@ _feed_to_exchange_map = {
         BEQUANT: 'subscribeBalance',
         BITCOINCOM: 'subscribeBalance',
         HITBTC: 'subscribeBalance',
+        DERIBIT: 'user.portfolio',
     },
 }
 

--- a/examples/demo_bybit_authenticated.py
+++ b/examples/demo_bybit_authenticated.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python
+
+from cryptofeed import FeedHandler
+from cryptofeed.callback import OrderInfoCallback, UserFillsCallback, TradeCallback
+from cryptofeed.defines import BYBIT, ORDER_INFO, USER_FILLS, TRADES
+
+
+async def order(feed, symbol, data: dict, receipt_timestamp):
+    print(f"{feed}: {symbol}: Order update: {data}")
+
+async def fill(feed, symbol, data: dict, receipt_timestamp):
+    print(f"{feed}: {symbol}: Fill update: {data}")
+
+async def trade(feed, symbol, order_id, timestamp, side, amount, price, receipt):
+    print(f"Timestamp: {timestamp} Feed: {feed} Pair: {symbol} ID: {order_id} Side: {side} Amount: {amount} Price: {price}")
+
+def main():
+
+    f = FeedHandler(config="config.yaml")
+    f.add_feed(BYBIT,
+                channels=[USER_FILLS, ORDER_INFO, TRADES],
+                symbols=["ETH-USD-1231"],
+                callbacks={USER_FILLS: UserFillsCallback(fill), ORDER_INFO: OrderInfoCallback(order), TRADES: TradeCallback(trade)},
+                timeout=-1		
+    )    
+    
+    f.run()
+
+if __name__ == '__main__':
+    main()

--- a/examples/demo_deribit.py
+++ b/examples/demo_deribit.py
@@ -1,6 +1,6 @@
 from cryptofeed import FeedHandler
-from cryptofeed.callback import BookCallback, TickerCallback, TradeCallback
-from cryptofeed.defines import BID, ASK, FUNDING, L2_BOOK, OPEN_INTEREST, TICKER, TRADES
+from cryptofeed.callback import BookCallback, TickerCallback, TradeCallback, L1BookCallback
+from cryptofeed.defines import BID, ASK, FUNDING, L1_BOOK, L2_BOOK, OPEN_INTEREST, TICKER, TRADES
 from cryptofeed.exchanges import Deribit
 
 
@@ -23,6 +23,9 @@ async def funding(**kwargs):
 async def oi(feed, symbol, open_interest, timestamp, receipt_timestamp):
     print(f'Timestamp: {timestamp} Feed: {feed} Pair: {symbol} open interest: {open_interest}')
 
+async def quote(feed, symbol, bid_price, ask_price, bid_amount, ask_amount, timestamp, receipt_timestamp):
+    print(f'Timestamp: {timestamp} Feed: {feed} Symbol: {symbol} Best bid (amount): {bid_price} ({bid_amount}) Best ask (amount): {ask_price} ({ask_amount})')
+
 
 def main():
     f = FeedHandler()
@@ -33,6 +36,8 @@ def main():
     sub = {TRADES: ["BTC-USD-PERPETUAL"], TICKER: ['ETH-USD-PERPETUAL'], FUNDING: ['ETH-USD-PERPETUAL'], OPEN_INTEREST: ['ETH-USD-PERPETUAL']}
     f.add_feed(Deribit(subscription=sub, callbacks={OPEN_INTEREST: oi, FUNDING: funding, TICKER: TickerCallback(ticker), TRADES: TradeCallback(trade)}))
     f.add_feed(Deribit(symbols=['BTC-USD-PERPETUAL'], channels=[L2_BOOK], callbacks={L2_BOOK: BookCallback(book)}))
+    
+    f.add_feed(Deribit(symbols=["ETH-24JUN22", "BTC-24JUN22-50000-C"], channels=[L1_BOOK], callbacks={L1_BOOK: L1BookCallback(quote)}))
 
     f.run()
 

--- a/examples/demo_deribit_authenticated.py
+++ b/examples/demo_deribit_authenticated.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python
+
+from cryptofeed import FeedHandler
+from cryptofeed.callback import OrderInfoCallback, AccBalancesCallback, UserFillsCallback, L1BookCallback
+from cryptofeed.defines import DERIBIT, ORDER_INFO, ACC_BALANCES, USER_FILLS, L1_BOOK
+
+
+async def quote(feed, symbol, bid_price, ask_price, bid_amount, ask_amount, timestamp, receipt_timestamp):
+    print(f"{feed} Symbol: {symbol} Best price (amount): bid: {bid_price} ({bid_amount}) ask: {ask_price} ({ask_amount})")
+
+async def order(feed, symbol, data: dict, receipt_timestamp):
+    print(f"{feed}: {symbol}: Order update: {data}")
+
+async def fill(feed, symbol, data: dict, receipt_timestamp):
+    print(f"{feed}: {symbol}: Fill update: {data}")
+
+async def balance(feed, currency, data: dict, receipt_timestamp):
+    print(f"{feed}: {currency}: Balance update: {data}")
+
+def main():
+
+    f = FeedHandler(config="config.yaml")
+    f.add_feed(DERIBIT,
+                channels=[L1_BOOK],
+                symbols=["BTC-24JUN22", "BTC-24JUN22-50000-C"],
+                callbacks={L1_BOOK: L1BookCallback(quote)},
+                timeout=-1
+    )
+    f.add_feed(DERIBIT,
+                channels=[USER_FILLS, ORDER_INFO],
+                symbols=["ETH-USD-PERPETUAL", "BTC-USD-PERPETUAL", "ETH-24JUN22", "BTC-24JUN22-50000-C"],
+                callbacks={USER_FILLS: UserFillsCallback(fill), ORDER_INFO: OrderInfoCallback(order)},
+                timeout=-1		
+    )    
+    f.add_feed(DERIBIT,
+                channels=[ACC_BALANCES],
+                symbols=['BTC', 'ETH'],
+                callbacks={ACC_BALANCES: AccBalancesCallback(balance)},
+	            timeout=-1
+    )    
+
+    f.run()
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This pull request code implements feeds and callbacks to authenticated (user) channels at Deribit exchange: `ORDER_INFO`,  `USER_FILLS`, `ACC_BALANCES`

Also `L1_BOOK` channel subscription introduced and implemented.
L1 order book =  `best bid/ask prices` +  ` best bid/ask amounts` data feed.

- [x] - Tested
- [ ] - Changelog updated
- [ ] - Tests run and pass
- [ ] - Flake8 run and all errors/warnings resolved
- [ ] - Contributors file updated (optional)
