### PR TITLE
fix: lock websockets version range

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -18,3 +18,4 @@ Cryptofeed was originally created by Bryant Moscon, but many others have contrib
 * [Thomas Bouamoud](https://github.com/thomasbs17) - <thomasbs17@yahoo.fr>
 * [Carlo Eugster](https://github.com/carloe) - <carlo@relaun.ch>
 * [Marten Schlüter](https://github.com/maschlr)
+* [Kanta | 5000e12](https://github.com/otomarukanta)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@
  * Bugfix: Handle OrderChanged event in IndependentReserve
  * Bugfix: Remove deprecated `USD` currency from bit.com
  * Bugfix: Make `entry` key optional when retrieving symbols for BitMex  
+ * Bugfix: Lock websockets version range
 
 ### 2.4.0 (2024-01-07)
  * Update: Fix tests

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ setup(
     tests_require=["pytest"],
     install_requires=[
         "requests>=2.18.4",
-        "websockets>=10.0",
+        "websockets>=10.0,<14.0",
         "pyyaml",
         "aiohttp==3.10.5",
         "aiofile>=2.0.0",


### PR DESCRIPTION
### Description of code - what bug does this fix / what feature does this add?

- [x] - Tested
- [x] - Changelog updated
- [ ] - Tests run and pass
- [x] - Flake8 run and all errors/warnings resolved
- [x] - Contributors file updated (optional)

The read_limit argument has been removed from websockets as of version 14.0. We have changed to using a version below 14.0.

https://github.com/python-websockets/websockets/blob/main/docs/howto/upgrade.rst#read_limit