### PR TITLE
Fix compile with/without assertions

### DIFF
--- a/cryptofeed/types.pyx
+++ b/cryptofeed/types.pyx
@@ -316,7 +316,7 @@ cdef class OrderBook:
     def to_dict(self, delta=False, as_type=None) -> dict:
         assert self.sequence_number is None or isinstance(self.sequence_number, int)
         assert self.checksum is None or isinstance(self.checksum, (str, int))
-        assert self.timestamp is None or isinstance(self.timestamp, Decimal)
+        assert self.timestamp is None or isinstance(self.timestamp, float)
 
         def helper(x):
             if isinstance(x, dict):

--- a/cryptofeed/types.pyx
+++ b/cryptofeed/types.pyx
@@ -10,6 +10,17 @@ from cryptofeed.defines import BID, ASK
 from order_book import OrderBook as _OrderBook
 
 
+cdef extern from *:
+    """
+    #ifdef CYTHON_WITHOUT_ASSERTIONS
+    #define _COMPILED_WITH_ASSERTIONS 0
+    #else
+    #define _COMPILED_WITH_ASSERTIONS 1
+    #endif
+    """
+    cdef bint _COMPILED_WITH_ASSERTIONS
+COMPILED_WITH_ASSERTIONS = _COMPILED_WITH_ASSERTIONS
+
 cdef class Trade:
     cdef readonly str exchange
     cdef readonly str symbol

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ associated with this software.
 import os
 import sys
 
-from setuptools import setup
+from setuptools import Extension, setup
 from setuptools import find_packages
 from setuptools.command.test import test as TestCommand
 from Cython.Build import cythonize
@@ -32,13 +32,20 @@ class Test(TestCommand):
         sys.exit(errno)
 
 
-# comment out line below to enable type checking in cython code (via assertions)
-os.environ['CFLAGS'] = '-DCYTHON_WITHOUT_ASSERTIONS'
+extra_compile_args = ["/O2" if os.name == "nt" else "-O3"]
+define_macros = []
 
+# comment out line to compile with type check assertions
+# verify value at runtime with cryptofeed.types.COMPILED_WITH_ASSERTIONS
+define_macros.append(('CYTHON_WITHOUT_ASSERTIONS', None))
+
+extension = Extension("cryptofeed.types", ["cryptofeed/types.pyx"],
+                      extra_compile_args=extra_compile_args,
+                      define_macros=define_macros)
 
 setup(
     name="cryptofeed",
-    ext_modules=cythonize("cryptofeed/types.pyx", language_level=3),
+    ext_modules=cythonize([extension], language_level=3, force=True),
     version="2.0.2",
     author="Bryant Moscon",
     author_email="bmoscon@gmail.com",
@@ -76,7 +83,7 @@ setup(
         'uvloop ; platform_system!="Windows"',
         # Two (optional) dependencies that speed up Cryptofeed:
         "aiodns>=1.1",  # aiodns speeds up DNS resolving
-        "cchardet",     # cchardet is a faster replacement for chardet
+        "cchardet",  # cchardet is a faster replacement for chardet
         "order_book>=0.4.0"
     ],
     extras_require={

--- a/tests/unit/test_runtime_type_assertions.py
+++ b/tests/unit/test_runtime_type_assertions.py
@@ -1,0 +1,14 @@
+import pytest
+from cryptofeed.types import COMPILED_WITH_ASSERTIONS, Ticker
+
+
+@pytest.mark.skipif(not COMPILED_WITH_ASSERTIONS, reason="cython assertions not enabled")
+def test_ticker_raises_with_bad_args_if_assertions_enabled():
+    with pytest.raises(AssertionError):
+        # bid and ask should be Decimal, not str
+        Ticker(exchange="", symbol="", bid="1.0", ask="2.0", timestamp=None)
+        
+@pytest.mark.skipif(COMPILED_WITH_ASSERTIONS, reason="cython assertions enabled")
+def test_ticker_does_not_raise_with_bad_args_if_assertions_not_enabled():
+    # bid and ask should be Decimal, not str, but it should not raise
+    Ticker(exchange="", symbol="", bid="1.0", ask="2.0", timestamp=None)


### PR DESCRIPTION
I think this would be the best platform independent way to compile with/without type check assertions

- Comment out line in setup.py to compile with assertions
- Use cythonize Extension idiom
- Force recompile to prevent caching c file after enabling assertions
- expose cryptofeed.types.COMPILED_WITH_ASSERTIONS
- add unit tests for whether assertions are enabled