### PR TITLE
Allow futures and options feed for OKEX

### DIFF
--- a/cryptofeed/exchanges/okex.py
+++ b/cryptofeed/exchanges/okex.py
@@ -419,7 +419,13 @@ class OKEx(Feed, OKExRestMixin):
     def inst_type_to_okex_type(self, ticker):
         sym = self.exchange_symbol_to_std_symbol(ticker)
         instrument_type = self.instrument_type(sym)
-        return 'SWAP' if instrument_type == 'perpetual' else 'MARGIN'
+        instrument_type_map = {
+                'perpetual': 'SWAP',
+                'spot': 'MARGIN',
+                'futures': 'FUTURES',
+                'option': 'OPTION'
+                }
+        return instrument_type_map.get(instrument_type, 'MARGIN')
 
     def _get_server_time(self):
         endpoint = "v5/public/time"


### PR DESCRIPTION
### Allow future and option data feed for OKEX

OKEX requires a datafeed type translation. This adds two additional types according to the spec.
https://www.okex.com/docs-v5/en/?python#websocket-api-private-channel-positions-channel

It won't change the existing behaviour, apart from adding two additional options for translation.

- [ ] - Tested
- [ ] - Changelog updated
- [ * ] - Tests run and pass
- [ ] - Flake8 run and all errors/warnings resolved
- [ ] - Contributors file updated (optional)
