### PR TITLE
dYdX perpetual swaps are incorrectly interepreted as spot

### DIFF
--- a/cryptofeed/exchanges/dydx.py
+++ b/cryptofeed/exchanges/dydx.py
@@ -38,10 +38,11 @@ class dYdX(Feed, dYdXRestMixin):
         for symbol, entry in data['markets'].items():
             if entry['status'] != 'ONLINE':
                 continue
-            s = Symbol(entry['baseAsset'], entry['quoteAsset'])
+            stype = entry['type'].lower()
+            s = Symbol(entry['baseAsset'], entry['quoteAsset'], type=stype)
             ret[s.normalized] = symbol
             info['tick_size'][s.normalized] = entry['tickSize']
-            info['instrument_type'][s.normalized] = s.type
+            info['instrument_type'][s.normalized] = stype
         return ret, info
 
     def __init__(self, **kwargs):


### PR DESCRIPTION
All the intestruments currently available on dYdX's latest API are [perpetual swaps](https://docs.dydx.exchange/#general), but they are incorrectly interpreted as spot. There is actually a `type` available within instrument definition, which should be used.

- [x] - Tested
- [ ] - Changelog updated
- [ ] - Tests run and pass
- [ ] - Flake8 run and all errors/warnings resolved
- [ ] - Contributors file updated (optional)
