### PR TITLE
Fix Socket backend

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 ## Changelog
 
 ### 2.3.2
+ * Bugfix: Fix Socket backend
  * Bugfix: Fix AUCTION symbol parsing on Coinbase
  * Bugfix: Fix PERPETUAL symbol parsing on Phemex
  * Bugfix: Fix PERPETUAL symbol parsing on Kraken Futures

--- a/cryptofeed/backends/socket.py
+++ b/cryptofeed/backends/socket.py
@@ -85,9 +85,9 @@ class SocketCallback(BackendQueue):
                                 msg = json.dumps({'type': 'chunked', 'chunks': len(chunks), 'data': chunk}).encode()
                                 self.conn.sendto(msg)
                         else:
-                            self.conn.sendto(update.encode())
+                            self.conn.sendto(data.encode())
                     else:
-                        self.conn.write(update.encode())
+                        self.conn.write(data.encode())
 
     async def connect(self):
         if not self.conn:


### PR DESCRIPTION
### Description of code - what bug does this fix / what feature does this add?

The demo_udp.py file has not been working since version 2.2.1. After adding multiprocessing functionality, the 'update' was changed to 'updates' and socket.py was updated. However, 'update.encode()' was causing error because 'update' is dictionary type and it doesn't has no encode function in it . in the context 'data' has to be there . 
This issue was resolved, and when running demo_udp.py, it can be confirmed that the bug has been fixed.

- [o] - Tested
- [o] - Changelog updated
- [o] - Tests run and pass
- [o] - Flake8 run and all errors/warnings resolved
- [] - Contributors file updated (optional)
