### PR TITLE
Fix liquidations postgres inserts

### DIFF
--- a/cryptofeed/backends/postgres.py
+++ b/cryptofeed/backends/postgres.py
@@ -132,7 +132,7 @@ class LiquidationsPostgres(PostgresCallback, BackendCallback):
 
     def format(self, data: Tuple):
         exchange, symbol, timestamp, receipt, data = data
-        return f"(DEFAULT,'{timestamp}','{receipt}','{exchange}','{symbol}',{data['price']},'{data['side']}',{data['quantity']},{data['price']},'{data['id']}','{data['status']}')"
+        return f"(DEFAULT,'{timestamp}','{receipt}','{exchange}','{symbol}','{data['side']}',{data['quantity']},{data['price']},'{data['id']}','{data['status']}')"
 
 
 class BookPostgres(PostgresCallback, BackendBookCallback):

--- a/examples/postgres_tables.sql
+++ b/examples/postgres_tables.sql
@@ -16,8 +16,8 @@ CREATE TABLE IF NOT EXISTS index (id serial PRIMARY KEY, timestamp TIMESTAMP, re
 -- funding
 CREATE TABLE IF NOT EXISTS funding (id serial PRIMARY KEY, timestamp TIMESTAMP, receipt_timestamp TIMESTAMP, exchange VARCHAR(32), symbol VARCHAR(32), mark_price DOUBLE PRECISION, rate DOUBLE PRECISION, next_funding_time TIMESTAMP, predicted_rate DOUBLE PRECISION);
 
--- liquidation
-CREATE TABLE IF NOT EXISTS liquidation (id serial PRIMARY KEY, timestamp TIMESTAMP, receipt_timestamp TIMESTAMP, exchange VARCHAR(32), symbol VARCHAR(32), side VARCHAR(8), quantity NUMERIC(64, 32), price NUMERIC(64, 32), id VARCHAR(64), status VARCHAR(16));
+-- liquidations
+CREATE TABLE IF NOT EXISTS liquidations (id serial PRIMARY KEY, timestamp TIMESTAMP, receipt_timestamp TIMESTAMP, exchange VARCHAR(32), symbol VARCHAR(32), side VARCHAR(8), quantity NUMERIC(64, 32), price NUMERIC(64, 32), trade_id VARCHAR(64), status VARCHAR(16));
 
 -- book
 CREATE TABLE IF NOT EXISTS l2_book (id serial PRIMARY KEY, timestamp TIMESTAMP, receipt_timestamp TIMESTAMP, exchange VARCHAR(32), symbol VARCHAR(32), data JSONB);


### PR DESCRIPTION
### Fix liquidations postgres inserts

**Fix LiquidationsPostgres format()**. 
LiquidationsPostgres returning more fields than corresponding examples table (price field appears twice)

**Update examples/postgres_tables.sql**. 
`examples/postgres_tables.sql` has duplicate 'id' field for liquidation table and liquidation table should be named 'liquidations' (with an s) corresponding to LIQUIDATIONS = 'liquidations'

no tests written for this...

- [ ] - Tested
- [ ] - Changelog updated
- [x] - Tests run and pass
- [x] - Flake8 run and all errors/warnings resolved
- [ ] - Contributors file updated (optional)
