### PR TITLE
Fix persisting Kraken trades in QuestDB

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -16,3 +16,4 @@ Cryptofeed was originally created by Bryant Moscon, but many others have contrib
 * [Jonggyun Kim](https://github.com/gyunt) - <truth0233@gmail.com>
 * [QuasarDB](https://quasar.ai/)
 * [Thomas Bouamoud](https://github.com/thomasbs17) - <thomasbs17@yahoo.fr>
+* [Carlo Eugster](https://github.com/carloe) - <carlo@relaun.ch>

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
  * Update: transitioned from Coinbase Pro (retired) to Coinbase Advanced Trade
  * Feature: Bybit spot support
  * Update: Bybit migrate to API V5 for public streams
+ * Bugfix: Handle None ids for Kraken trades in QuestDB
 
 ### 2.4.0 (2024-01-07)
  * Update: Fix tests

--- a/cryptofeed/backends/quest.py
+++ b/cryptofeed/backends/quest.py
@@ -54,9 +54,12 @@ class TradeQuest(QuestCallback, BackendCallback):
     async def write(self, data):
         timestamp = data["timestamp"]
         received_timestamp_int = int(data["receipt_timestamp"] * 1_000_000)
+        id_field = f'id={data["id"]}i,' if data["id"] is not None else ''
         timestamp_int = int(timestamp * 1_000_000_000) if timestamp is not None else received_timestamp_int * 1000
-        update = f'{self.key}-{data["exchange"]},symbol={data["symbol"]},side={data["side"]},type={data["type"]} ' \
-                 f'price={data["price"]},amount={data["amount"]},id={data["id"]}i,receipt_timestamp={received_timestamp_int}t {timestamp_int}'
+        update = (
+            f'{self.key}-{data["exchange"]},symbol={data["symbol"]},side={data["side"]},type={data["type"]} '
+            f'price={data["price"]},amount={data["amount"]},{id_field}receipt_timestamp={received_timestamp_int}t {timestamp_int}'
+        )
         await self.queue.put(update)
 
 


### PR DESCRIPTION
This PR fixes an issue (#1038) where inserting Kraken trades into QuestDB would always fail silently.

When `TradeQuest` persists a `Trade` it tried to use `Trade.id` for for the db `id` field. But the old Kraken websocket does not return trade id's, which means `TradeQuest` attempts to insert every record with id `None`. But the QuestDB server will silently ignore any record that have that has it's id set to `None`. 

Since in quest `id` is not a required field in qdb (actually not sure if this is specific to qdb, or more generally true for the InfluxDB line protocol), this pr only adds the `id` peoperty to the request if it's not `None`.

### Description of code - what bug does this fix / what feature does this add?

- [x] - Tested
- [x] - Changelog updated
- [ ] - Tests run and pass
- [x] - Flake8 run and all errors/warnings resolved
- [x] - Contributors file updated (optional)
