### PR TITLE
Fix typo by renaming rest_options to order_options

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@
  * Feature: Remove pandas dependency
  * Breaking Change: Rewrite all rest endpoints to support sync and async versions of the endpoint.
  * Feature: Add dYdX REST endpoints
+ * Bugfix: Fix typo by renaming rest_options to order_options
 
 ### 1.9.3 (2021-08-05)
   * Feature: Add support for private channel USER_DATA, public channel LAST_PRICE on Phemex

--- a/cryptofeed/exchanges/mixins/coinbase_rest.py
+++ b/cryptofeed/exchanges/mixins/coinbase_rest.py
@@ -31,7 +31,7 @@ class CoinbaseRestMixin(RestExchange):
     rest_channels = (
         TRADES, TICKER, L2_BOOK, L3_BOOK, ORDER_INFO, ORDER_STATUS, CANDLES, CANCEL_ORDER, PLACE_ORDER, BALANCES, TRADE_HISTORY
     )
-    rest_options = {
+    order_options = {
         LIMIT: 'limit',
         MARKET: 'market',
         FILL_OR_KILL: {'time_in_force': 'FOK'},

--- a/cryptofeed/exchanges/mixins/gemini_rest.py
+++ b/cryptofeed/exchanges/mixins/gemini_rest.py
@@ -25,7 +25,7 @@ class GeminiRestMixin(RestExchange):
     rest_channels = (
         TRADES, TICKER, L2_BOOK, ORDER_STATUS, CANCEL_ORDER, PLACE_ORDER, BALANCES, TRADE_HISTORY
     )
-    rest_options = {
+    order_options = {
         LIMIT: 'exchange limit',
         FILL_OR_KILL: 'fill-or-kill',
         IMMEDIATE_OR_CANCEL: 'immediate-or-cancel',
@@ -134,7 +134,7 @@ class GeminiRestMixin(RestExchange):
     async def place_order(self, symbol: str, side: str, order_type: str, amount: Decimal, price=None, client_order_id=None, options=None):
         if not price:
             raise ValueError('Gemini only supports limit orders, must specify price')
-        ot = self.order_options(order_type)
+        ot = self.normalize_order_options(order_type)
         sym = self.std_symbol_to_exchange_symbol(symbol)
 
         parameters = {
@@ -143,7 +143,7 @@ class GeminiRestMixin(RestExchange):
             'side': side,
             'amount': str(amount),
             'price': str(price),
-            'options': [self.order_options(o) for o in options] if options else []
+            'options': [self.normalize_order_options(o) for o in options] if options else []
         }
 
         if client_order_id:

--- a/cryptofeed/exchanges/mixins/kraken_rest.py
+++ b/cryptofeed/exchanges/mixins/kraken_rest.py
@@ -28,7 +28,7 @@ class KrakenRestMixin(RestExchange):
     rest_channels = (
         TRADES, TICKER, L2_BOOK, ORDER_STATUS, CANCEL_ORDER, PLACE_ORDER, BALANCES, ORDERS, TRADE_HISTORY
     )
-    rest_options = {
+    order_options = {
         LIMIT: 'limit',
         MARKET: 'market',
         MAKER_OR_CANCEL: 'post'

--- a/cryptofeed/exchanges/mixins/poloniex_rest.py
+++ b/cryptofeed/exchanges/mixins/poloniex_rest.py
@@ -29,7 +29,7 @@ class PoloniexRestMixin(RestExchange):
     rest_channels = (
         TRADES, TICKER, L2_BOOK, ORDER_INFO, ORDER_STATUS, CANCEL_ORDER, PLACE_ORDER, BALANCES, TRADE_HISTORY
     )
-    rest_options = {
+    order_options = {
         LIMIT: 'limit',
         FILL_OR_KILL: 'fillOrKill',
         IMMEDIATE_OR_CANCEL: 'immediateOrCancel',


### PR DESCRIPTION
Fix typo by renaming rest_options to order_options

- [x] - Tested
- [x] - Changelog updated
- [x] - Tests run and pass
- [x] - Flake8 run and all errors/warnings resolved
- [ ] - Contributors file updated (optional)
