### PR TITLE
Fix the private channel connection.

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -13,3 +13,4 @@ Cryptofeed was originally created by Bryant Moscon, but many others have contrib
 * [James Lee](https://github.com/jinusean) - <atjameslee@gmail.com>
 * [O. Janche](https://github.com/toyan) - <toyan@yandex.ru>
 * [Bastien Enjalbert](https://github.com/bastienjalbert) - <bastienjalbert@gmail.com>
+* [Jonggyun Kim](https://github.com/gyunt) - <truth0233@gmail.com>

--- a/cryptofeed/exchanges/bybit.py
+++ b/cryptofeed/exchanges/bybit.py
@@ -201,7 +201,6 @@ class Bybit(Feed):
                     }
                 ))
 
-
     async def _instrument_info(self, msg: dict, timestamp: float):
         """
         ### Snapshot type update

--- a/cryptofeed/exchanges/bybit.py
+++ b/cryptofeed/exchanges/bybit.py
@@ -183,7 +183,7 @@ class Bybit(Feed):
 
     async def subscribe(self, connection: AsyncConnection):
         self.__reset()
-        for chan in self.subscription:
+        for chan in connection.subscription:
             if not self.is_authenticated_channel(self.exchange_channel_to_std(chan)):
                 for pair in self.subscription[chan]:
                     sym = str_to_symbol(pair)
@@ -193,6 +193,14 @@ class Bybit(Feed):
                             "args": [f"{chan}.{pair}"] if self.exchange_channel_to_std(chan) != CANDLES else [f"{chan if sym.quote == 'USD' else 'candle'}.{self.candle_interval_map[self.candle_interval]}.{pair}"]
                         }
                     ))
+            else:
+                await connection.write(json.dumps(
+                    {
+                        "op": "subscribe",
+                        "args": [f"{chan}"]
+                    }
+                ))
+
 
     async def _instrument_info(self, msg: dict, timestamp: float):
         """
@@ -490,7 +498,7 @@ class Bybit(Feed):
     #        await self.callback(BALANCES, feed=self.id, symbol=symbol, data=data, receipt_timestamp=timestamp)
 
     async def authenticate(self, conn: AsyncConnection):
-        if any(self.is_authenticated_channel(self.exchange_channel_to_std(chan)) for chan in self.subscription):
+        if any(self.is_authenticated_channel(self.exchange_channel_to_std(chan)) for chan in conn.subscription):
             auth = self._auth(self.key_id, self.key_secret)
             LOG.debug(f"{conn.uuid}: Sending authentication request with message {auth}")
             await conn.write(auth)


### PR DESCRIPTION
### Description of code - what bug does this fix / what feature does this add?

1. Currently Bybit class can not subscribe the private channels. 
    - It does NOT send `subscribe` op.
    - It even send `auth` op to the public channels.

~~2. it has a deprecated websocket url.
    - `wss://stream.bybit.com/realtime` is now deprecated.
    - See https://bybit-exchange.github.io/docs/linear/#t-websocketauthentication~~

I fixed aboves. 
Thanks!

- [x] - Tested
- [ ] - Changelog updated
- [x] - Tests run and pass
- [x] - Flake8 run and all errors/warnings resolved
- [x] - Contributors file updated (optional)
