### PR TITLE
Fix OrderChanged event in IndependentReserve

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@
  * Feature: Bybit spot support
  * Update: Bybit migrate to API V5 for public streams
  * Bugfix: Handle None ids for Kraken trades in QuestDB
+ * Bugfix: Handle OrderChanged event in IndependentReserve
 
 ### 2.4.0 (2024-01-07)
  * Update: Fix tests

--- a/cryptofeed/exchanges/independent_reserve.py
+++ b/cryptofeed/exchanges/independent_reserve.py
@@ -159,7 +159,7 @@ class IndependentReserve(Feed):
                         self._l3_book[instrument].book[side][price] = {uuid: size}
                     delta[side].append((uuid, price, size))
 
-                elif msg['event'] == 'OrderChanged':
+                elif msg['Event'] == 'OrderChanged':
                     uuid = msg['Data']['OrderGuid']
                     size = msg['Data']['Volume']
                     side = BID if msg['Data']['OrderType'].endswith('Bid') else ASK

--- a/cryptofeed/exchanges/independent_reserve.py
+++ b/cryptofeed/exchanges/independent_reserve.py
@@ -167,11 +167,11 @@ class IndependentReserve(Feed):
                         price, side = self._order_ids[instrument][uuid]
 
                         if size == 0:
-                            del self._l3_book[instrument][side][price][uuid]
-                            if len(self._l3_book[instrument][side][price]) == 0:
-                                del self._l3_book[instrument][side][price]
+                            del self._l3_book[instrument].book[side][price][uuid]
+                            if len(self._l3_book[instrument].book[side][price]) == 0:
+                                del self._l3_book[instrument].book[side][price]
                         else:
-                            self._l3_book[instrument][side][price][uuid] = size
+                            self._l3_book[instrument].book[side][price][uuid] = size
 
                         del self._order_ids[instrument][uuid]
                         delta[side].append((uuid, price, size))


### PR DESCRIPTION
### Description of code - what bug does this fix / what feature does this add?

Fixes `KeyError`:
```log
2024-07-23 15:25:49,502 : ERROR : INDEPENDENT_RESERVE.ws.6: encountered an exception, reconnecting in 1.0 seconds Traceback (most recent call last):
  File "/Users/simon/.pyenv/versions/3.11.6/lib/python3.11/site-packages/cryptofeed/connection_handler.py", line 69, in _create_connection
    await self._handler(connection, self.handler)
  File "/Users/simon/.pyenv/versions/3.11.6/lib/python3.11/site-packages/cryptofeed/connection_handler.py", line 119, in _handler
    await handler(message, connection, self.conn.last_message)
  File "/Users/simon/.pyenv/versions/3.11.6/lib/python3.11/site-packages/cryptofeed/exchanges/independent_reserve.py", line 215, in message_handler
    await self._book(msg, timestamp)
  File "/Users/simon/.pyenv/versions/3.11.6/lib/python3.11/site-packages/cryptofeed/exchanges/independent_reserve.py", line 162, in _book
    elif msg['event'] == 'OrderChanged':
         ~~~^^^^^^^^^
KeyError: 'event'
```

Fixes `TypeError`:
```log
TypeError: 'cryptofeed.types.OrderBook' object is not subscriptable
2024-07-23 15:41:32,001 : ERROR : INDEPENDENT_RESERVE.ws.5: encountered an exception, reconnecting in 1.0 seconds
Traceback (most recent call last):
  File "/Users/simon/.pyenv/versions/3.11.6/lib/python3.11/site-packages/cryptofeed/connection_handler.py", line 69, in _create_connection
    await self._handler(connection, self.handler)
  File "/Users/simon/.pyenv/versions/3.11.6/lib/python3.11/site-packages/cryptofeed/connection_handler.py", line 119, in _handler
    await handler(message, connection, self.conn.last_message)
  File "/Users/simon/.pyenv/versions/3.11.6/lib/python3.11/site-packages/cryptofeed/exchanges/independent_reserve.py", line 215, in message_handler
    await self._book(msg, timestamp)
  File "/Users/simon/.pyenv/versions/3.11.6/lib/python3.11/site-packages/cryptofeed/exchanges/independent_reserve.py", line 174, in _book
    self._l3_book[instrument][side][price][uuid] = size
    ~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^
TypeError: 'cryptofeed.types.OrderBook' object is not subscriptable
```


- [x] - Tested
- [x] - Changelog updated
- [x] - Tests run and pass
- [x] - Flake8 run and all errors/warnings resolved
- [ ] - Contributors file updated (optional)
