### PR TITLE
 Some ideas for revamping REST

### DIFF
--- a/cryptofeed/defines.py
+++ b/cryptofeed/defines.py
@@ -125,6 +125,30 @@ GET = 'GET'
 DELETE = 'DELETE'
 POST = 'POST'
 
+# Timestamp Standarization
+TIMESTAMP = 'timestamp'
+TS_SCALE = 'timestamp_scale'
+TS_DECIMAL_PLACES = 'timestamp_decimal_places'
+NANOSECONDS = 'nanoseconds'
+MICROSECONDS = 'microseconds'
+MILLISECONDS = 'milliseconds'
+SECONDS = 'seconds'
+
+# REST-API Standarizaion
+SIDE = 'side'
+AMOUNT = 'amount'
+PRICE = 'price'
+BID_AMOUNT = 'bid_amount'
+BID_PRICE = 'bid_price'
+ASK_AMOUNT = 'ask_amount'
+ASK_PRICE = 'ask_price'
+SYMBOL = 'symbol'
+FEED = 'feed'
+ID = 'id'
+START = 'start'
+END = 'end'
+LIMIT = 'limit'
+
 
 """
 L2 Orderbook Layout

--- a/cryptofeed/exchanges/binance.py
+++ b/cryptofeed/exchanges/binance.py
@@ -16,7 +16,13 @@ from urllib.parse import urlencode
 from yapic import json
 
 from cryptofeed.connection import AsyncConnection, HTTPPoll, HTTPConcurrentPoll
-from cryptofeed.defines import ASK, BALANCES, BID, BINANCE, BUY, CANDLES, FUNDING, FUTURES, L2_BOOK, LIMIT, LIQUIDATIONS, MARKET, OPEN_INTEREST, ORDER_INFO, PERPETUAL, SELL, SPOT, TICKER, TRADES, FILLED, UNFILLED
+#import new defines concerning timestamps
+from cryptofeed.defines import (
+    ASK, BALANCES, BID, BINANCE, BUY, CANDLES, FUNDING, FUTURES, 
+    L2_BOOK, LIMIT, LIQUIDATIONS, MARKET, OPEN_INTEREST, ORDER_INFO, 
+    PERPETUAL, SELL, SPOT, TICKER, TRADES, FILLED, UNFILLED, TS_SCALE,
+    TS_DECIMAL_PLACES, MILLISECONDS
+)
 from cryptofeed.feed import Feed
 from cryptofeed.symbols import Symbol
 from cryptofeed.exchanges.mixins.binance_rest import BinanceRestMixin
@@ -45,6 +51,14 @@ class Binance(Feed, BinanceRestMixin):
         ORDER_INFO: ORDER_INFO
     }
     request_limit = 20
+    '''
+    add timestamp dict class variable with information that can be utilized to employ
+    a std_ts_to_exchange_ts function, and vice, versa. 
+    '''
+    timestamp = {
+        TS_SCALE : MILLISECONDS,
+        TS_DECIMAL_PLACES : 0
+        }
 
     @classmethod
     def timestamp_normalize(cls, ts: float) -> float:

--- a/cryptofeed/exchanges/mixins/binance_rest.py
+++ b/cryptofeed/exchanges/mixins/binance_rest.py
@@ -14,167 +14,93 @@ from urllib.parse import urlencode
 
 from yapic import json
 
-from cryptofeed.defines import BALANCES, BUY, CANCEL_ORDER, CANDLES, DELETE, FILL_OR_KILL, GET, GOOD_TIL_CANCELED, IMMEDIATE_OR_CANCEL, LIMIT, MARKET, ORDERS, ORDER_STATUS, PLACE_ORDER, POSITIONS, POST, SELL, TRADES
+#import new defines
+from cryptofeed.defines import (BALANCES, BUY, CANCEL_ORDER, CANDLES, DELETE, 
+    FILL_OR_KILL, GET, GOOD_TIL_CANCELED, IMMEDIATE_OR_CANCEL, LIMIT, MARKET, 
+    ORDERS, ORDER_STATUS, PLACE_ORDER, POSITIONS, POST, SELL, TRADES, FEED, 
+    SYMBOL, BID, ASK, L2_BOOK, TICKER, BID_PRICE, BID_AMOUNT, ASK_PRICE, ASK_AMOUNT, 
+    START, END, LIMIT, TIMESTAMP, SIDE, BUY, AMOUNT, PRICE)
 from cryptofeed.exchange import RestExchange
 from cryptofeed.types import Candle
+#import the new helper classes
+from cryptofeed.util.payloads import Payload
+from cryptofeed.util.keymapping import Keymap, access_route
 
 
 LOG = logging.getLogger('feedhandler')
 
 
 class BinanceRestMixin(RestExchange):
-    api = "https://api.binance.com/api/v3/"
-    rest_channels = (
-        TRADES, ORDER_STATUS, CANCEL_ORDER, PLACE_ORDER, BALANCES, ORDERS, CANDLES
-    )
-    order_options = {
-        LIMIT: 'LIMIT',
-        MARKET: 'MARKET',
-        FILL_OR_KILL: 'FOK',
-        IMMEDIATE_OR_CANCEL: 'IOC',
-        GOOD_TIL_CANCELED: 'GTC',
+    rest_channels = [
+        TICKER, 
+        L2_BOOK, 
+        TRADES]
+    '''
+    basic request data is defined at class level, minimalizes the need to pass
+    numerous parameters. 
+    ''' 
+    api_endpoints = {
+        TICKER      : 'https://api.binance.com/api/v3/ticker/bookTicker',
+        L2_BOOK     : 'https://api.binance.com/api/v3/depth',
+        TRADES      : 'https://api.binance.com/api/v3/aggTrades',
     }
+    methods = {
+        TICKER : GET,
+        L2_BOOK : GET,
+        TRADES : GET,
+    }
+    payload_as_params = {
+        TICKER : True, 
+        L2_BOOK : True,
+        TRADES : True,
+    }
+    
 
-    def _nonce(self):
-        return str(int(round(time.time() * 1000)))
-
-    def _generate_signature(self, query_string: str):
-        h = hmac.new(self.key_secret.encode('utf8'), query_string.encode('utf8'), hashlib.sha256)
-        return h.hexdigest()
-
-    async def _request(self, method: str, endpoint: str, auth: bool = False, payload={}, api=None):
-        query_string = urlencode(payload)
-        if auth:
-            if query_string:
-                query_string = '{}&timestamp={}'.format(query_string, self._nonce())
-            else:
-                query_string = 'timestamp={}'.format(self._nonce())
-
-        if not api:
-            api = self.api
-
-        url = f'{api}{endpoint}?{query_string}'
-        header = {}
-        if auth:
-            signature = self._generate_signature(query_string)
-            url += f'&signature={signature}'
-            header = {
-                "X-MBX-APIKEY": self.key_id,
-            }
-        if method == GET:
-            data = await self.http_conn.read(url, header=header)
-        elif method == POST:
-            data = await self.http_conn.write(url, msg=None, header=header)
-        elif method == DELETE:
-            data = await self.http_conn.delete(url, header=header)
-        return json.loads(data, parse_float=Decimal)
-
-    async def trades(self, symbol: str, start=None, end=None, retry_count=1, retry_delay=60):
-        symbol = self.std_symbol_to_exchange_symbol(symbol)
-        start, end = self._interval_normalize(start, end)
-        if start and end:
-            start = int(start * 1000)
-            end = int(end * 1000)
-
-        while True:
-            if start and end:
-                endpoint = f"{self.api}aggTrades?symbol={symbol}&limit=1000&startTime={start}&endTime={end}"
-            else:
-                endpoint = f"{self.api}aggTrades?symbol={symbol}&limit=1000"
-
-            r = await self.http_conn.read(endpoint, retry_count=retry_count, retry_delay=retry_delay)
-            data = json.loads(r, parse_float=Decimal)
-
-            if data:
-                if data[-1]['T'] == start:
-                    LOG.warning("%s: number of trades exceeds exchange time window, some data will not be retrieved for time %d", self.id, start)
-                    start += 1
-                else:
-                    start = data[-1]['T']
-
-            yield [self._trade_normalization(symbol, d) for d in data]
-
-            if len(data) < 1000 or end is None:
-                break
-            await asyncio.sleep(1 / self.request_limit)
-
-    def _trade_normalization(self, symbol: str, trade: list) -> dict:
-        ret = {
-            'timestamp': self.timestamp_normalize(trade['T']),
-            'symbol': self.exchange_symbol_to_std_symbol(symbol),
-            'id': trade['a'],
-            'feed': self.id,
-            'side': BUY if trade['m'] else SELL,
-            'amount': abs(Decimal(trade['q'])),
-            'price': Decimal(trade['p']),
-        }
-        return ret
-
-    async def candles(self, symbol: str, start=None, end=None, interval='1m', retry_count=1, retry_delay=60):
-        sym = self.std_symbol_to_exchange_symbol(symbol)
-        ep = f'{self.api}klines?symbol={sym}&interval={interval}&limit=1000'
-
-        start, end = self._interval_normalize(start, end)
-        if start and end:
-            start = int(start * 1000)
-            end = int(end * 1000)
-
-        while True:
-            if start and end:
-                endpoint = f'{ep}&startTime={start}&endTime={end}'
-            else:
-                endpoint = ep
-            r = await self.http_conn.read(endpoint, retry_count=retry_count, retry_delay=retry_delay)
-            data = json.loads(r, parse_float=Decimal)
-            start = data[-1][6]
-            data = [Candle(self.id, symbol, self.timestamp_normalize(e[0]), self.timestamp_normalize(e[6]), interval, e[8], Decimal(e[1]), Decimal(e[4]), Decimal(e[2]), Decimal(e[3]), Decimal(e[5]), True, self.timestamp_normalize(e[6]), raw=e) for e in data]
-            yield data
-
-            if len(data) < 1000 or end is None:
-                break
-            await asyncio.sleep(1 / self.request_limit)
-
-    # Trading APIs
-    async def place_order(self, symbol: str, side: str, order_type: str, amount: Decimal, price=None, time_in_force=None, test=False):
-        if order_type == MARKET and price:
-            raise ValueError('Cannot specify price on a market order')
-        if order_type == LIMIT:
-            if not price:
-                raise ValueError('Must specify price on a limit order')
-            if not time_in_force:
-                raise ValueError('Must specify time in force on a limit order')
-        ot = self.normalize_order_options(order_type)
-        sym = self.std_symbol_to_exchange_symbol(symbol)
-        parameters = {
-            'symbol': sym,
-            'side': 'BUY' if side is BUY else 'SELL',
-            'type': ot,
-            'quantity': str(amount),
-        }
-        if price:
-            parameters['price'] = str(price)
-        if time_in_force:
-            parameters['timeInForce'] = self.normalize_order_options(time_in_force)
-
-        data = await self._request(POST, 'test' if test else 'order', auth=True, payload=parameters)
-        return data
-
-    async def cancel_order(self, order_id: str, symbol: str):
-        sym = self.std_symbol_to_exchange_symbol(symbol)
-        data = await self._request(DELETE, 'order', auth=True, payload={'symbol': sym, 'orderId': order_id})
-        return data
-
-    async def balances(self):
-        data = await self._request(GET, 'account', auth=True)
-        return data['balances']
-
-    async def orders(self, symbol: str = None):
-        data = await self._request(GET, 'openOrders', auth=True, payload={'symbol': self.std_symbol_to_exchange_symbol(symbol)} if symbol else {})
-        return data
-
-    async def order_status(self, order_id: str):
-        data = await self._request(GET, 'order', auth=True, payload={'orderId': order_id})
-        return data
+    '''all functions only require the instialization of a Payload and Keymap'''
+    async def ticker(self, symbol: str, retry=None, retry_wait=10):
+        payload = Payload({
+        SYMBOL : {'symbol' : None}
+        })
+        keymap = Keymap({
+            SYMBOL : symbol,
+            FEED : self.id,
+            BID : access_route('bidPrice', Decimal),
+            ASK : access_route('askPrice', Decimal)
+        })
+        return await self._rest_ticker(payload, keymap, symbol, retry, retry_wait)
+    
+    async def l2_book(self, symbol: str, retry=None, retry_wait=10):
+        payload = Payload({
+            SYMBOL : {'symbol' : None},
+        })
+        keymap = Keymap({
+            BID_PRICE   : access_route('bids', slice(0, limit), 0, Decimal),
+            BID_AMOUNT  : access_route('bids', slice(0, limit), 1, Decimal),
+            ASK_PRICE   : access_route('bids', slice(0, limit), 0, Decimal),
+            ASK_AMOUNT  : access_route('bids', slice(0, limit), 1, Decimal),
+        })
+        return await self._rest_l2_book(payload, keymap, symbol, limit, retry, retry_wait)
+    
+    async def trades(self, symbol, limit=None, start= None, end=None, retry=None, retry_wait=None):
+        payload = Payload({
+            SYMBOL : {'symbol' : None},
+            START : {'startTime' : None},
+            END :   {'endTime' : None}, 
+            LIMIT : {'limit' : None}
+        })
+        keymap = Keymap({
+            TIMESTAMP   : access_route(slice(None), 'T', self.exchange_ts_to_std_ts),
+            SYMBOL      : symbol,
+            ID          : access_route(slice(None), 'a'),
+            FEED        : self.id,
+            SIDE        : access_route(slice(None), 'm', lambda x : BUY if x is True else SELL),
+            AMOUNT      : access_route(slice(None), 'q', Decimal),
+            PRICE       : access_route(slice(None), 'p', Decimal)
+            
+        })
+        return await self._rest_trades(payload, keymap, symbol, 
+                            limit, start, end, 60*60, retry=retry, 
+                            retry_wait=retry_wait)
 
 
 class BinanceFuturesRestMixin(BinanceRestMixin):

--- a/cryptofeed/util/keymapping.py
+++ b/cryptofeed/util/keymapping.py
@@ -1,0 +1,65 @@
+from typing import Dict
+
+class Payload:
+    '''
+    class which takes a dictionary as input, the values of which corrospond to a payload's specific item.
+    
+    this class allows for easy dynamic manipulation of a payload where successive requests with updated
+    payload's are required. An example is when we wish to get historical trades on binance.
+    
+    for this example we may intiate a payload as such:
+    
+    import time
+    trades_payload = Payload({
+        SYMBOL : {'symbol' : 'BTC-USDT},
+        START  : {'startTime' : time.time()-60*60*3}, # 3 hours in the past
+        END    : {'endTime' : time.time()},
+        
+    })
+    
+    The binance docs specify that the END may not exceed 1 hour beyond the START. 
+    In this case, when we pool data with successive calls, we most curtail the END
+    to not overexceed 1 hour and increment the START by 1 hour. This can be easily done 
+    by utilizing the __get_item__ and __set_item__ dunbar methods, as such:
+    
+    while True:
+        trade_payload[START] = trade_payload[START] + 60*60 # increment by 1 hour
+        trade_payload[END] = trade_payload[START] + 60*60 # make sure END is, at max, only 1 hour ahead
+        requests.get(url=url data=trade_payload())
+        
+        # Data manipulation 
+     
+    
+    
+    As can be seen the the payload itself is returned by utilizing the __call__ dunbar method 
+    (i.e. my_payload() will supply the actual payload)
+    
+    payload items may be deleted using del trade_payload[Key]
+    
+    payload values can be updated by my_payload[key] = some value
+        ->  note: if the value supplied is of type dict the key will be overwritten
+            or newly created with the value being the supplied dict as the payload item   
+    '''
+    
+    def __init__(self, data_dict : Dict[str, dict]):
+        self.payload = data_dict
+        
+    def __getitem__(self, key):
+        return self.payload[key]
+    
+    def __setitem__(self, key, value):
+        if isinstance(value, dict):
+            self.payload[key] = value
+        elif key in self.payload.keys():
+            load = dict() 
+            for k in reversed(self.payload[key]):
+                load  = {k : load} if load else {k : value}
+            self.payload[key].update(load)
+        else:
+            raise KeyError
+    
+    def __call__(self):
+        payload = dict()
+        for load in self.payload.values():
+            payload.update(load) 
+        return payload

--- a/cryptofeed/util/payloads.py
+++ b/cryptofeed/util/payloads.py
@@ -1,0 +1,107 @@
+import json
+from typing import Any, Callable
+
+class access_route(list):
+        def __init__(self, *args, **kwargs):
+            super(access_route, self).__init__(args)
+            
+        ''' 
+        Inherits all functionality of a standard phython list. Is used to differentiate from other sequence objects, 
+        i.e. a Keymap will not extract data with other types as values! Therefore if a value in the Keymap is not of type access_route 
+        we can assume that the value supplied is predefinded. Also increases readability of code.
+        '''
+
+class Keymap:
+    '''
+    Class which takes a dictionary who's values point to a sequence of type access_route. 
+    The access_route can map information from a corrosponding dictionary to the supplied keys.
+        
+    The practical usage for which this class was created is to unify data from differing json_response formats. 
+    
+    For example: if we know the structure of two differing json responses for the price data of a particular stock
+    on two different exchanges we can create a keymap for each exchange to extract the data in a unified manner.
+
+        Code_example:
+        
+        StockExchange_1_keymap = Keymap({'ask' : access_route('request', 'price'), 'bid' : access_route('offer', 'price')})
+        StockExchange_2_keymap = Keymap({'ask' : access_route('ask', 'value' ), 'bid' : access_route('bid', 'value')}) 
+        
+        # Call to corrosponding APIs
+        
+        print(json_response_stock_exchange_1) -> {'request' : {'price' : 12.14}, 'offer' : {'price' : 12:10}}
+        print(json_response_stock_exchange_2) -> {'ask' : {'value' : 12.13}, 'bid' : {'value' : 12.11}}
+        
+        #extract unified response
+        
+        print(StockExchange_1_keymap(json_response_stock_exchange_1)) -> {'ask' : 12.14, 'bid' :  12.10}
+        print(StockExchange_2_keymap(json_response_stock_exchange_2)) -> {'ask' : 12.13, 'bid' :  12.11}
+    
+    How sequences in an access_route are employed:
+       
+        ints and str:
+            these work as simple indices or keys for dictionaries / lists.
+
+        list and slice notation:
+            The keymap is able to utilize slices, as well as list of indices, to extract data from a json response, 
+            this works by applying all further keys to each individual element extracted by the slice / list of indices notation. 
+            the data returned will hence be a list of values.
+            
+        Callables:
+            A callable may be supplied to the keymap, this callable will be applied to each element in the keymap
+            at the specfied location. A practical example would be to supply a function to manipulate the final value, 
+            such as converting millisecond timestamps to timestamps in seconds, or rectifying inverted booleans. 
+
+    Concerning Values that are not of type access_route:
+    
+        if values are not of type access route, the given value is returned, see comment @ access_route for more info. 
+        
+    Considerations for Future:
+        1) Currently a keymap can extract required values from differing json_responses, despite this only a single key 
+        may be mapped to a single value or list of values. Allowing the keymap to restructure data into nested dicts would 
+        cut reliance on post_processing techniques currently employed to fully standarize a json response.
+        
+        2) The Keymap always retrives values packed in lists, which need post_processing attention. 
+        Ideally Keymaps should be able to extract standalone types as they are. 
+    '''
+    
+    allowed_types = (int, str, list, slice, Callable)
+    
+    def __init__(self, keymap : dict[Any:access_route]) -> None:
+        self.keymap = keymap
+        self.data = None
+    
+    def retrive_apriori_data(self):
+        return {k : v for k, v in self.keymap.items() if not isinstance(v, access_route)}
+    
+    def __call__(self, data_dict):
+        if isinstance(data_dict, (dict, list)):
+            self.data = data_dict
+        else:
+            self.data = json.loads(data_dict) 
+        return {key : [*self[key]] for key in self.keymap.keys()}
+    
+    def __getitem__(self, key):
+        if isinstance(self.keymap[key], access_route):
+            
+            def inner(value, depth):
+            
+                if depth == len(self.keymap[key]):
+                    yield value
+                elif isinstance(self.keymap[key][depth], (int, str)):
+                    yield from inner(value[self.keymap[key][depth]], depth+1)
+                elif isinstance(self.keymap[key][depth], (slice, list)):
+                    if isinstance(value, dict):
+                        value = list(value.values())
+                    if isinstance(self.keymap[key][depth], slice):
+                        for val in value[self.keymap[key][depth]]:
+                            yield from inner(val, depth+1)
+                    else:
+                        for i in self.keymap[key][depth]:
+                            yield from inner(value[i], depth+1)
+                elif isinstance(self.keymap[key][depth], Callable):
+                    yield from inner(self.keymap[key][depth](value), depth+1) 
+            
+            yield from inner(self.data, 0)
+        
+        else:
+            yield self.keymap[key]


### PR DESCRIPTION
Hello,

This code isn't fully fledged out, and probably shouldn't be merged for a while, if at all, but I have decided to open a draft pull none-the-less, mainly i just want to gauge if there is any interest in my idea for an overhaul of the REST API before I go any further.

The basic premises is to use keymaps to unify responses from differing exchanges, allow for dynamic manipulation of payloads, add a bunch of class level dictionaries into the Mixin, add a bunch of defines, and a way to translate 'std' and 'exchange' timestamps. All this can be used to make the heavy lifting go to the base RestExchange class and hopefully streamline coding for new exchanges.

I also have an idea of implementing AuthBase from the requests library to streamline authentication.

### Description of code - what bug does this fix / what feature does this add?

- [ ] - Tested
- [ ] - Changelog updated
- [ ] - Tests run and pass
- [ ] - Flake8 run and all errors/warnings resolved
- [ ] - Contributors file updated (optional)
