### PR TITLE
Kafka enhancements

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,8 @@
 ### 2.3.2
  * Bugfix: Fix AUCTION symbol parsing on Coinbase
  * Bugfix: Fix PERPETUAL symbol parsing on Phemex
+ * Feature: Access to all AIOKafka configuration options
+ * Feature: Use backend Queue for Kafka
 
 ### 2.3.1 (2022-10-31)
  * Bugfix: timestamp not reset correctly on reconnect

--- a/cryptofeed/backends/kafka.py
+++ b/cryptofeed/backends/kafka.py
@@ -19,7 +19,7 @@ class KafkaCallback:
         """
         producer_config: dict
             A dictionary of configuration settings for AIOKafkaProducer.
-            A 'value_serializer' option allows use of various alternative schemas such as Protobuf, Avro, etc. 
+            A 'value_serializer' option allows use of other schemas such as Avro, Protobuf etc. 
             The default serialization is JSON Bytes
             A full list of configuration parameters can be found at https://aiokafka.readthedocs.io/en/stable/api.html#aiokafka.AIOKafkaProducer  
             Example:
@@ -38,7 +38,7 @@ class KafkaCallback:
         self.numeric_type = numeric_type
         self.none_to = none_to
 
-    async def __connect(self):
+    async def _connect(self):
         if not self.producer:
             loop = asyncio.get_event_loop()
             self.producer = AIOKafkaProducer(**self.producer_config, loop=loop)
@@ -47,14 +47,8 @@ class KafkaCallback:
     def topic(self, data: dict) -> str:
         return f"{self.key}-{data['exchange']}-{data['symbol']}"
 
-    def partition_key(self, data: dict) -> Optional[bytes]:
-        return None
-
-    def partition(self, data: dict) -> Optional[int]:
-        return None
-
     async def write(self, data: dict):
-        await self.__connect()
+        await self._connect()
         await self.producer.send_and_wait(self.topic(data), json.dumps(data).encode('utf-8'), self.partition_key(data), self.partition(data))
 
 

--- a/cryptofeed/backends/kafka.py
+++ b/cryptofeed/backends/kafka.py
@@ -7,7 +7,7 @@ associated with this software.
 from collections import defaultdict
 import asyncio
 import logging
-from typing import Optional, List, Callable, ByteString
+from typing import Optional, ByteString
 
 from aiokafka import AIOKafkaProducer
 from aiokafka.errors import RequestTimedOutError
@@ -19,10 +19,9 @@ LOG = logging.getLogger('feedhandler')
 
 
 class KafkaCallback(BackendQueue):
-    def __init__(self, producer_config: Optional[dict[str, str | List | int | Callable]] = None, key=None, numeric_type=float, none_to=None, **kwargs):
+    def __init__(self, key=None, numeric_type=float, none_to=None, **kwargs):
         """
-        producer_config: dict
-            A dictionary of configuration settings for AIOKafkaProducer.
+        You can pass configuration options to AIOKafkaProducer as kwargs.
             A full list of configuration parameters can be found at
             https://aiokafka.readthedocs.io/en/stable/api.html#aiokafka.AIOKafkaProducer  
             
@@ -31,18 +30,14 @@ class KafkaCallback(BackendQueue):
             
             Example:
             
-                {'bootstrap_servers': '127.0.0.1:9092',
+            **{'bootstrap_servers': '127.0.0.1:9092',
                 'client_id': 'cryptofeed',
                 'acks': 1,
                 'value_serializer': your_serialization_function}
                 
             (Passing the event loop is already handled)
         """
-        self.producer_config = producer_config or {
-            'bootstrap_servers': '127.0.0.1:9092',
-            'client_id': 'cryptofeed',
-            'acks': 1
-        }
+        self.producer_config = dict(**kwargs)
         self.producer = None
         self.key: str = key or self.default_key
         self.numeric_type = numeric_type

--- a/cryptofeed/backends/kafka.py
+++ b/cryptofeed/backends/kafka.py
@@ -7,7 +7,7 @@ associated with this software.
 from collections import defaultdict
 import asyncio
 import logging
-from typing import Optional, DefaultDict, List, Callable, ByteString
+from typing import Optional, List, Callable, ByteString
 
 from aiokafka import AIOKafkaProducer
 from aiokafka.errors import RequestTimedOutError
@@ -19,7 +19,7 @@ LOG = logging.getLogger('feedhandler')
 
 
 class KafkaCallback(BackendQueue):
-    def __init__(self, producer_config: Optional[DefaultDict[str, str | List | int | Callable]] = None, key=None, numeric_type=float, none_to=None, **kwargs):
+    def __init__(self, producer_config: Optional[dict[str, str | List | int | Callable]] = None, key=None, numeric_type=float, none_to=None, **kwargs):
         """
         producer_config: dict
             A dictionary of configuration settings for AIOKafkaProducer.
@@ -36,7 +36,7 @@ class KafkaCallback(BackendQueue):
                 'acks': 1,
                 'value_serializer': your_serialization_function}
                 
-            (the event loop is provided by Cryptofeed)
+            (Passing the event loop is already handled)
         """
         self.producer_config = producer_config or {
             'bootstrap_servers': '127.0.0.1:9092',
@@ -85,9 +85,9 @@ class KafkaCallback(BackendQueue):
                     try:
                         await self.producer.send_and_wait(topic, value, key, partition)
                     except RequestTimedOutError:
-                        LOG.error(f'{self.__class__.name}: No response received from server within {self.producer._request_timeout_ms} ms. Messages may not have been delivered')
+                        LOG.error(f'{self.__class__.__name__}: No response received from server within {self.producer._request_timeout_ms} ms. Messages may not have been delivered')
                     except Exception as e:
-                        LOG.info(f'{self.__class__.name}: Encountered an error:{chr(10)}{e}')
+                        LOG.info(f'{self.__class__.__name__}: Encountered an error:{chr(10)}{e}')
         LOG.info(f"{self.__class__.__name__}: sending last messages and closing connection '{self.producer.client._client_id}'")
         await self.producer.stop()
 

--- a/cryptofeed/backends/kafka.py
+++ b/cryptofeed/backends/kafka.py
@@ -21,7 +21,8 @@ LOG = logging.getLogger('feedhandler')
 class KafkaCallback(BackendQueue):
     def __init__(self, key=None, numeric_type=float, none_to=None, **kwargs):
         """
-        You can pass configuration options to AIOKafkaProducer as kwargs.
+        You can pass configuration options to AIOKafkaProducer as keyword arguments.
+        (either individual kwargs, an unpacked dictionary `**config_dict`, or both)
         A full list of configuration parameters can be found at
         https://aiokafka.readthedocs.io/en/stable/api.html#aiokafka.AIOKafkaProducer  
         
@@ -37,7 +38,7 @@ class KafkaCallback(BackendQueue):
             
         (Passing the event loop is already handled)
         """
-        self.producer_config = dict(**kwargs)
+        self.producer_config = kwargs
         self.producer = None
         self.key: str = key or self.default_key
         self.numeric_type = numeric_type

--- a/cryptofeed/backends/kafka.py
+++ b/cryptofeed/backends/kafka.py
@@ -41,7 +41,7 @@ class KafkaCallback(BackendQueue):
         self.producer_config = producer_config or {
             'bootstrap_servers': '127.0.0.1:9092',
             'client_id': 'cryptofeed',
-            'acks': 0
+            'acks': 1
         }
         self.producer = None
         self.key: str = key or self.default_key
@@ -57,7 +57,7 @@ class KafkaCallback(BackendQueue):
         else:
             raise TypeError(f'{type(to_bytes)} is not a valid Serialization type')
 
-    async def __connect(self):
+    async def _connect(self):
         if not self.producer:
             loop = asyncio.get_event_loop()
             self.producer = AIOKafkaProducer(**self.producer_config, loop=loop)

--- a/cryptofeed/backends/kafka.py
+++ b/cryptofeed/backends/kafka.py
@@ -57,7 +57,7 @@ class KafkaCallback(BackendQueue):
         else:
             raise TypeError(f'{type(to_bytes)} is not a valid Serialization type')
 
-    async def _connect(self):
+    async def __connect(self):
         if not self.producer:
             loop = asyncio.get_event_loop()
             self.producer = AIOKafkaProducer(**self.producer_config, loop=loop)

--- a/cryptofeed/backends/kafka.py
+++ b/cryptofeed/backends/kafka.py
@@ -6,7 +6,7 @@ associated with this software.
 '''
 from collections import defaultdict
 import asyncio
-from typing import Optional
+from typing import Optional, DefaultDict, List, Callable
 
 from aiokafka import AIOKafkaProducer
 from yapic import json
@@ -15,31 +15,33 @@ from cryptofeed.backends.backend import BackendBookCallback, BackendCallback
 
 
 class KafkaCallback:
-    def __init__(self, bootstrap='127.0.0.1', port=9092, key=None, numeric_type=float, none_to=None, acks=0, client_id='cryptofeed', **kwargs):
+    def __init__(self, producer_config: DefaultDict[str, str | List | int | Callable] | None = None, key=None, numeric_type=float, none_to=None, **kwargs):
         """
-        bootstrap: str, list
-            if a list, should be a list of strings in the format: ip/host:port, i.e.
-                192.1.1.1:9092
-                192.1.1.2:9092
-                etc
-            if a string, should be ip/port only
+        producer_config: dict
+            A dictionary of configuration settings for AIOKafkaProducer.
+            A 'value_serializer' option allows use of various alternative schemas such as Protobuf, Avro, etc. 
+            The default serialization is JSON Bytes
+            A full list of configuration parameters can be found at https://aiokafka.readthedocs.io/en/stable/api.html#aiokafka.AIOKafkaProducer  
+            Example:
+            {'bootstrap_servers': '127.0.0.1:9092',
+            'client_id': 'cryptofeed',
+            'acks': 1}
+            (the event loop is provided by Cryptofeed)
         """
-        self.bootstrap = bootstrap
-        self.port = port
+        self.producer_config = producer_config or {
+            'bootstrap_servers': '127.0.0.1:9092',
+            'client_id': 'cryptofeed',
+            'acks': 0
+        }
         self.producer = None
         self.key = key if key else self.default_key
         self.numeric_type = numeric_type
         self.none_to = none_to
-        self.acks = acks
-        self.client_id = client_id
 
     async def __connect(self):
         if not self.producer:
             loop = asyncio.get_event_loop()
-            self.producer = AIOKafkaProducer(acks=self.acks,
-                                             loop=loop,
-                                             bootstrap_servers=f'{self.bootstrap}:{self.port}' if isinstance(self.bootstrap, str) else self.bootstrap,
-                                             client_id=self.client_id)
+            self.producer = AIOKafkaProducer(**self.producer_config, loop=loop)
             await self.producer.start()
 
     def topic(self, data: dict) -> str:

--- a/examples/demo_kafka.py
+++ b/examples/demo_kafka.py
@@ -12,7 +12,12 @@ from cryptofeed.exchanges import Coinbase
 
 
 """
-You can run a consumer in the console with the following command
+The AIOKafkaProducer accepts configuration options passed as kwargs to the Kafka callback(s)
+either as individual kwargs, an unpacked dictionary `**config_dict`, or both, as in the example below.
+The full list of configuration parameters can be found at
+https://aiokafka.readthedocs.io/en/stable/api.html#aiokafka.AIOKafkaProducer  
+
+You can run a Kafka consumer in the console with the following command
 (assuminng the defaults for the consumer group and bootstrap server)
 
 $ kafka-console-consumer --bootstrap-server 127.0.0.1:9092 --topic trades-COINBASE-BTC-USD
@@ -28,8 +33,14 @@ class CustomTradeKafka(TradeKafka):
 
 
 def main():
-    f = FeedHandler()
-    cbs = {TRADES: CustomTradeKafka(), L2_BOOK: BookKafka()}
+    common_kafka_config = {
+        'bootstrap_servers': '127.0.0.1:9092',
+        'acks': 1,
+        'request_timeout_ms': 10000,
+        'connections_max_idle_ms': 20000,
+    }
+    f = FeedHandler({'log':{'filename': 'feedhandler.log', 'level': 'INFO'}})
+    cbs = {TRADES: CustomTradeKafka(client_id='Coinbase Trades', **common_kafka_config), L2_BOOK: BookKafka(client_id='Coinbase Book', **common_kafka_config)}
 
     f.add_feed(Coinbase(max_depth=10, channels=[TRADES, L2_BOOK], symbols=['BTC-USD'], callbacks=cbs))
 


### PR DESCRIPTION
This PR adds two new features:

1. All `AIOKafkerProducer` configuration options are now accessible by passing kwargs to the backend callback
2. Kafka backend now uses `BackendQueue` with immediate 'sends', reliable reconnects and cleanup on shutdown.

- [X] - Tested
- [X] - Changelog updated
- [X] - Tests run and pass
- [X] - Flake8 run and all errors/warnings resolved
- [ ] - Contributors file updated (optional)
