### PR TITLE
Support for private channel USER_DATA, public channel LAST_PRICE on Phemex

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 ## Changelog
 
 ### 1.9.3
+  * Feature: Add support for private channel USER_DATA, public channel LAST_PRICE on Phemex
   * Feature: Add support for private channels USER_FILLS, ORDER_INFO, ACC_BALANCES on Deribit
   * Feature: Add support for public channel L1_BOOK on Deribit
   * Feature: Add support for private channels USER_FILLS and ORDER_INFO on Bybit

--- a/cryptofeed/callback.py
+++ b/cryptofeed/callback.py
@@ -117,3 +117,11 @@ class UserFillsCallback(Callback):
 
 class L1BookCallback(Callback):
     pass
+
+
+class UserDataCallback(Callback):
+    pass
+
+
+class LastPriceCallback(Callback):
+    pass

--- a/cryptofeed/defines.py
+++ b/cryptofeed/defines.py
@@ -60,13 +60,14 @@ LIQUIDATIONS = 'liquidations'
 FUTURES_INDEX = 'futures_index'
 UNSUPPORTED = 'unsupported'
 CANDLES = 'candles'
+LAST_PRICE = 'last_price'
 
 # Account Data / Authenticated Channels
 ORDER_INFO = 'order_info'
 USER_FILLS = 'user_fills'
 ACC_TRANSACTIONS = 'transactions'
 ACC_BALANCES = 'balances'
-
+USER_DATA = 'user_data'
 
 BUY = 'buy'
 SELL = 'sell'

--- a/cryptofeed/exchange/phemex.py
+++ b/cryptofeed/exchange/phemex.py
@@ -71,7 +71,6 @@ class Phemex(Feed):
 
     def __reset(self):
         self.l2_book = {}
-        self.accounts = {}
 
     async def _book(self, msg: dict, timestamp: float):
         """
@@ -116,10 +115,6 @@ class Phemex(Feed):
         await self.book_callback(self.l2_book[symbol], L2_BOOK, symbol, forced, delta, ts, timestamp)
 
     async def _trade(self, msg: dict, timestamp: float):
-        # for i in range(len(msg['trades'])):
-        #     print(f'--{i}--')
-        #     print(msg['trades'][i])
-        # quit()
         """
         {
             'sequence': 9047166781,
@@ -185,7 +180,6 @@ class Phemex(Feed):
                             receipt_timestamp=timestamp)
 
     async def _user_data(self, msg: dict, timestamp: float):
-
         await self.callback(USER_DATA, feed=self.id, data=msg, receipt_timestamp=timestamp)
 
     def connect(self) -> List[Tuple[AsyncConnection, Callable[[None], None], Callable[[str, float], None]]]:

--- a/cryptofeed/standards.py
+++ b/cryptofeed/standards.py
@@ -15,10 +15,10 @@ import datetime as dt
 from cryptofeed.defines import (BEQUANT, BINANCE, BINANCE_DELIVERY, BINANCE_FUTURES, BINANCE_US, BITCOINCOM, BITFLYER, BITFINEX,
                                 BITHUMB, ASCENDEX, BITMEX, PHEMEX, BITSTAMP, BITTREX, BLOCKCHAIN, BYBIT, CANDLES, COINBASE,
                                 DERIBIT, DYDX, EXX, FTX, FTX_US, GATEIO, GEMINI, HITBTC, HUOBI, HUOBI_DM, HUOBI_SWAP,
-                                KRAKEN, KRAKEN_FUTURES, KUCOIN, OKCOIN, OKEX, POLONIEX, PROBIT, ACC_TRANSACTIONS, UPBIT, USER_FILLS)
+                                KRAKEN, KRAKEN_FUTURES, KUCOIN, OKCOIN, OKEX, POLONIEX, PROBIT, UPBIT)
 from cryptofeed.defines import (FILL_OR_KILL, IMMEDIATE_OR_CANCEL, LIMIT, MAKER_OR_CANCEL, MARKET, UNSUPPORTED)
-from cryptofeed.defines import (ACC_BALANCES, FUNDING, FUTURES_INDEX, L1_BOOK, L2_BOOK, L3_BOOK, LIQUIDATIONS, OPEN_INTEREST,
-                                TICKER, TRADES, ORDER_INFO)
+from cryptofeed.defines import (ACC_BALANCES, ACC_TRANSACTIONS, FUNDING, FUTURES_INDEX, L1_BOOK, L2_BOOK, L3_BOOK, LIQUIDATIONS, OPEN_INTEREST,
+                                TICKER, TRADES, ORDER_INFO, USER_DATA, USER_FILLS, LAST_PRICE)
 from cryptofeed.exceptions import UnsupportedDataFeed, UnsupportedTradingOption
 
 
@@ -265,6 +265,13 @@ _feed_to_exchange_map = {
         HITBTC: 'subscribeBalance',
         DERIBIT: 'user.portfolio',
     },
+    USER_DATA: {
+        DERIBIT: 'user.changes',
+        PHEMEX: 'aop.subscribe',
+    },
+    LAST_PRICE: {
+        PHEMEX: 'tick.subscribe',
+    },
 }
 
 _exchange_options = {
@@ -358,4 +365,4 @@ def normalize_channel(exchange: str, feed: str) -> str:
 
 
 def is_authenticated_channel(channel: str) -> bool:
-    return channel in (ORDER_INFO, USER_FILLS, ACC_TRANSACTIONS, ACC_BALANCES)
+    return channel in (ORDER_INFO, USER_FILLS, ACC_TRANSACTIONS, ACC_BALANCES, USER_DATA)

--- a/examples/demo_phemex.py
+++ b/examples/demo_phemex.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python
+from decimal import Decimal
+from cryptofeed import FeedHandler
+from cryptofeed.callback import BookCallback, TradeCallback, CandleCallback, UserDataCallback, LastPriceCallback
+from cryptofeed.defines import BID, ASK, PHEMEX, L2_BOOK, TRADES, CANDLES, LAST_PRICE, USER_DATA
+
+
+'''
+    Public channels supported:
+        L2_BOOK, TRADES, CANDLES, LAST_PRICE
+
+    Authenticated channel: USER_DATA
+        It streams info regarding user accounts, orders and positions.
+        Latest account snapshot messages will be sent immediately on subscription,
+        and incremental messages will be sent for later updates.
+        Each account snapshot contains a trading account information, holding positions,
+        and open / max 100 closed / max 100 filled order event message history.
+'''
+
+
+async def trade(feed, symbol, order_id, timestamp, side, amount, price, receipt_timestamp):
+    assert isinstance(timestamp, float)
+    assert isinstance(side, str)
+    assert isinstance(amount, Decimal)
+    assert isinstance(price, Decimal)
+    print(f'{feed} Trades: {symbol}: Side: {side} Amount: {amount} Price: {price} Time: {timestamp}')
+
+
+async def book(feed, symbol, book, timestamp, receipt_timestamp):
+    print(f'{feed} Book: {symbol}: Book Bid Size is {len(book[BID])} Ask Size is {len(book[ASK])} Time: {timestamp}')
+
+
+async def candle(feed, symbol, start, stop, interval, trades, open_price, close_price, high_price, low_price, volume, closed, timestamp, receipt_timestamp):
+    print(f'{feed} Candle: {symbol}: Start: {start} Stop: {stop} Interval: {interval} Trades: {trades} Open: {open_price} Close: {close_price} High: {high_price} Low: {low_price} Volume: {volume} Candle Closed? {closed} Time: {timestamp}')
+
+
+async def price(feed, symbol, last_price, receipt_timestamp):
+    print(f'{feed} Price: {symbol}: {last_price}')
+
+
+async def userdata(feed, data: dict, receipt_timestamp):
+    print(f'{feed} User data update: {data}')
+
+
+def main():
+    f = FeedHandler(config="config.yaml")
+
+    f.add_feed(PHEMEX, channels=[L2_BOOK, TRADES, CANDLES],
+               symbols=["ETH-USD-PERP", "BTC-USD-PERP"],
+               callbacks={L2_BOOK: BookCallback(book), TRADES: TradeCallback(trade), CANDLES: CandleCallback(candle)})
+
+    f.add_feed(PHEMEX, channels=[LAST_PRICE], symbols=["ETH-USD-PERP", "BTC-USD-PERP"], callbacks={LAST_PRICE: LastPriceCallback(price)})
+
+    f.add_feed(PHEMEX, channels=[USER_DATA], symbols=["BTC-USD-PERP"], callbacks={USER_DATA: UserDataCallback(userdata)}, timeout=-1)
+
+    f.run()
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
- Implemented authenticated channel `USER_DATA` on Phemex.
    It streams info regarding user accounts, orders and positions.
    Latest account snapshot messages will be sent immediately on subscription,
    and incremental messages will be sent for later updates.
    Each account snapshot contains a trading account information, holding positions,
    and open / max 100 closed / max 100 filled order event message history.

- Implemented public channel `LAST_PRICE` on Phemex.
    It is very simple channel: unlike of 'ticker' and 'book' it streams last price only, no bids/ask, no amounts.


- [x] - Tested
- [x] - Changelog updated
- [x] - Tests run and pass
- [x] - Flake8 run and all errors/warnings resolved
- [ ] - Contributors file updated (optional)
