### PR TITLE
(bugfix): rate limit and fetch ending rest OKEx

### DIFF
--- a/cryptofeed/exchanges/mixins/okex_rest.py
+++ b/cryptofeed/exchanges/mixins/okex_rest.py
@@ -52,11 +52,13 @@ class OKExRestMixin(RestExchange):
                            True, self._datetime_normalize(e[0]), raw=e) for e in data]
 
             yield data
-            if not end or len(data) < 10000:
+            if not end or len(data) < 300:
                 break
-            start = data[-1].start + offset
+            end = data[-1].stop - offset
 
-            await asyncio.sleep(1 / self.request_limit)
+            # TODO : optimize and use the 20 requests per 2 seconds slots
+            # TODO : Need to calculate current number of requests per 2 seconds slot and wait enough to start other requests
+            await asyncio.sleep(2)
 
     def _to_isoformat(self, timestamp):
         """Required for okex (ISO 8601)


### PR DESCRIPTION
OKEx candles api endpoint are time reversed (start at end attribute and finish at start attribute). So the loop should decrease end attribute.
Requests must finished when len of data < 300 (since the current rate limit specified is 300)

- [X] - Tested
- [ ] - Changelog updated
- [X] - Tests run and pass
- [ ] - Flake8 run and all errors/warnings resolved
- [ ] - Contributors file updated (optional)
