### PR TITLE
Adding QuestDB to the list of supported backends

### DIFF
--- a/docs/callbacks.md
+++ b/docs/callbacks.md
@@ -38,6 +38,7 @@ The backends are defined [here](../cryptofeed/backends/). Currently the followin
 * Kafka
 * MongoDB
 * Postgres
+* QuestDB
 * RabbitMQ
 * Redis
 * Redis Streams


### PR DESCRIPTION
QuestDB was already supported but missing from this list

### Description of code - what bug does this fix / what feature does this add?

No tests since this is a minor doc change