### PR TITLE
Micro Fix of missing argument values in ORDER_INFO for FTX. #863, #861

### DIFF
--- a/cryptofeed/exchanges/ftx.py
+++ b/cryptofeed/exchanges/ftx.py
@@ -400,7 +400,8 @@ class FTX(Feed, FTXRestMixin):
             Decimal(order['price']) if order['price'] else None,
             Decimal(order['filledSize']),
             Decimal(order['remainingSize']),
-            None,
+            timestamp=str(order['createdAt']),
+            client_order_id=str(order['clientId']),
             account=self.subaccount,
             raw=msg
         )


### PR DESCRIPTION
Micro Fix. Fixed #861 and #863 at once. (code change line-to-line).