### PR TITLE
Fix fetching symbols from bitmex and bit.com

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -17,3 +17,4 @@ Cryptofeed was originally created by Bryant Moscon, but many others have contrib
 * [QuasarDB](https://quasar.ai/)
 * [Thomas Bouamoud](https://github.com/thomasbs17) - <thomasbs17@yahoo.fr>
 * [Carlo Eugster](https://github.com/carloe) - <carlo@relaun.ch>
+* [Marten Schlüter](https://github.com/maschlr)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,8 @@
  * Update: Bybit migrate to API V5 for public streams
  * Bugfix: Handle None ids for Kraken trades in QuestDB
  * Bugfix: Handle OrderChanged event in IndependentReserve
+ * Bugfix: Remove deprecated `USD` currency from bit.com
+ * Bugfix: Make `entry` key optional when retrieving symbols for BitMex  
 
 ### 2.4.0 (2024-01-07)
  * Update: Fix tests

--- a/cryptofeed/exchanges/bitdotcom.py
+++ b/cryptofeed/exchanges/bitdotcom.py
@@ -5,7 +5,7 @@ import itertools
 import logging
 from decimal import Decimal
 import time
-from typing import Dict, List, Tuple, Union
+from typing import Dict, Tuple
 from collections import defaultdict
 import hashlib
 import hmac
@@ -51,9 +51,9 @@ class BitDotCom(Feed):
         self._sequence_no = defaultdict(int)
 
     @classmethod
-    def _symbol_endpoint_prepare(cls, ep: RestEndpoint) -> Union[List[str], str]:
+    def _symbol_endpoint_prepare(cls, ep: RestEndpoint) -> str:
         if ep.routes.currencies:
-            return [ep.route('instruments').format(currency) for currency in ('USD', 'USDT')]
+            return ep.route('instruments').format('USDT')
         return ep.route('instruments')
 
     @classmethod

--- a/cryptofeed/exchanges/bitmex.py
+++ b/cryptofeed/exchanges/bitmex.py
@@ -58,7 +58,7 @@ class Bitmex(Feed, BitmexRestMixin):
             else:
                 LOG.info('Unsupported type %s for instrument %s', entry['typ'], entry['symbol'])
 
-            s = Symbol(base, quote, type=stype, expiry_date=entry['expiry'])
+            s = Symbol(base, quote, type=stype, expiry_date=entry.get('expiry'))
             if s.normalized not in ret:
                 ret[s.normalized] = entry['symbol']
                 info['tick_size'][s.normalized] = entry['tickSize']


### PR DESCRIPTION
### Description of code - what bug does this fix / what feature does this add?

- [x] - Tested
- [x] - Changelog updated
- [ ] - Tests run and pass (_I get an error when running `python -m unittest` from the main dir, see below_)
- [x] - Flake8 run and all errors/warnings resolved (_no errors in the files I've updated_)
- [x] - Contributors file updated (optional)

*
```
File "/home/marten/code/projects/cryptofeed/cryptofeed/feed.py", line 20, in <module>
    from cryptofeed.types import OrderBook
ModuleNotFoundError: No module named 'cryptofeed.types'
```