### PR TITLE
fix _change handler for coinbase

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 ### 2.0.1
  * Bugfix: Upbit REST candles do not work when start/end are not specified
  * Bugfix: New version of websockets enforces RFC rules and non-compliant exchanges will fail to connect.
+ * Bugfix: Coinbase book _change handler passing wrong book type
 
 ### 2.0.0 (2021-09-11)
  * Feature: Binance REST support

--- a/cryptofeed/exchanges/coinbase.py
+++ b/cryptofeed/exchanges/coinbase.py
@@ -328,7 +328,7 @@ class Coinbase(Feed, CoinbaseRestMixin):
 
         delta[side].append((order_id, price, new_size))
 
-        await self.book_callback(L3_BOOK, self._l3_book, timestamp, delta=delta, timestamp=ts, raw=msg, sequence_number=msg['sequence'])
+        await self.book_callback(L3_BOOK, self._l3_book[pair], timestamp, delta=delta, timestamp=ts, raw=msg, sequence_number=msg['sequence'])
 
     async def message_handler(self, msg: str, conn: AsyncConnection, timestamp: float):
         # PERF perf_start(self.id, 'msg')


### PR DESCRIPTION
### Description of code - what bug does this fix / what feature does this add?

There is a typo in _change handler which will pass a dict instead of OrderBook object to book_callback.
The fix is just pass OrderBook

- [x] - Tested
- [x] - Changelog updated
- [x] - Tests run and pass
- [x] - Flake8 run and all errors/warnings resolved
- [ ] - Contributors file updated (optional)
