### PR TITLE
Master

### DIFF
--- a/cryptofeed/exchanges/ftx.py
+++ b/cryptofeed/exchanges/ftx.py
@@ -401,6 +401,7 @@ class FTX(Feed, FTXRestMixin):
             Decimal(order['filledSize']),
             Decimal(order['remainingSize']),
             None,
+            client_order_id=str(order['clientId']),
             account=self.subaccount,
             raw=msg
         )


### PR DESCRIPTION
 #861 fixed. Simply added the attribute client_order_id, which is/was already part of the OrderInfo signature.