### PR TITLE
Use hasattr() for aggregate callbacks

### DIFF
--- a/cryptofeed/backends/aggregate.py
+++ b/cryptofeed/backends/aggregate.py
@@ -13,7 +13,9 @@ import numpy as np
 class AggregateCallback:
     def __init__(self, handler):
         self.handler = handler
-        if not callable(self.handler):
+        if hasattr(self.handler, '__class__')\
+                and hasattr(self.handler, 'start')\
+                and hasattr(self.handler, 'stop'):
             setattr(self, 'start', self.handler.start)
             setattr(self, 'stop', self.handler.stop)
             self.__name__ = self.handler.__class__


### PR DESCRIPTION
`callable()` returns True for classes that override the `__call__` method, which means the existing logic doesn't properly handle all backends (using a BookPostgres callback as the handler will break, for example). 
This change uses `hasattr()` to explicitly determine if the given handler:
- Is a  class
- Has a start method
- Has a stop method