### PR TITLE
using callable method to check if handler is class.

### DIFF
--- a/cryptofeed/backends/aggregate.py
+++ b/cryptofeed/backends/aggregate.py
@@ -13,7 +13,7 @@ import numpy as np
 class AggregateCallback:
     def __init__(self, handler):
         self.handler = handler
-        if hasattr(self.handler, '__class__'):
+        if not callable(self.handler):
             setattr(self, 'start', self.handler.start)
             setattr(self, 'stop', self.handler.stop)
             self.__name__ = self.handler.__class__


### PR DESCRIPTION
- using callable method to check if handler is a class.

checking for '__class__' attribute is ambiguous as async functions are also of type class.
