### PR TITLE
Update redis.py

### DIFF
--- a/cryptofeed/backends/redis.py
+++ b/cryptofeed/backends/redis.py
@@ -22,8 +22,9 @@ class RedisCallback(BackendQueue):
         prefix = 'redis://'
         if socket:
             prefix = 'unix://'
+            port = None
 
-        self.redis = f"{prefix}{host}:{port}"
+        self.redis = f"{prefix}{host}" + f":{port}" if port else ""
         self.key = key if key else self.default_key
         self.numeric_type = numeric_type
         self.none_to = none_to


### PR DESCRIPTION
### Description of code - what bug does this fix / what feature does this add?

dont use ":{port}" if port is None, instead use ""  in other words, if using a socket to connect to redis, dont have a trailing ":" in the connection string


- [ no, i just jammed my correct connection string in locally] - Tested
- [ i didnt do this] - Changelog updated
- [ i didnt add any tests] - Tests run and pass
- [ github text editor does not have flake8] - Flake8 run and all errors/warnings resolved
- [ decline this option due to laziness, but thanks for the offer] - Contributors file updated (optional)
