### PR TITLE
[phemex] fix symbol parsing

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
  * Bugfix: timestamp not reset correctly on reconnect
  * Bugfix: Arctic backend failing to write Trades when trade type was not present in data
  * Bugfix: Timestamp sometimes not present in Coinbase ticker updates
+ * Bugfix: Phemex, symbols parsing
 
 ### 2.3.0 (2022-09-04)
  * Bugfix: added list and str support to websocket_endpoint creation (allows more than 200 symbols on Binance)

--- a/cryptofeed/exchanges/phemex.py
+++ b/cryptofeed/exchanges/phemex.py
@@ -50,8 +50,8 @@ class Phemex(Feed):
             if entry['status'] != 'Listed':
                 continue
             stype = entry['type'].lower()
-            base, quote = entry['displaySymbol'].split(" / ")
-            s = Symbol(base, quote, type=stype)
+            base, quote = entry['displaySymbol'].split("/")
+            s = Symbol(base.strip(), quote.strip(), type=stype)
             ret[s.normalized] = entry['symbol']
             info['tick_size'][s.normalized] = entry['tickSize'] if 'tickSize' in entry else entry['quoteTickSize']
             info['instrument_type'][s.normalized] = stype


### PR DESCRIPTION
### Description of code - what bug does this fix / what feature does this add?

Phemex has a symbol that is incompatible and makes the feed constructor crash:
```
 2022-10-20 00:33:10,002 ERROR    WebSocket - CryptofeedWebSocketExchange not enough values to unpack (expected 2, got 1)
Traceback (most recent call last):
  File "C:\Users\gdsm\TradingBots\0.4\OctoBot-Trading\octobot_trading\exchanges\implementations\cryptofeed_websocket_exchange.py", line 38, in create_feeds
    connector = self.websocket_connector(config=self.config, exchange_manager=self.exchange_manager)
  File "C:\Users\gdsm\TradingBots\0.4\OctoBot-Trading\octobot_trading\exchanges\connectors\cryptofeed_websocket_connector.py", line 148, in __init__
    self.cryptofeed_exchange = cryptofeed_exchanges.EXCHANGE_MAP[self.get_feed_name()](
  File "C:\Users\gdsm\TradingBots\0.4\OctoBot\venv\lib\site-packages\cryptofeed\exchanges\phemex.py", line 65, in __init__
    super().__init__(**kwargs)
  File "C:\Users\gdsm\TradingBots\0.4\OctoBot\venv\lib\site-packages\cryptofeed\feed.py", line 63, in __init__
    super().__init__(**kwargs)
  File "C:\Users\gdsm\TradingBots\0.4\OctoBot\venv\lib\site-packages\cryptofeed\exchange.py", line 49, in __init__
    self.symbol_mapping()
  File "C:\Users\gdsm\TradingBots\0.4\OctoBot\venv\lib\site-packages\cryptofeed\exchange.py", line 105, in symbol_mapping
    syms, info = cls._parse_symbol_data(data if len(data) > 1 else data[0])
  File "C:\Users\gdsm\TradingBots\0.4\OctoBot\venv\lib\site-packages\cryptofeed\exchanges\phemex.py", line 53, in _parse_symbol_data
    base, quote = entry['displaySymbol'].split(" / ")
ValueError: not enough values to unpack (expected 2, got 1)
 2022-10-20 00:33:10,002 ERROR    WebSocket - CryptofeedWebSocketExchange Fail to create feed : not enough values to unpack (expected 2, got 1) (ValueError)
```
![image](https://user-images.githubusercontent.com/9078616/196824191-5b67fc47-1dda-46eb-a402-9fda51537075.png)

- [x ] - Tested
- [x ] - Changelog updated
- [ ] - Tests run and pass
- [ ] - Flake8 run and all errors/warnings resolved
- [ ] - Contributors file updated (optional)
