### PR TITLE
Skip subscriptions for open-interest for SPOT on OKEx that generate errors

### DIFF
--- a/cryptofeed/exchanges/okex.py
+++ b/cryptofeed/exchanges/okex.py
@@ -136,6 +136,8 @@ class OKEx(Feed):
                     instrument_type = self.instrument_type(sym)
                     if instrument_type != PERPETUAL and 'funding' in chan:
                         continue  # No funding for spot, futures and options
+                    if instrument_type == SPOT and chan == 'open-interest':
+                        continue  # No open interest for spot
                     request = {"op": "subscribe", "args": [{"channel": chan, "instId": symbol}]}
                     await conn.write(json.dumps(request))
 


### PR DESCRIPTION
This change skips `SPOT` symbols when subscribing to `open-interest` on OKEx. There is obviously no open interest for spot, and exchange returns the following error. It doesn't break existing code, but the error is still annoying. This happens e.g. when subscribing to a number of channels across a range of symbols.

```
[feedhandler] ERROR: OKEX: Error: {'event': 'error', 'msg': "channel:open-interest,instId:BCH-USDK doesn't exist", 'code': '60018'}
```

- [x] - Tested
- [ ] - Changelog updated
- [ ] - Tests run and pass
- [ ] - Flake8 run and all errors/warnings resolved
- [ ] - Contributors file updated (optional)
