### PR TITLE
Fix liquidations postgres inserts

### DIFF
--- a/cryptofeed/backends/postgres.py
+++ b/cryptofeed/backends/postgres.py
@@ -132,7 +132,7 @@ class LiquidationsPostgres(PostgresCallback, BackendCallback):
 
     def format(self, data: Tuple):
         exchange, symbol, timestamp, receipt, data = data
-        return f"(DEFAULT,'{timestamp}','{receipt}','{exchange}','{symbol}',{data['price']},'{data['side']}',{data['quantity']},{data['price']},'{data['id']}','{data['status']}')"
+        return f"(DEFAULT,'{timestamp}','{receipt}','{exchange}','{symbol}','{data['side']}',{data['quantity']},{data['price']},'{data['id']}','{data['status']}')"
 
 
 class BookPostgres(PostgresCallback, BackendBookCallback):

--- a/cryptofeed/exchanges/huobi.py
+++ b/cryptofeed/exchanges/huobi.py
@@ -1,9 +1,9 @@
-'''
+"""
 Copyright (C) 2017-2021  Bryant Moscon - bmoscon@gmail.com
 
 Please see the LICENSE file for the terms and conditions
 associated with this software.
-'''
+"""
 from cryptofeed.symbols import Symbol
 from cryptofeed.util.time import timedelta_str_to_sec
 import logging
@@ -19,20 +19,42 @@ from cryptofeed.feed import Feed
 from cryptofeed.types import OrderBook, Trade, Candle, Ticker
 
 
-LOG = logging.getLogger('feedhandler')
+LOG = logging.getLogger("feedhandler")
 
 
 class Huobi(Feed):
     id = HUOBI
-    symbol_endpoint = 'https://api.huobi.pro/v1/common/symbols'
-    websocket_endpoint = 'wss://api.huobi.pro/ws'
-    valid_candle_intervals = {'1m', '5m', '15m', '30m', '1h', '4h', '1d', '1w', '1M', '1Y'}
-    candle_interval_map = {'1m': '1min', '5m': '5min', '15m': '15min', '30m': '30min', '1h': '60min', '4h': '4hour', '1d': '1day', '1M': '1mon', '1w': '1week', '1Y': '1year'}
+    symbol_endpoint = "https://api.huobi.pro/v1/common/symbols"
+    websocket_endpoint = "wss://api.huobi.pro/ws"
+    valid_candle_intervals = {
+        "1m",
+        "5m",
+        "15m",
+        "30m",
+        "1h",
+        "4h",
+        "1d",
+        "1w",
+        "1M",
+        "1Y",
+    }
+    candle_interval_map = {
+        "1m": "1min",
+        "5m": "5min",
+        "15m": "15min",
+        "30m": "30min",
+        "1h": "60min",
+        "4h": "4hour",
+        "1d": "1day",
+        "1M": "1mon",
+        "1w": "1week",
+        "1Y": "1year",
+    }
     websocket_channels = {
-        L2_BOOK: 'depth.step0',
-        TRADES: 'trade.detail',
-        CANDLES: 'kline',
-        TICKER: 'ticker'
+        L2_BOOK: "depth.step0",
+        TRADES: "trade.detail",
+        CANDLES: "kline",
+        TICKER: "ticker",
     }
 
     @classmethod
@@ -42,32 +64,42 @@ class Huobi(Feed):
     @classmethod
     def _parse_symbol_data(cls, data: dict) -> Tuple[Dict, Dict]:
         ret = {}
-        info = {'instrument_type': {}}
+        info = {"instrument_type": {}}
 
-        for e in data['data']:
-            if e['state'] == 'offline':
+        for e in data["data"]:
+            if e["state"] == "offline":
                 continue
-            base, quote = e['base-currency'].upper(), e['quote-currency'].upper()
+            base, quote = e["base-currency"].upper(), e["quote-currency"].upper()
             s = Symbol(base, quote)
 
-            ret[s.normalized] = e['symbol']
-            info['instrument_type'][s.normalized] = s.type
+            ret[s.normalized] = e["symbol"]
+            info["instrument_type"][s.normalized] = s.type
         return ret, info
 
     def __reset(self):
         self._l2_book = {}
 
     async def _book(self, msg: dict, timestamp: float):
-        pair = self.exchange_symbol_to_std_symbol(msg['ch'].split('.')[1])
-        data = msg['tick']
+        pair = self.exchange_symbol_to_std_symbol(msg["ch"].split(".")[1])
+        data = msg["tick"]
         if pair not in self._l2_book:
             self._l2_book[pair] = OrderBook(self.id, pair, max_depth=self.max_depth)
 
-        self._l2_book[pair].book.bids = {Decimal(price): Decimal(amount) for price, amount in data['bids']}
-        self._l2_book[pair].book.asks = {Decimal(price): Decimal(amount) for price, amount in data['asks']}
+        self._l2_book[pair].book.bids = {
+            Decimal(price): Decimal(amount) for price, amount in data["bids"]
+        }
+        self._l2_book[pair].book.asks = {
+            Decimal(price): Decimal(amount) for price, amount in data["asks"]
+        }
 
-        await self.book_callback(L2_BOOK, self._l2_book[pair], timestamp, timestamp=self.timestamp_normalize(msg['ts']), raw=msg)
-    
+        await self.book_callback(
+            L2_BOOK,
+            self._l2_book[pair],
+            timestamp,
+            timestamp=self.timestamp_normalize(msg["ts"]),
+            raw=msg,
+        )
+
     async def _ticker(self, msg: dict, timestamp: float):
         """
         {
@@ -92,11 +124,11 @@ class Huobi(Feed):
         """
         t = Ticker(
             self.id,
-            self.exchange_symbol_to_std_symbol(msg['ch'].split('.')[1]),
-            msg['tick']['bid'],
-            msg['tick']['ask'],
-            self.timestamp_normalize(msg['ts']),
-            raw=msg['tick']
+            self.exchange_symbol_to_std_symbol(msg["ch"].split(".")[1]),
+            msg["tick"]["bid"],
+            msg["tick"]["ask"],
+            self.timestamp_normalize(msg["ts"]),
+            raw=msg["tick"],
         )
         await self.callback(TICKER, t, timestamp)
 
@@ -121,16 +153,16 @@ class Huobi(Feed):
             }
         }
         """
-        for trade in msg['tick']['data']:
+        for trade in msg["tick"]["data"]:
             t = Trade(
                 self.id,
-                self.exchange_symbol_to_std_symbol(msg['ch'].split('.')[1]),
-                BUY if trade['direction'] == 'buy' else SELL,
-                Decimal(trade['amount']),
-                Decimal(trade['price']),
-                self.timestamp_normalize(trade['ts']),
-                id=str(trade['tradeId']),
-                raw=trade
+                self.exchange_symbol_to_std_symbol(msg["ch"].split(".")[1]),
+                BUY if trade["direction"] == "buy" else SELL,
+                Decimal(trade["amount"]),
+                Decimal(trade["price"]),
+                self.timestamp_normalize(trade["ts"]),
+                id=str(trade["tradeId"]),
+                raw=trade,
             )
             await self.callback(TRADES, t, timestamp)
 
@@ -152,7 +184,7 @@ class Huobi(Feed):
         }
         """
         interval = self.normalize_candle_interval[interval]
-        start = int(msg['tick']['id'])
+        start = int(msg["tick"]["id"])
         end = start + timedelta_str_to_sec(interval) - 1
         c = Candle(
             self.id,
@@ -160,15 +192,15 @@ class Huobi(Feed):
             start,
             end,
             interval,
-            msg['tick']['count'],
-            Decimal(msg['tick']['open']),
-            Decimal(msg['tick']['close']),
-            Decimal(msg['tick']['high']),
-            Decimal(msg['tick']['low']),
-            Decimal(msg['tick']['amount']),
+            msg["tick"]["count"],
+            Decimal(msg["tick"]["open"]),
+            Decimal(msg["tick"]["close"]),
+            Decimal(msg["tick"]["high"]),
+            Decimal(msg["tick"]["low"]),
+            Decimal(msg["tick"]["amount"]),
             None,
-            self.timestamp_normalize(msg['ts']),
-            raw=msg
+            self.timestamp_normalize(msg["ts"]),
+            raw=msg,
         )
         await self.callback(CANDLES, c, timestamp)
 
@@ -178,19 +210,19 @@ class Huobi(Feed):
         msg = json.loads(msg, parse_float=Decimal)
 
         # Huobi sends a ping evert 5 seconds and will disconnect us if we do not respond to it
-        if 'ping' in msg:
-            await conn.write(json.dumps({'pong': msg['ping']}))
-        elif 'status' in msg and msg['status'] == 'ok':
+        if "ping" in msg:
+            await conn.write(json.dumps({"pong": msg["ping"]}))
+        elif "status" in msg and msg["status"] == "ok":
             return
-        elif 'ch' in msg:
-            if 'trade' in msg['ch']:
+        elif "ch" in msg:
+            if "trade" in msg["ch"]:
                 await self._trade(msg, timestamp)
-            elif 'tick' in msg['ch']:
+            elif "tick" in msg["ch"]:
                 await self._ticker(msg, timestamp)
-            elif 'depth' in msg['ch']:
+            elif "depth" in msg["ch"]:
                 await self._book(msg, timestamp)
-            elif 'kline' in msg['ch']:
-                _, symbol, _, interval = msg['ch'].split(".")
+            elif "kline" in msg["ch"]:
+                _, symbol, _, interval = msg["ch"].split(".")
                 await self._candles(msg, symbol, interval, timestamp)
             else:
                 LOG.warning("%s: Invalid message type %s", self.id, msg)
@@ -204,9 +236,13 @@ class Huobi(Feed):
             for pair in self.subscription[chan]:
                 client_id += 1
                 normalized_chan = self.exchange_channel_to_std(chan)
-                await conn.write(json.dumps(
-                    {
-                        "sub": f"market.{pair}.{chan}" if normalized_chan != CANDLES else f"market.{pair}.{chan}.{self.candle_interval_map[self.candle_interval]}",
-                        "id": client_id
-                    }
-                ))
+                await conn.write(
+                    json.dumps(
+                        {
+                            "sub": f"market.{pair}.{chan}"
+                            if normalized_chan != CANDLES
+                            else f"market.{pair}.{chan}.{self.candle_interval_map[self.candle_interval]}",
+                            "id": client_id,
+                        }
+                    )
+                )

--- a/examples/postgres_tables.sql
+++ b/examples/postgres_tables.sql
@@ -16,8 +16,8 @@ CREATE TABLE IF NOT EXISTS index (id serial PRIMARY KEY, timestamp TIMESTAMP, re
 -- funding
 CREATE TABLE IF NOT EXISTS funding (id serial PRIMARY KEY, timestamp TIMESTAMP, receipt_timestamp TIMESTAMP, exchange VARCHAR(32), symbol VARCHAR(32), mark_price DOUBLE PRECISION, rate DOUBLE PRECISION, next_funding_time TIMESTAMP, predicted_rate DOUBLE PRECISION);
 
--- liquidation
-CREATE TABLE IF NOT EXISTS liquidation (id serial PRIMARY KEY, timestamp TIMESTAMP, receipt_timestamp TIMESTAMP, exchange VARCHAR(32), symbol VARCHAR(32), side VARCHAR(8), quantity NUMERIC(64, 32), price NUMERIC(64, 32), id VARCHAR(64), status VARCHAR(16));
+-- liquidations
+CREATE TABLE IF NOT EXISTS liquidations (id serial PRIMARY KEY, timestamp TIMESTAMP, receipt_timestamp TIMESTAMP, exchange VARCHAR(32), symbol VARCHAR(32), side VARCHAR(8), quantity NUMERIC(64, 32), price NUMERIC(64, 32), trade_id VARCHAR(64), status VARCHAR(16));
 
 -- book
 CREATE TABLE IF NOT EXISTS l2_book (id serial PRIMARY KEY, timestamp TIMESTAMP, receipt_timestamp TIMESTAMP, exchange VARCHAR(32), symbol VARCHAR(32), data JSONB);


### PR DESCRIPTION
### Fix postgres backend inserts for liquidations

LiquidationsPostgres returning more fields than corresponding table.
`examples/postgres_tables.sql` has duplicate 'id' field for liquidation table and liquidation table should be named 'liquidations' (with an s) 

- [ ] - Tested
- [ ] - Changelog updated
- [x] - Tests run and pass
- [x] - Flake8 run and all errors/warnings resolved
- [ ] - Contributors file updated (optional)
