### PR TITLE
Add authentication to Phemex user data stream

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,7 @@
  * Bugfix: Binance Futures not correctly formatting the side on liquidations
  * Bugfix: Interval from candle_sync was not being passed correctly to async candle interface in REST mixins.
  * Update: Cleanup Coinbase candle REST interface, use standard string interval
+ * Bugfix: Authenticate Phemex user data stream
 
 ### 1.9.3 (2021-08-05)
   * Feature: Add support for private channel USER_DATA, public channel LAST_PRICE on Phemex

--- a/cryptofeed/exchange.py
+++ b/cryptofeed/exchange.py
@@ -10,7 +10,7 @@ import logging
 from datetime import datetime as dt, timezone
 from typing import Dict, Optional, Tuple, Union
 
-from cryptofeed.defines import CANDLES, FUNDING, L2_BOOK, L3_BOOK, OPEN_INTEREST, TICKER, TRADES, TRANSACTIONS, BALANCES, ORDER_INFO, USER_FILLS
+from cryptofeed.defines import CANDLES, FUNDING, L2_BOOK, L3_BOOK, OPEN_INTEREST, TICKER, TRADES, TRANSACTIONS, BALANCES, ORDER_INFO, USER_FILLS, USER_DATA
 from cryptofeed.symbols import Symbol, Symbols
 from cryptofeed.connection import HTTPSync
 from cryptofeed.exceptions import UnsupportedDataFeed, UnsupportedSymbol, UnsupportedTradingOption
@@ -113,7 +113,7 @@ class Exchange:
 
     @classmethod
     def is_authenticated_channel(cls, channel: str) -> bool:
-        return channel in (ORDER_INFO, USER_FILLS, TRANSACTIONS, BALANCES)
+        return channel in (ORDER_INFO, USER_FILLS, TRANSACTIONS, BALANCES, USER_DATA)
 
     def exchange_symbol_to_std_symbol(self, symbol: str) -> str:
         try:

--- a/cryptofeed/raw_data_collection.py
+++ b/cryptofeed/raw_data_collection.py
@@ -62,7 +62,7 @@ async def _playback(feed: str, filenames: list):
         if 'ws' not in f and 'http' not in f:
             exchange = f.rsplit("/", 1)[1]
             exchange = exchange.split(".", 1)[0]
-            with open(f, 'r') as fp:
+            with open(f, 'r', encoding='utf-8') as fp:
                 for line in fp.readlines():
                     if 'configuration' in line:
                         sub = json.loads(line.split(": ", 1)[1])


### PR DESCRIPTION
Phemex user data stream was not authenticated and no data was received.

Fixes regression error from https://github.com/bmoscon/cryptofeed/commit/311150b8ee1b09060662e9f019c3f1d43d4e0d31 when authenticate method was added to phemex.py.

- [x] - Tested
- [x] - Changelog updated
- [x] - Tests run and pass
- [x] - Flake8 run and all errors/warnings resolved
- [ ] - Contributors file updated (optional)
