### PR TITLE
Fixed symbol normalization for Huobi Swap funding and FTX open interest.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,7 @@
  * Feature: Perpetual support for Bitfinex
  * Feature: Type checking in Cython code (disabled by default, enable in setup.py)
  * Bugfix: Fix type issues in OKEx and Binance Futures - some numeric data being returned as string
+ * Bugfix: Fix symbol normalization in FTX and Huoni Swap
 
 ### 2.0.0 (2021-09-11)
  * Feature: Binance REST support

--- a/cryptofeed/exchanges/ftx.py
+++ b/cryptofeed/exchanges/ftx.py
@@ -171,7 +171,7 @@ class FTX(Feed, FTXRestMixin):
                     if oi != self._open_interest_cache.get(pair, None):
                         o = OpenInterest(
                             self.id,
-                            pair,
+                            self.exchange_symbol_to_std_symbol(pair),
                             oi,
                             None,
                             raw=data

--- a/cryptofeed/exchanges/huobi_swap.py
+++ b/cryptofeed/exchanges/huobi_swap.py
@@ -80,7 +80,7 @@ class HuobiSwap(HuobiDM):
 
                 f = Funding(
                     self.id,
-                    pair,
+                    self.exchange_symbol_to_std_symbol(pair),
                     None,
                     Decimal(data['data']['funding_rate']),
                     self.timestamp_normalize(int(data['data']['next_funding_time'])),


### PR DESCRIPTION
### Description of code - what bug does this fix / what feature does this add?
This code fixes the omission of symbol normalization for the `funding` channel of `HuobiSwap`, as raised in https://github.com/bmoscon/cryptofeed/issues/642. A second occurrence was also found in `open_interest` of `FTX`. 

- [x] - Tested
- [x] - Changelog updated
- [x] - Tests run and pass
- [x] - Flake8 run and all errors/warnings resolved
- [ ] - Contributors file updated (optional)
