### PR TITLE
Fix case missmatch for KrakenFutures symbols

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@
  * Feature: Bybit spot support
  * Update: Bybit migrate to API V5 for public streams
  * Bugfix: Handle None ids for Kraken trades in QuestDB
+ * Bugfix: Fix case missmatch in KrakenFutures symbols 
 
 ### 2.4.0 (2024-01-07)
  * Update: Fix tests

--- a/cryptofeed/exchanges/kraken_futures.py
+++ b/cryptofeed/exchanges/kraken_futures.py
@@ -246,8 +246,7 @@ class KrakenFutures(Feed):
             else:
                 LOG.warning("%s: Invalid message type %s", self.id, msg)
         else:
-            # As per Kraken support: websocket product_id is uppercase version of the REST API symbols
-            pair = self.exchange_symbol_to_std_symbol(msg['product_id'].lower())
+            pair = self.exchange_symbol_to_std_symbol(msg['product_id'])
             if msg['feed'] == 'trade':
                 await self._trade(msg, pair, timestamp)
             elif msg['feed'] == 'trade_snapshot':


### PR DESCRIPTION
This old workaround seems to break things. I have this code:

```python
def main():
    loop = asyncio.get_event_loop()
    f.add_feed(KrakenFutures(symbols=['BTC-USD-PERP'], channels=[TRADES], callbacks={...}))

    k = KrakenFutures()
    print(k.exchange_symbol_mapping)

    f.run(start_loop=False)
    loop.call_later(60, stop)
    loop.run_forever()
```

Which produces this output:

```
{'PF_XBTUSD': 'BTC-USD-PERP',  ... }
```
And once I get the following error.

```
2024-06-05 17:24:43,728 : INFO : KRAKEN_FUTURES.ws.2: closed connection 'WebSocketClientProtocol'
2024-06-05 17:24:43,728 : ERROR : KRAKEN_FUTURES.ws.2: encountered an exception, reconnecting in 1.0 seconds
Traceback (most recent call last):
  File ".../site-packages/cryptofeed/exchange.py", line 132, in exchange_symbol_to_std_symbol
    return self.exchange_symbol_mapping[symbol]
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^
KeyError: 'pf_xbtusd'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File ".../site-packages/cryptofeed/connection_handler.py", line 69, in _create_connection
    await self._handler(connection, self.handler)
  File ".../site-packages/cryptofeed/connection_handler.py", line 119, in _handler
    await handler(message, connection, self.conn.last_message)
  File ".../site-packages/cryptofeed/exchanges/kraken_futures.py", line 250, in message_handler
    pair = self.exchange_symbol_to_std_symbol(msg['product_id'].lower())
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".../site-packages/cryptofeed/exchange.py", line 137, in exchange_symbol_to_std_symbol
    raise UnsupportedSymbol(f'{symbol} is not supported on {self.id}')
cryptofeed.exceptions.UnsupportedSymbol: pf_xbtusd is not supported on KRAKEN_FUTURES
2024-06-05 17:24:44,731 : DEBUG : KRAKEN_FUTURES.ws.2: connecting to wss://futures.kraken.com/ws/v1
2024-06-05 17:24:45,013 : INFO : KRAKEN_FUTURES.ws.2: closed connection 'WebSocketClientProtocol'
2024-06-05 17:24:45,013 : ERROR : KRAKEN_FUTURES.ws.2: encountered an exception, reconnecting in 1.0 seconds
Traceback (most recent call last):
  File ".../site-packages/cryptofeed/exchange.py", line 132, in exchange_symbol_to_std_symbol
    return self.exchange_symbol_mapping[symbol]
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^
KeyError: 'pf_xbtusd'
```

The problem seems to come from this old workaround(?). Without `.lower()` my code above runs without issues. 

https://github.com/bmoscon/cryptofeed/blob/cac8c97f55af662e039b2ea7c6fe3c3afec4350e/cryptofeed/exchanges/kraken_futures.py#L249-L250

- [x] - Tested
- [x] - Changelog updated
- [ ] - Tests run and pass
- [x] - Flake8 run and all errors/warnings resolved
- [ ] - Contributors file updated (optional)
