### PR TITLE
Handle null next_funding_time and estimated_rate in HuobiSwap funding

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ### 2.4.1
  * Bugfix: Handle empty nextFundingRate in OKX
+ * Bugfix: Handle null next_funding_time and estimated_rate in HuobiSwap funding
 
 ### 2.4.0 (2024-01-07)
  * Update: Fix tests

--- a/cryptofeed/exchanges/huobi_swap.py
+++ b/cryptofeed/exchanges/huobi_swap.py
@@ -86,7 +86,7 @@ class HuobiSwap(HuobiDM):
                 data = await self.http_conn.read(endpoint)
                 data = json.loads(data, parse_float=Decimal)
                 received = time.time()
-                update = (data['data']['funding_rate'], self.timestamp_normalize(int(data['data']['next_funding_time'])))
+                update = (data['data']['funding_rate'], self.timestamp_normalize(int(data['data']['funding_time'])))
                 if pair in self.funding_updates and self.funding_updates[pair] == update:
                     await asyncio.sleep(1)
                     continue
@@ -97,9 +97,9 @@ class HuobiSwap(HuobiDM):
                     self.exchange_symbol_to_std_symbol(pair),
                     None,
                     Decimal(data['data']['funding_rate']),
-                    self.timestamp_normalize(int(data['data']['next_funding_time'])),
+                    self.timestamp_normalize(int(data['data']['next_funding_time'])) if data['data']['next_funding_time'] else None,
                     self.timestamp_normalize(int(data['data']['funding_time'])),
-                    predicted_rate=Decimal(data['data']['estimated_rate']),
+                    predicted_rate=Decimal(data['data']['estimated_rate']) if data['data']['estimated_rate'] is not None else None,
                     raw=data
                 )
                 await self.callback(FUNDING, f, received)


### PR DESCRIPTION
HuobiSwap has null values for `next_funding_time` and `estimated_rate` in the funding rate, as can be seen at https://api.hbdm.com/swap-api/v1/swap_funding_rate?contract_code=BTC-USD:

```{"status":"ok","data":{"estimated_rate":null,"funding_rate":"0.000268519557868291","contract_code":"BTC-USD","symbol":"BTC","fee_asset":"BTC","funding_time":"1705334400000","next_funding_time":null},"ts":1705307089168}```

This PR sets the corresponding values to None if this is the case, thus avoiding an exception and missing data. I'm not completely sure about the rationale for the early stopping with the cached value in `self.funding_updates`, but if the reasoning was to avoid duplicate values then the pair `funding_rate` and `funding_time` should work just as well.

- [x] - Tested
- [x] - Changelog updated
- [x] - Tests run and pass
- [x] - Flake8 run and all errors/warnings resolved
- [ ] - Contributors file updated (optional)
