### PR TITLE
fix/kraken-timestamp - convert string timestamp to a float when passing it to a callback

### DIFF
--- a/cryptofeed/exchanges/kraken.py
+++ b/cryptofeed/exchanges/kraken.py
@@ -208,7 +208,7 @@ class Kraken(Feed, KrakenRestMixin):
             Decimal(low),
             Decimal(volume),
             None,
-            start,
+            float(start),
             raw=msg
         )
         await self.callback(CANDLES, c, timestamp)


### PR DESCRIPTION
In `Types.pyx`, the timestamp of a `Candle` is supposed to be a float (or None) but this is not enforced by the type system:
```
cdef class Candle:
    cdef readonly str exchange
    ...
    cdef readonly object timestamp  # None or float
    ...
```
I noticed that in the Kraken exchange code for Candles, the timestamp is not correctly converted to a float, but is rather passed as a string. This one-liner fixes the issue.

Also this is my first PR on this repo, what exactly do you expect regarding the testing, changelog and stuff? I didn't open an issue for this because it's such a small bugfix.

### Description of code - what bug does this fix / what feature does this add?

- [ ] - Tested
- [ ] - Changelog updated
- [ ] - Tests run and pass
- [ ] - Flake8 run and all errors/warnings resolved
- [ ] - Contributors file updated (optional)
