### PR TITLE
Fix funding rate zero

### DIFF
--- a/cryptofeed/types.pyx
+++ b/cryptofeed/types.pyx
@@ -180,7 +180,7 @@ cdef class Funding:
         if numeric_type is None:
             data = {'exchange': self.exchange, 'symbol': self.symbol, 'mark_price': self.mark_price, 'rate': self.rate, 'next_funding_time': self.next_funding_time, 'predicted_rate': self.predicted_rate, 'timestamp': self.timestamp}
         else:
-            data = {'exchange': self.exchange, 'symbol': self.symbol, 'mark_price': numeric_type(self.mark_price) if self.mark_price else None, 'rate': numeric_type(self.rate), 'next_funding_time': self.next_funding_time, 'predicted_rate': numeric_type(self.predicted_rate) if self.predicted_rate else None, 'timestamp': self.timestamp}
+            data = {'exchange': self.exchange, 'symbol': self.symbol, 'mark_price': numeric_type(self.mark_price) if self.mark_price else None, 'rate': numeric_type(self.rate), 'next_funding_time': self.next_funding_time, 'predicted_rate': numeric_type(self.predicted_rate) if self.predicted_rate is not None else None, 'timestamp': self.timestamp}
         return data if not none_to else convert_none_values(data, none_to)
 
     def __repr__(self):

--- a/tests/unit/test_funding_type.py
+++ b/tests/unit/test_funding_type.py
@@ -6,49 +6,23 @@ from decimal import Decimal
 
 
 def test_funding_to_dict():
-    # data and data2 is example funding data from FTX
     data = {
-        "success": True,
-        "result": [
-            {
-                "future": "MER-PERP",
-                "rate": Decimal("-0.000001"),
-                "time": datetime.datetime(
-                    2021, 12, 26, 20, 0, tzinfo=datetime.timezone.utc
-                ),
-            },
-            {
-                "future": "MER-PERP",
-                "rate": Decimal("0.000015"),
-                "time": datetime.datetime(
-                    2021, 12, 26, 19, 0, tzinfo=datetime.timezone.utc
-                ),
-            },
-        ],
+        "exchange": "FTX",
+        "symbol": "BTC-USD-PERP",
+        "mark_price": Decimal("50000"),
+        "rate": Decimal("0.0002"),
+        "next_funding_time": Exchange.timestamp_normalize(
+            datetime.datetime(2021, 12, 26, 21, 0, tzinfo=datetime.timezone.utc)
+        ),
+        "predicted_rate": Decimal("0.0"),
+        "timestamp": Exchange.timestamp_normalize(
+            datetime.datetime(2021, 12, 26, 20, 0, tzinfo=datetime.timezone.utc)
+        ),
     }
-
-    data2 = {
-        "success": True,
-        "result": {
-            "volume": Decimal("3391482.0"),
-            "nextFundingRate": Decimal("0.0"),
-            "nextFundingTime": datetime.datetime(
-                2021, 12, 26, 21, 0, tzinfo=datetime.timezone.utc
-            ),
-            "openInterest": Decimal("1164922.0"),
-        },
-    }
-    data["predicted_rate"] = Decimal(data2["result"]["nextFundingRate"])
 
     f = Funding(
-        "FTX",
-        "MER-PERP",
-        None,
-        data["result"][0]["rate"],
-        Exchange.timestamp_normalize(data2["result"]["nextFundingTime"]),
-        Exchange.timestamp_normalize(data["result"][0]["time"]),
-        predicted_rate=data["predicted_rate"],
-        raw=[data, data2],
+        **data,
+        raw=data,
     )
     f_dict = f.to_dict(numeric_type=float, none_to=None)
 

--- a/tests/unit/test_funding_type.py
+++ b/tests/unit/test_funding_type.py
@@ -1,0 +1,55 @@
+from cryptofeed.exchange import Exchange
+from cryptofeed.types import Funding
+
+import datetime
+from decimal import Decimal
+
+
+def test_funding_to_dict():
+    # data and data2 is example funding data from FTX
+    data = {
+        "success": True,
+        "result": [
+            {
+                "future": "MER-PERP",
+                "rate": Decimal("-0.000001"),
+                "time": datetime.datetime(
+                    2021, 12, 26, 20, 0, tzinfo=datetime.timezone.utc
+                ),
+            },
+            {
+                "future": "MER-PERP",
+                "rate": Decimal("0.000015"),
+                "time": datetime.datetime(
+                    2021, 12, 26, 19, 0, tzinfo=datetime.timezone.utc
+                ),
+            },
+        ],
+    }
+
+    data2 = {
+        "success": True,
+        "result": {
+            "volume": Decimal("3391482.0"),
+            "nextFundingRate": Decimal("0.0"),
+            "nextFundingTime": datetime.datetime(
+                2021, 12, 26, 21, 0, tzinfo=datetime.timezone.utc
+            ),
+            "openInterest": Decimal("1164922.0"),
+        },
+    }
+    data["predicted_rate"] = Decimal(data2["result"]["nextFundingRate"])
+
+    f = Funding(
+        "FTX",
+        "MER-PERP",
+        None,
+        data["result"][0]["rate"],
+        Exchange.timestamp_normalize(data2["result"]["nextFundingTime"]),
+        Exchange.timestamp_normalize(data["result"][0]["time"]),
+        predicted_rate=data["predicted_rate"],
+        raw=[data, data2],
+    )
+    f_dict = f.to_dict(numeric_type=float, none_to=None)
+
+    assert f_dict["predicted_rate"] == data["predicted_rate"]


### PR DESCRIPTION
### When funding rate or predicted rate is 0, Funding.to_dict() returns None but should return 0. This causes errors, for example, when using FundingPostgres callback.

- [x] - Tested
- [ ] - Changelog updated
- [x] - Tests run and pass
- [x] - Flake8 run and all errors/warnings resolved
- [ ] - Contributors file updated (optional)
