### PR TITLE
added support for string and list address in connect method of feed

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 ## Changelog
 
 ### 2.3.0
+ * Bugfix: added list and str support to websocket_endpoint creation (allows more than 200 symbols on Binance)
  * Feature: Add support for OKx streaming candles
 
 ### 2.2.3 (2022-05-29)

--- a/cryptofeed/feed.py
+++ b/cryptofeed/feed.py
@@ -207,7 +207,11 @@ class Feed(Exchange):
             if limit and count > limit:
                 ret.extend(limit_sub(filtered_sub, limit, auth, endpoint.options))
             else:
-                ret.append((WSAsyncConn(addr, self.id, authentication=auth, subscription=filtered_sub, **endpoint.options), self.subscribe, self.message_handler, self.authenticate))
+                if isinstance(addr, list):
+                    for add in addr:
+                        ret.append((WSAsyncConn(add, self.id, authentication=auth, subscription=filtered_sub, **endpoint.options), self.subscribe, self.message_handler, self.authenticate))
+                else:
+                    ret.append((WSAsyncConn(addr, self.id, authentication=auth, subscription=filtered_sub, **endpoint.options), self.subscribe, self.message_handler, self.authenticate))
 
         return ret
 


### PR DESCRIPTION
Fix of #808 - supports string and list addresses
- [x] - Tested
- [x] - Changelog updated
- [ ] - Tests run and pass
- [ ] - Flake8 run and all errors/warnings resolved
- [ ] - Contributors file updated (optional)
