### PR TITLE
Set predicted funding rate to None in OKX if nextFundingRate is empty.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 ## Changelog
 
+### 2.4.1
+ * Bugfix: Handle empty nextFundingRate in OKX
+
 ### 2.4.0 (2024-01-07)
  * Update: Fix tests
  * Update: Okcoin moved to v5 API used by OKX

--- a/cryptofeed/exchanges/okx.py
+++ b/cryptofeed/exchanges/okx.py
@@ -266,7 +266,7 @@ class OKX(Feed, OKXRestMixin):
                 Decimal(update['fundingRate']),
                 None,
                 self.timestamp_normalize(int(update['fundingTime'])),
-                predicted_rate=Decimal(update['nextFundingRate']),
+                predicted_rate=Decimal(update['nextFundingRate']) if update['nextFundingRate'] != '' else None,
                 raw=update
             )
             await self.callback(FUNDING, f, timestamp)


### PR DESCRIPTION
This trivial change fixes exceptions on funding messages from OKX with empty `nextFundingRate`, such as
```{"arg":{"channel":"funding-rate","instId":"XRP-USDT-SWAP"},"data":[{"fundingRate":"0.0000348111167807","fundingTime":"1705190400000","instId":"XRP-USDT-SWAP","instType":"SWAP","maxFundingRate":"0.0075","method":"current_period","minFundingRate":"-0.0075","nextFundingRate":"","nextFundingTime":"1705219200000","settFundingRate":"0.0000682274966659","settState":"settled","ts":"1705182304043"}]}```

- [x] - Tested
- [x] - Changelog updated
- [x] - Tests run and pass
- [x] - Flake8 run and all errors/warnings resolved
- [ ] - Contributors file updated (optional)
