### PR TITLE
Add support for user channels on Deribit

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,8 @@
 ## Changelog
 
 ### 1.9.3
+  * Feature: Add support for private channels USER_FILLS, ORDER_INFO, ACC_BALANCES on Deribit
+  * Feature: Add support for public channel L1_BOOK on Deribit
   * Feature: Add support for private channels USER_FILLS and ORDER_INFO on Bybit
   * Bugfix: Fix demo.py
   * Feature: Allow user to specify a delay when starting an exchange connection (useful for avoiding 429s when creating a large number of feeds)

--- a/cryptofeed/callback.py
+++ b/cryptofeed/callback.py
@@ -113,3 +113,7 @@ class AccTransactionsCallback(Callback):
 
 class UserFillsCallback(Callback):
     pass
+
+
+class L1BookCallback(Callback):
+    pass

--- a/cryptofeed/defines.py
+++ b/cryptofeed/defines.py
@@ -48,6 +48,7 @@ UPBIT = 'UPBIT'
 
 
 # Market Data
+L1_BOOK = 'l1_book'
 L2_BOOK = 'l2_book'
 L3_BOOK = 'l3_book'
 BOOK_DELTA = 'book_delta'

--- a/cryptofeed/standards.py
+++ b/cryptofeed/standards.py
@@ -17,7 +17,7 @@ from cryptofeed.defines import (BEQUANT, BINANCE, BINANCE_DELIVERY, BINANCE_FUTU
                                 DERIBIT, DYDX, EXX, FTX, FTX_US, GATEIO, GEMINI, HITBTC, HUOBI, HUOBI_DM, HUOBI_SWAP,
                                 KRAKEN, KRAKEN_FUTURES, KUCOIN, OKCOIN, OKEX, POLONIEX, PROBIT, ACC_TRANSACTIONS, UPBIT, USER_FILLS)
 from cryptofeed.defines import (FILL_OR_KILL, IMMEDIATE_OR_CANCEL, LIMIT, MAKER_OR_CANCEL, MARKET, UNSUPPORTED)
-from cryptofeed.defines import (ACC_BALANCES, FUNDING, FUTURES_INDEX, L2_BOOK, L3_BOOK, LIQUIDATIONS, OPEN_INTEREST,
+from cryptofeed.defines import (ACC_BALANCES, FUNDING, FUTURES_INDEX, L1_BOOK, L2_BOOK, L3_BOOK, LIQUIDATIONS, OPEN_INTEREST,
                                 TICKER, TRADES, ORDER_INFO)
 from cryptofeed.exceptions import UnsupportedDataFeed, UnsupportedTradingOption
 
@@ -47,6 +47,9 @@ def timestamp_normalize(exchange, ts):
 
 
 _feed_to_exchange_map = {
+    L1_BOOK: {
+        DERIBIT: 'quote',
+    },
     L2_BOOK: {
         DYDX: 'v3_orderbook',
         BEQUANT: 'subscribeOrderbook',
@@ -260,6 +263,7 @@ _feed_to_exchange_map = {
         BEQUANT: 'subscribeBalance',
         BITCOINCOM: 'subscribeBalance',
         HITBTC: 'subscribeBalance',
+        DERIBIT: 'user.portfolio',
     },
 }
 

--- a/examples/demo_deribit_authenticated.py
+++ b/examples/demo_deribit_authenticated.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python
+
+from cryptofeed import FeedHandler
+from cryptofeed.callback import OrderInfoCallback, AccBalancesCallback, UserFillsCallback
+from cryptofeed.defines import DERIBIT, ORDER_INFO, ACC_BALANCES, USER_FILLS
+
+
+async def order(feed, symbol, data: dict, receipt_timestamp):
+    print(f"{feed}: {symbol}: Order update: {data}")
+
+
+async def fill(feed, symbol, data: dict, receipt_timestamp):
+    print(f"{feed}: {symbol}: Fill update: {data}")
+
+
+async def balance(feed, currency, data: dict, receipt_timestamp):
+    print(f"{feed}: Currency: {currency} Balance update: {data}")
+
+
+def main():
+    f = FeedHandler(config="config.yaml")
+
+    f.add_feed(DERIBIT,
+               channels=[USER_FILLS, ORDER_INFO],
+               symbols=["ETH-USD-PERP", "BTC-USD-PERP", "ETH-USD-22M24", "BTC-50000-22M24-call"],
+               callbacks={USER_FILLS: UserFillsCallback(fill), ORDER_INFO: OrderInfoCallback(order)},
+               timeout=-1)
+    f.add_feed(DERIBIT,
+               channels=[ACC_BALANCES],
+               symbols=["BTC", "ETH"],
+               callbacks={ACC_BALANCES: AccBalancesCallback(balance)},
+               timeout=-1)
+    f.run()
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Introduced `L1_BOOK` definition. It streams best bid/ask prices with their amounts (unlike of 'ticker').
Add support for public channel `L1_BOOK` on Deribit.
Add support for authenticated channels `ORDER_INFO`, `USER_FILLS`, `ACC_BALANCES` on Deribit.


### Description of code - what bug does this fix / what feature does this add?

- [x] - Tested
- [x] - Changelog updated
- [x] - Tests run and pass
- [x] - Flake8 run and all errors/warnings resolved
- [ ] - Contributors file updated (optional)
