### PR TITLE
[Bitget] fix subscribe

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ### 2.3.0
  * Feature: Add support for OKx streaming candles
+ * Bugfix: Bitget, bug in subscribe method.
 
 ### 2.2.3 (2022-05-29)
  * Feature: Authenticated channel support for Bitget

--- a/cryptofeed/exchanges/bitget.py
+++ b/cryptofeed/exchanges/bitget.py
@@ -550,7 +550,7 @@ class Bitget(Feed):
 
         interval = self.candle_interval
         if interval[-1] != 'm':
-            interval[-1] = interval[-1].upper()
+            interval = f"{interval[:-1]}{interval[-1].upper()}"
 
         for chan, symbols in conn.subscription.items():
             for s in symbols:


### PR DESCRIPTION
### Fix Bitget subscribe
Issue:
![image](https://user-images.githubusercontent.com/9078616/179402602-d1c2a67b-9263-40cf-81e3-404702ecd0a1.png)
`interval` being a `str`, it is immutable in Python. Therefore `interval[-1] = interval[-1].upper()` can't work.
Use `interval = f"{interval[:-1]}{interval[-1].upper()}"` instead.
- [ X ] - Tested
- [ X ] - Changelog updated
- [ ] - Tests run and pass
- [ ] - Flake8 run and all errors/warnings resolved
- [ ] - Contributors file updated (optional)
