### PR TITLE
Fix check_update_id in BinanceFutures & BinanceDelivery

### DIFF
--- a/cryptofeed/exchange/binance_delivery.py
+++ b/cryptofeed/exchange/binance_delivery.py
@@ -30,9 +30,10 @@ class BinanceDelivery(Binance):
         self.rest_endpoint = 'https://dapi.binance.com/dapi/v1'
         self.address = self._address()
 
-    def _check_update_id(self, pair: str, msg: dict) -> Tuple[bool, bool]:
+    def _check_update_id(self, pair: str, msg: dict) -> Tuple[bool, bool, bool]:
         skip_update = False
         forced = not self.forced[pair]
+        current_match = self.last_update_id[pair] == msg['u']
 
         if forced and msg['u'] < self.last_update_id[pair]:
             skip_update = True
@@ -45,7 +46,7 @@ class BinanceDelivery(Binance):
             self._reset()
             LOG.warning("%s: Missing book update detected, resetting book", self.id)
             skip_update = True
-        return skip_update, forced
+        return skip_update, forced, current_match
 
     async def message_handler(self, msg: str, conn, timestamp: float):
         msg = json.loads(msg, parse_float=Decimal)

--- a/cryptofeed/exchange/binance_futures.py
+++ b/cryptofeed/exchange/binance_futures.py
@@ -44,9 +44,10 @@ class BinanceFutures(Binance):
         self.rest_endpoint = 'https://fapi.binance.com/fapi/v1'
         self.address = self._address()
 
-    def _check_update_id(self, pair: str, msg: dict) -> Tuple[bool, bool]:
+    def _check_update_id(self, pair: str, msg: dict) -> Tuple[bool, bool, bool]:
         skip_update = False
         forced = not self.forced[pair]
+        current_match = self.last_update_id[pair] == msg['u']
 
         if forced and msg['u'] < self.last_update_id[pair]:
             skip_update = True
@@ -59,7 +60,7 @@ class BinanceFutures(Binance):
             self._reset()
             LOG.warning("%s: Missing book update detected, resetting book", self.id)
             skip_update = True
-        return skip_update, forced
+        return skip_update, forced, current_match
 
     async def _open_interest(self, msg: dict, timestamp: float):
         """


### PR DESCRIPTION
Include 'current_match' when checking for update_id in BinanceFutures and BinanceDelivery.

- [x] - Tested
- [ ] - Changelog updated
- [x] - Tests run and pass
- [x] - Flake8 run and all errors/warnings resolved
- [ ] - Contributors file updated (optional)
