### PR TITLE
Fix phemex symbol parsing

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ### 2.3.2
  * Bugfix: Fix AUCTION symbol parsing on Coinbase
+ * Bugfix: Fix PERPETUAL symbol parsing on Phemex
 
 ### 2.3.1 (2022-10-31)
  * Bugfix: timestamp not reset correctly on reconnect

--- a/cryptofeed/exchanges/phemex.py
+++ b/cryptofeed/exchanges/phemex.py
@@ -15,7 +15,7 @@ from typing import Dict, Tuple
 from yapic import json
 
 from cryptofeed.connection import AsyncConnection, RestEndpoint, Routes, WebsocketEndpoint
-from cryptofeed.defines import BALANCES, BID, ASK, BUY, CANDLES, PHEMEX, L2_BOOK, SELL, TRADES
+from cryptofeed.defines import BALANCES, BID, ASK, BUY, CANDLES, PHEMEX, L2_BOOK, SELL, TRADES, PERPETUAL
 from cryptofeed.feed import Feed
 from cryptofeed.types import OrderBook, Trade, Candle, Balance
 
@@ -50,6 +50,8 @@ class Phemex(Feed):
             if entry['status'] != 'Listed':
                 continue
             stype = entry['type'].lower()
+            if "perpetual" in stype:    # can be "perpetualv2"
+                stype = PERPETUAL
             base, quote = entry['displaySymbol'].split("/")
             s = Symbol(base.strip(), quote.strip(), type=stype)
             ret[s.normalized] = entry['symbol']


### PR DESCRIPTION
Phemex now describes its perpetual instruments as `perpetualv2` which is crashing the feed constructor and preventing phemex feeds from starting.

![image](https://user-images.githubusercontent.com/9078616/202926349-3fda093a-a761-48cb-93ef-2db24b8966e0.png)


- [ x ] - Tested
- [ x ] - Changelog updated
- [ ] - Tests run and pass
- [ ] - Flake8 run and all errors/warnings resolved
- [ ] - Contributors file updated (optional)
