### PR TITLE
Remove typo in Binance rest api

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,7 @@
   * Breaking Change: Rework how REST endpoints are integrated into exchange classes. Rest module has been removed. REST methods are part of exchanges classes.
   * Feature: Add support for funding data in Bybit
   * Update: Correct and update sections of the documentation.
+  * Bugfix: Remove typo in Binance rest api
 
 ### 1.9.2 (2021-07-14)
   * Bugfix: add config kwarg to add_nbbo method

--- a/cryptofeed/exchanges/mixins/binance_rest.py
+++ b/cryptofeed/exchanges/mixins/binance_rest.py
@@ -54,7 +54,7 @@ class BinanceDeliveryRestMixin(RestExchange):
 
     def _trade_normalization(self, symbol: str, trade: list) -> dict:
         ret = {
-            'timestamp': self.self.timestamp_normalize(trade['T']),
+            'timestamp': self.timestamp_normalize(trade['T']),
             'symbol': self.exchange_symbol_to_std_symbol(symbol),
             'id': trade['a'],
             'feed': self.id,

--- a/cryptofeed/exchanges/mixins/binance_rest.py
+++ b/cryptofeed/exchanges/mixins/binance_rest.py
@@ -154,7 +154,7 @@ class BinanceFuturesRestMixin(RestExchange):
 
     def _trade_normalization(self, symbol: str, trade: list) -> dict:
         ret = {
-            'timestamp': self.self.timestamp_normalize(trade['T']),
+            'timestamp': self.timestamp_normalize(trade['T']),
             'symbol': self.exchange_symbol_to_std_symbol(symbol),
             'id': trade['a'],
             'feed': self.id,


### PR DESCRIPTION
Remove typo in function call in Binance rest api

- [x] - Tested
- [x] - Changelog updated
- [x] - Tests run and pass
- [x] - Flake8 run and all errors/warnings resolved
- [ ] - Contributors file updated (optional)
