### PR TITLE
config redis writer sleep interval instead of hard code 0.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,6 +22,7 @@
  * Feature: Type checking in Cython code (disabled by default, enable in setup.py)
  * Bugfix: Fix type issues in OKEx and Binance Futures - some numeric data being returned as string
  * Bugfix: Fix symbol normalization in FTX and Huoni Swap
+ * Feature: Redis backend to choose sleep interval for writer
 
 ### 2.0.0 (2021-09-11)
  * Feature: Binance REST support


### PR DESCRIPTION
### Description of code

Add option to config sleep interval for redis backend. The reason is that I notice that sleep 0 make this backend having high CPU usage for nearly nothing. Simply change it to 10 ms make CPU usage drop a lot. 

- [x] - Tested
- [x] - Changelog updated
- [x] - Tests run and pass
- [ ] - Flake8 run and all errors/warnings resolved
- [ ] - Contributors file updated (optional)
