### PR TITLE
Fix Kraken futures symbols of alternative lengths

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 ### 2.3.2
  * Bugfix: Fix AUCTION symbol parsing on Coinbase
  * Bugfix: Fix PERPETUAL symbol parsing on Phemex
+ * Bugfix: Fix PERPETUAL symbol parsing on Kraken Futures
  * Feature: Access to all AIOKafka configuration options
  * Feature: Use backend Queue for Kafka
  * Feature: Add support for storing book snapshots in Redis as key-value

--- a/cryptofeed/exchanges/kraken_futures.py
+++ b/cryptofeed/exchanges/kraken_futures.py
@@ -63,7 +63,7 @@ class KrakenFutures(Feed):
                 stype = FUTURES
                 symbol, expiry = symbol.split("_")
             symbol = symbol.replace('XBT', 'BTC')
-            base, quote = symbol[:3], symbol[3:]
+            base, quote = symbol[:len(symbol) - 3], symbol[-3:]
 
             s = Symbol(base, quote, type=stype, expiry_date=expiry)
 


### PR DESCRIPTION
### Description of code - what bug does this fix / what feature does this add?
Kraken Futures does not handle the parsing of symbols correctly for base currencies that are not of a length of 3 chars. This causes incorrect symbols, for example:
- ALI-CEUSD-PERP, while it should be be ALICE-USD-PERP.
- OPU-SD-PERP, while it should be OP-USD-PERP

### Testing
I did a diff on the symbols before and after the change and verified they are correct. 

- [X] - Tested
- [X ] - Changelog updated
- [X] - Tests run and pass
- [X] - Flake8 run and all errors/warnings resolved
- [ ] - Contributors file updated (optional)
