### PR TITLE
Coinbase level 3 book has a potential memory leak in `order_type_map`. 

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,7 @@
  * Feature: Candle support for Bybit
  * Bugfix: Fix L3 Book Deltas when use as_type kwarg in to_dict
  * Bugfix: Use V3 endpoint for book snapshots in Binance and BinanceUS
+ * Bugfix: Coinbase level 3 book potential memory leak
 
 ### 2.0.0 (2021-09-11)
  * Feature: Binance REST support

--- a/cryptofeed/exchanges/coinbase.py
+++ b/cryptofeed/exchanges/coinbase.py
@@ -261,6 +261,9 @@ class Coinbase(Feed, CoinbaseRestMixin):
         for orders which are not on the book should be ignored when maintaining a real-time order book.
         """
         if 'price' not in msg:
+            # market order life cycle: received -> done
+            self.order_type_map.pop(msg['order_id'], None)
+            self.order_map.pop(msg['order_id'], None)
             return
 
         order_id = msg['order_id']


### PR DESCRIPTION
### Description of code 

Coinbase level 3 book has a potential memory leak in `order_type_map`. I think it is getting worse when more market order comes in.

The order life cycle start from `receive` and ends with `done`. While in received handler order_id is added to `order_type_map`. But in done handler, there is a silent code path just returns (as far as I see, only market order goes to this path), which leave order_id in order_type_map forever. 

And I do see some strange memory increase in one long run task with Coinbase:

<img width="993" alt="image" src="https://user-images.githubusercontent.com/8540575/133898392-11dfbe46-c066-4de2-8d8e-b89096210db9.png">


Here is an example:

```
2021-09-18 19:04:43.808500 Received: {'type': 'received', 'side': 'buy', 'product_id': 'BTC-USD', 'time': datetime.datetime(2021, 9, 18, 18, 4, 43, 17479, tzinfo=datetime.timezone.utc), 'sequence': 29393561378, 'order_id': '56ad1700-a0e8-4160-bc52-52bb90a7620f', 'order_type': 'market', 'funds': '2996.98563228', 'client_oid': '25ee3b4d-7d06-49be-f3b9-571d2ee54596'}
2021-09-18 19:04:43.808558 Done: {'type': 'done', 'side': 'buy', 'product_id': 'BTC-USD', 'time': datetime.datetime(2021, 9, 18, 18, 4, 43, 17479, tzinfo=datetime.timezone.utc), 'sequence': 29393561380, 'order_id': '56ad1700-a0e8-4160-bc52-52bb90a7620f', 'reason': 'filled'}.
Length of order_map: 80584
Length of order_type_map: 23
In order_map? False
In order_type_map? True


2021-09-18 19:04:54.100835 Received: {'type': 'received', 'side': 'buy', 'product_id': 'BTC-USD', 'time': datetime.datetime(2021, 9, 18, 18, 4, 54, 44696, tzinfo=datetime.timezone.utc), 'sequence': 29393564381, 'order_id': 'edec5316-9c43-4c02-be64-6206034b427f', 'order_type': 'market', 'funds': '24.974978127', 'client_oid': 'bdc7803b-0109-4635-9d4f-33e42e0f8c5d'}
2021-09-18 19:04:54.101325 Done: {'type': 'done', 'side': 'buy', 'product_id': 'BTC-USD', 'time': datetime.datetime(2021, 9, 18, 18, 4, 54, 44696, tzinfo=datetime.timezone.utc), 'sequence': 29393564383, 'order_id': 'edec5316-9c43-4c02-be64-6206034b427f', 'reason': 'filled'}.
Length of order_map: 80589
Length of order_type_map: 233
In order_map? False
In order_type_map? True

We got this in receive handler

{'type': 'received', 'side': 'buy', 'product_id': 'BTC-USD', 'time': datetime.datetime(2021, 9, 18, 18, 4, 54, 44696, tzinfo=datetime.timezone.utc), 'sequence': 29393564381, 'order_id': 'edec5316-9c43-4c02-be64-6206034b427f', 'order_type': 'market', 'funds': '24.974978127', 'client_oid': 'bdc7803b-0109-4635-9d4f-33e42e0f8c5d'}

And then in done handler, we got this msg, and it does not have a price field, hence go away silently. But we left 50e541ec-edec5316-9c43-4c02-be64-6206034b427f' in order_type_map forever. 

{'type': 'done', 'side': 'buy', 'product_id': 'BTC-USD', 'time': datetime.datetime(2021, 9, 18, 18, 4, 54, 44696, tzinfo=datetime.timezone.utc), 'sequence': 29393564383, 'order_id': 'edec5316-9c43-4c02-be64-6206034b427f', 'reason': 'filled'}.
```

Given that any order_id goes in to done handler will never show again, we could also clean the order_map dict in the same code path. (Although I didn't observe any leak in order_map yet....)

- [x] - Tested
- [x] - Changelog updated
- [x] - Tests run and pass
- [x] - Flake8 run and all errors/warnings resolved
- [ ] - Contributors file updated (optional)
