### PR TITLE
Candle REST end time bug

### DIFF
--- a/cryptofeed/exchange.py
+++ b/cryptofeed/exchange.py
@@ -171,6 +171,8 @@ class RestExchange:
                 end = dt.utcnow()
         if end:
             end = self._datetime_normalize(end)
+        if start and start > end:
+            raise ValueError('Start time must be less than or equal to end time') 
         return start, end if start else None
 
     # public / non account specific

--- a/cryptofeed/exchange.py
+++ b/cryptofeed/exchange.py
@@ -168,7 +168,7 @@ class RestExchange:
         if start:
             start = self._datetime_normalize(start)
             if not end:
-                end = dt.now()
+                end = dt.utcnow()
         if end:
             end = self._datetime_normalize(end)
         return start, end if start else None


### PR DESCRIPTION
Bug fix. 

I noticed a bug when using the Binance 'candles' API on a server using the 'America/New_York' timezone. The local time is used when calling 'dt.now()' resulting in the end timestamp being 5 hours earlier than UTC.

Furthermore, when using a start time that is within the last 5 hours, the start ts ends up being greater than the end ts. Consequently, no data from Binance is returned which causes an IndexError exception in cryptofeed/exchanges/mixins/binance_rest.py at line 129.

Replacing dt.now() with dt.utcnow() fixes the end timezone issue. I have also added a check to ensure that 'start' is less than 'end' if a start value is provided
