### PR TITLE
Fix TypeError reduce-only order price on FTX

### DIFF
--- a/cryptofeed/exchanges/ftx.py
+++ b/cryptofeed/exchanges/ftx.py
@@ -398,7 +398,7 @@ class FTX(Feed, FTXRestMixin):
             BUY if order['side'].lower() == 'buy' else SELL,
             status,
             LIMIT if order['type'] == 'limit' else MARKET,
-            Decimal(order['price']),
+            Decimal(order['price']) if order['price'] else None,
             Decimal(order['filledSize']),
             Decimal(order['remainingSize']),
             None,


### PR DESCRIPTION
FTX order will not send None for price with reduce-only orders, so Decimal(None) fails TypeError

Here's what FTX will send:
```
{'id': 12345, 'clientId': 'multipart-fffffff', 'market': 'XXX-PERP', 'type': 'market', 'side': 'buy', 'price': None, 'size': Decimal('10.0'), 'status': 'closed', 'filledSize': Decimal('10.0'), 'remainingSize': Decimal('0.0'), 'reduceOnly': True, 'liquidation': False, 'avgFillPrice': Decimal('0.1234'), 'postOnly': False, 'ioc': True, 'createdAt': datetime.datetime(2021, 10, 1, 1, 1, 1, 123456, tzinfo=datetime.timezone.utc)}
```

### Description of code - what bug does this fix / what feature does this add?

- [ ] - Tested
- [ ] - Changelog updated
- [ ] - Tests run and pass
- [ ] - Flake8 run and all errors/warnings resolved
- [ ] - Contributors file updated (optional)
