### PR TITLE
Kraken info dict fix

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 ### 2.0.0
  * Feature: Binance REST support
  * Feature: Add next funding rate data to FTX funding data
+ * Bugfix: Kraken info dict returning empty
 
 ### 1.9.3 (2021-08-05)
   * Feature: Add support for private channel USER_DATA, public channel LAST_PRICE on Phemex

--- a/cryptofeed/exchanges/kraken.py
+++ b/cryptofeed/exchanges/kraken.py
@@ -5,6 +5,7 @@ Please see the LICENSE file for the terms and conditions
 associated with this software.
 '''
 from decimal import Decimal
+from collections import defaultdict
 from functools import partial
 import logging
 from typing import Callable, Dict, List, Tuple
@@ -41,7 +42,7 @@ class Kraken(Feed, KrakenRestMixin):
     @classmethod
     def _parse_symbol_data(cls, data: dict) -> Tuple[Dict, Dict]:
         ret = {}
-        info = defaultDi
+        info = defaultdict(dict)
 
         for symbol in data['result']:
             if 'wsname' not in data['result'][symbol] or '.d' in symbol:
@@ -56,7 +57,7 @@ class Kraken(Feed, KrakenRestMixin):
 
             ret[s.normalized] = data['result'][symbol]['wsname']
             info['instrument_type'][s.normalized] = s.type
-        return ret, {}
+        return ret, info
 
     def __init__(self, candle_interval='1m', max_depth=1000, **kwargs):
         lookup = {'1m': 1, '5m': 5, '15m': 15, '30m': 30, '1h': 60, '4h': 240, '1d': 1440, '1w': 10080, '15d': 21600}

--- a/cryptofeed/exchanges/kraken.py
+++ b/cryptofeed/exchanges/kraken.py
@@ -4,7 +4,6 @@ Copyright (C) 2017-2021  Bryant Moscon - bmoscon@gmail.com
 Please see the LICENSE file for the terms and conditions
 associated with this software.
 '''
-from cryptofeed.symbols import Symbol
 from decimal import Decimal
 from functools import partial
 import logging
@@ -18,6 +17,7 @@ from cryptofeed.connection import AsyncConnection, WSAsyncConn
 from cryptofeed.defines import BID, ASK, BUY, CANDLES, KRAKEN, L2_BOOK, SELL, TICKER, TRADES
 from cryptofeed.exceptions import BadChecksum
 from cryptofeed.feed import Feed
+from cryptofeed.symbols import Symbol
 from cryptofeed.util.split import list_by_max_items
 from cryptofeed.exchanges.mixins.kraken_rest import KrakenRestMixin
 
@@ -41,7 +41,7 @@ class Kraken(Feed, KrakenRestMixin):
     @classmethod
     def _parse_symbol_data(cls, data: dict) -> Tuple[Dict, Dict]:
         ret = {}
-        info = {'instrument_type': {}}
+        info = defaultDi
 
         for symbol in data['result']:
             if 'wsname' not in data['result'][symbol] or '.d' in symbol:


### PR DESCRIPTION
_parse_symbol_data was returning an empty dict instead of the info dict

- [X] - Tested
- [X] - Changelog updated
- [ ] - Tests run and pass
- [X] - Flake8 run and all errors/warnings resolved
- [ ] - Contributors file updated (optional)
