### PR TITLE
Fix instrument types in symbol parsing on Bitmex.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
  * Update: Okcoin moved to v5 API used by OKX
  * Bugfix: InfluxDB none type conversions
  * New Exchange: GateIO Futures
+ * Bugfix: Fix instrument types in symbol parsing on Bitmex
 
 ### 2.3.2 (2023-05-27)
  * Bugfix: Fix Socket backend


### PR DESCRIPTION
### Description of code - what bug does this fix / what feature does this add?

This fix resolves two related bugs in the symbol handling for Bitmex. Firstly, it properly decodes instrument types, including disambiguating `SPOT` and `PERPETUAL` symbols. Since both have the same counter and base currency, formerly the spot instrument would overwrite the perpetual instrument simply because it came later in the active instruments rest endpoint. For example, during parsing the normalized symbol `BTC-USDT-PERP` would first (correctly) refer to Bitmex instrument `XBTUSDT` and later be overwritten to refer to Bitmex's spot market `XBT_USDT` (yes, the naming is indeed confusing).

This fix resolves a second bug, in that Bitmex has two `ETH-USD-PERP` instruments, namely `ETHUSD` and `ETHUSD_ETH`. Also in this case the latter, much less active instrument would overwrite the former. In case of ambiguity, this fix therefore gives precedence to the first match.

I think this PR will resolve https://github.com/bmoscon/cryptofeed/issues/905. Note that the instrument types were taking from the [official documentation](https://www.bitmex.com/api/explorer/#!/Instrument/Instrument_get). An obvious consequence of this fix is that cryptofeed will support Bitmex's spot markets.

- [x] - Tested
- [x] - Changelog updated
- [x] - Tests run and pass
- [x] - Flake8 run and all errors/warnings resolved
- [ ] - Contributors file updated (optional)
