### PR TITLE
set last_message to None in HTTPAsyncConnection._open

### DIFF
--- a/cryptofeed/connection.py
+++ b/cryptofeed/connection.py
@@ -151,6 +151,7 @@ class HTTPAsyncConn(AsyncConnection):
             self.conn = aiohttp.ClientSession()
             self.sent = 0
             self.received = 0
+            self.last_message = None
 
     async def read(self, address: str, header=None, params=None, return_headers=False, retry_count=0, retry_delay=60) -> str:
         if not self.is_open:


### PR DESCRIPTION
### Description of code - what bug does this fix / what feature does this add?
**Describe the bug**
I observe an infinite loop in the timeout retry mechanism of the ConnectionHandler
I think the issue is that the connection's `last_message` is not being reset on `HTTPAsynConnection._open`

**To Reproduce**
Steps to reproduce the behavior:
* `ConnectionHandler._watcher` detects a timeout and close the connection
* The connection and the `_watcher` get reinitialized in `ConnectionHandler._create_connection`
* The newly created `_watcher` task closes the newly created connection because `self.conn.last_message` is still set to the previous connection's `last_message`

**Screenshots**
![Screenshot from 2022-09-08 10-15-57](https://user-images.githubusercontent.com/3825783/189072969-a8468743-de68-4ae9-8087-eb70025e14d2.png)

**Operating System:**
 -linux

**Cryptofeed Version**
- 2.3.0

- [ ] - Tested
- [ ] - Changelog updated
- [ ] - Tests run and pass
- [ ] - Flake8 run and all errors/warnings resolved
- [ ] - Contributors file updated (optional)
