### PR TITLE
Add support for private channels on Bybit

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -10,3 +10,4 @@ Cryptofeed was originally created by Bryant Moscon, but many others have contrib
 * [Alex](https://github.com/globophobe)
 * [Michael Zhao](https://github.com/dynamikey) - <mr_michaelzhao@hotmail.com>
 * [Tim Meggs](https://github.com/twmeggs) - <twmeggs@gmail.com>
+* [O. Janche](https://github.com/toyan) - <toyan@yandex.ru>

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 ## Changelog
 
 ### 1.9.3
+  * Feature: Add support for private channels USER_FILLS and ORDER_INFO on Bybit
   * Bugfix: Fix demo.py
   * Feature: Allow user to specify a delay when starting an exchange connection (useful for avoiding 429s when creating a large number of feeds)
   * Update: Support Okex v5

--- a/cryptofeed/callback.py
+++ b/cryptofeed/callback.py
@@ -109,3 +109,7 @@ class AccBalancesCallback(Callback):
 
 class AccTransactionsCallback(Callback):
     pass
+
+
+class UserFillsCallback(Callback):
+    pass

--- a/cryptofeed/standards.py
+++ b/cryptofeed/standards.py
@@ -227,9 +227,14 @@ _feed_to_exchange_map = {
         BEQUANT: 'subscribeReports',
         BITCOINCOM: 'subscribeReports',
         HITBTC: 'subscribeReports',
+        BYBIT: 'order',
+        DERIBIT: 'user.orders',
+
     },
     USER_FILLS: {
         FTX: 'fills',
+        BYBIT: 'execution',
+        DERIBIT: 'user.trades',
     },
     CANDLES: {
         BEQUANT: 'subscribeCandles',

--- a/examples/demo_bybit.py
+++ b/examples/demo_bybit.py
@@ -22,8 +22,8 @@ async def book(feed, symbol, book, timestamp, receipt):
 def main():
     f = FeedHandler()
 
-    f.add_feed(Bybit(symbols=['BTC-USD', 'ETH-USD', 'XRP-USD', 'EOS-USD'], channels=[TRADES], callbacks={TRADES: TradeCallback(trade)}))
-    f.add_feed(Bybit(symbols=['BTC-USD', 'ETH-USD', 'XRP-USD', 'EOS-USD'], channels=[L2_BOOK], callbacks={L2_BOOK: BookCallback(book)}))
+    f.add_feed(Bybit(symbols=['BTC-USD-PERP', 'ETH-USD-PERP', 'XRP-USD-PERP', 'EOS-USD-PERP'], channels=[TRADES], callbacks={TRADES: TradeCallback(trade)}))
+    f.add_feed(Bybit(symbols=['BTC-USD-PERP', 'ETH-USD-PERP', 'XRP-USD-PERP', 'EOS-USD-PERP'], channels=[L2_BOOK], callbacks={L2_BOOK: BookCallback(book)}))
 
     f.run()
 

--- a/examples/demo_bybit_authenticated.py
+++ b/examples/demo_bybit_authenticated.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python
+
+from cryptofeed import FeedHandler
+from cryptofeed.callback import OrderInfoCallback, UserFillsCallback
+from cryptofeed.defines import BYBIT, ORDER_INFO, USER_FILLS
+
+
+async def order(feed, symbol, data: dict, receipt_timestamp):
+    print(f"{feed}: {symbol}: Order update: {data}")
+
+
+async def fill(feed, symbol, data: dict, receipt_timestamp):
+    print(f"{feed}: {symbol}: Fill update: {data}")
+
+
+async def trade(feed, symbol, order_id, timestamp, side, amount, price, receipt):
+    print(f"Timestamp: {timestamp} Feed: {feed} Pair: {symbol} ID: {order_id} Side: {side} Amount: {amount} Price: {price}")
+
+
+def main():
+
+    f = FeedHandler(config="config.yaml")
+    f.add_feed(BYBIT,
+               channels=[USER_FILLS, ORDER_INFO],
+               symbols=["ETH-USD-21Z31", "EOS-USD-PERP", "SOL-USDT-PERP"],
+               callbacks={USER_FILLS: UserFillsCallback(fill), ORDER_INFO: OrderInfoCallback(order)},
+               timeout=-1)
+
+    f.run()
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Add support for private (authenticated) channels `USER_FILLS` and `ORDER_INFO` on Bybit for derivatives market. 
Recently launched SPOT market on Bybit is not supported in this implementation.

- [x] - Tested
- [x] - Changelog updated
- [x] - Tests run and pass
- [x] - Flake8 run and all errors/warnings resolved
- [x] - Contributors file updated (optional)
