### PR TITLE
Fix race condition when resetting feeds with multiple connections

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,7 @@
  * Bugfix: OKX, liquidations subscription was never called.
  * Update: OKX, use publicly available channel for book updates.
  * Bugfix: Fix race condition when resetting feeds with multiple connections
+ * Update: Send Phemex subscriptions one symbol at a time
 
 ### 2.2.2 (2022-04-17)
  * Bugfix: OKX filled amount being reported incorrectly in OrderInfo

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,7 @@
  * Update: OKX, use publicly available channel for book updates.
  * Bugfix: Fix race condition when resetting feeds with multiple connections
  * Update: Send Phemex subscriptions one symbol at a time
+ * Bugfix: BitDotCom, the subscription message for perpetuals was incorrect
 
 ### 2.2.2 (2022-04-17)
  * Bugfix: OKX filled amount being reported incorrectly in OrderInfo

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,7 @@
  * Bugfix: Phemex, websocket subscription error.
  * Bugfix: OKX, liquidations subscription was never called.
  * Update: OKX, use publicly available channel for book updates.
+ * Bugfix: Fix race condition when resetting feeds with multiple connections
 
 ### 2.2.2 (2022-04-17)
  * Bugfix: OKX filled amount being reported incorrectly in OrderInfo

--- a/cryptofeed/exchanges/bitdotcom.py
+++ b/cryptofeed/exchanges/bitdotcom.py
@@ -170,7 +170,7 @@ class BitDotCom(Feed):
             msg = {
                 'type': 'subscribe',
                 'channels': [chan],
-                'instruments' if stype in {FUTURES, OPTION} else 'pairs': symbols,
+                'instruments' if stype in {PERPETUAL, FUTURES, OPTION} else 'pairs': symbols,
             }
             if self.is_authenticated_channel(self.exchange_channel_to_std(chan)):
                 msg['token'] = self._auth_token

--- a/cryptofeed/exchanges/bitdotcom.py
+++ b/cryptofeed/exchanges/bitdotcom.py
@@ -46,6 +46,10 @@ class BitDotCom(Feed):
     }
     request_limit = 10
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._sequence_no = defaultdict(int)
+
     @classmethod
     def _symbol_endpoint_prepare(cls, ep: RestEndpoint) -> Union[List[str], str]:
         if ep.routes.currencies:
@@ -94,9 +98,16 @@ class BitDotCom(Feed):
 
         return ret, info
 
-    def __reset(self):
-        self._l2_book = {}
-        self._sequence_no = defaultdict(int)
+    def __reset(self, conn: AsyncConnection):
+        if self.std_channel_to_exchange(L2_BOOK) in conn.subscription:
+            for pair in conn.subscription[self.std_channel_to_exchange(L2_BOOK)]:
+                std_pair = self.exchange_symbol_to_std_symbol(pair)
+
+                if std_pair in self._l2_book:
+                    del self._l2_book[std_pair]
+
+                if std_pair in self._sequence_no:
+                    del self._sequence_no[std_pair]
 
     def encode_list(self, item_list: list):
         list_val = []
@@ -150,7 +161,7 @@ class BitDotCom(Feed):
                     return
 
     async def subscribe(self, connection: AsyncConnection):
-        self.__reset()
+        self.__reset(connection)
 
         for chan, symbols in connection.subscription.items():
             if len(symbols) == 0:

--- a/cryptofeed/exchanges/bitget.py
+++ b/cryptofeed/exchanges/bitget.py
@@ -98,8 +98,13 @@ class Bitget(Feed):
 
         return ret, info
 
-    def __reset(self):
-        self._l2_book = {}
+    def __reset(self, conn: AsyncConnection):
+        if self.std_channel_to_exchange(L2_BOOK) in conn.subscription:
+            for pair in conn.subscription[self.std_channel_to_exchange(L2_BOOK)]:
+                std_pair = self.exchange_symbol_to_std_symbol(pair)
+
+                if std_pair in self._l2_book:
+                    del self._l2_book[std_pair]
 
     async def _ticker(self, msg: dict, timestamp: float, symbol: str):
         """
@@ -540,7 +545,7 @@ class Bitget(Feed):
     async def subscribe(self, conn: AsyncConnection):
         if self.key_id and self.key_passphrase and self.key_secret:
             await self._login(conn)
-        self.__reset()
+        self.__reset(conn)
         args = []
 
         interval = self.candle_interval

--- a/cryptofeed/exchanges/phemex.py
+++ b/cryptofeed/exchanges/phemex.py
@@ -639,11 +639,12 @@ class Phemex(Feed):
 
         for chan, symbols in conn.subscription.items():
             if not self.exchange_channel_to_std(chan) == BALANCES:
-                msg = {"id": 1, "method": chan, "params": symbols}
-                if self.exchange_channel_to_std(chan) == CANDLES:
-                    msg['params'] = [*symbols, self.candle_interval_map[self.candle_interval]]
-                LOG.debug(f"{conn.uuid}: Sending subscribe request to public channel: {msg}")
-                await conn.write(json.dumps(msg))
+                for sym in symbols:
+                    msg = {"id": 1, "method": chan, "params": [sym]}
+                    if self.exchange_channel_to_std(chan) == CANDLES:
+                        msg['params'] = [*[sym], self.candle_interval_map[self.candle_interval]]
+                    LOG.debug(f"{conn.uuid}: Sending subscribe request to public channel: {msg}")
+                    await conn.write(json.dumps(msg))
 
     async def authenticate(self, conn: AsyncConnection):
         if any(self.is_authenticated_channel(self.exchange_channel_to_std(chan)) for chan in self.subscription):


### PR DESCRIPTION
### Description of code - what bug does this fix / what feature does this add?

This PR solves https://github.com/bmoscon/cryptofeed/issues/848. It solves the issue in all exchanges where I could replicate the bug.

Though this PR resolves the issue, I think it would be much better to do ``connection-dependent'' resetting in all exchanges by implementing a shared `_reset(self, conn: AsyncConnection)` method in the `Feed` base class and overload it when necessary in the derived classes. Since this change would affect all exchanges, I'd first like to know whether there is a shared interest for this refactoring.

In addition, while solving the original issue I came across two issues:
- When passing multiple symbols in a subscription message for Phemex, only the first symbol seems to be accepted. This seems counter to their documentation, so please double check. The workaround is to send a subscription for each symbol individually.
- There was a small but crucial bug in the subscription message for perpetuals on BitDotCom.

- [x] - Tested
- [x] - Changelog updated
- [x] - Tests run and pass
- [x] - Flake8 run and all errors/warnings resolved
- [ ] - Contributors file updated (optional)
