### PR TITLE
Add JSON support to `write()` in `HTTPSync` for `POST` requests #1071

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -18,3 +18,4 @@ Cryptofeed was originally created by Bryant Moscon, but many others have contrib
 * [Thomas Bouamoud](https://github.com/thomasbs17) - <thomasbs17@yahoo.fr>
 * [Carlo Eugster](https://github.com/carloe) - <carlo@relaun.ch>
 * [Marten Schlüter](https://github.com/maschlr)
+* [Handel Scholze](https://github.com/HandelSM) - <handel.scholze@gmail.com>

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,9 +1,7 @@
 ## Changelog
 
-### [Unreleased]
- * Added `is_data_json` to `write()` in `HTTPSync` from `connection.py` to support JSON payloads (#1071)
-
 ### 2.4.1
+ * Update: Added `is_data_json` to `write()` in `HTTPSync` from `connection.py` to support JSON payloads (#1071)
  * Bugfix: Handle empty nextFundingRate in OKX
  * Bugfix: Handle null next_funding_time and estimated_rate in HuobiSwap funding
  * Update: transitioned from Coinbase Pro (retired) to Coinbase Advanced Trade

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 ## Changelog
 
+### [Unreleased]
+ * Added `is_data_json` to `write()` in `HTTPSync` from `connection.py` to support JSON payloads (#1071)
+
 ### 2.4.1
  * Bugfix: Handle empty nextFundingRate in OKX
  * Bugfix: Handle null next_funding_time and estimated_rate in HuobiSwap funding

--- a/cryptofeed/connection.py
+++ b/cryptofeed/connection.py
@@ -56,9 +56,13 @@ class HTTPSync(Connection):
         r = requests.get(address, headers=headers, params=params)
         return self.process_response(r, address, json=json, text=text, uuid=uuid)
 
-    def write(self, address: str, data=None, json=False, text=True, uuid=None):
+    def write(self, address: str, data=None, json=False, text=True, uuid=None, is_data_json=False):
         LOG.debug("HTTPSync: post to %s", address)
-        r = requests.post(address, data=data)
+        if (is_data_json):
+            r = requests.post(address, json=data)
+        else:
+            r = requests.post(address, data=data)
+
         return self.process_response(r, address, json=json, text=text, uuid=uuid)
 
 


### PR DESCRIPTION
…loads (#1071)

### Description of code - what bug does this fix / what feature does this add?

This PR adds support for sending JSON payloads in the `write()` method of `HTTPSync`. 
The `write()` method now accepts a new optional boolean parameter `is_data_json` to specify if the data should be sent as JSON.

#### Problem
As described in [issue #1071](https://github.com/bmoscon/cryptofeed/issues/1071), the `write()` method does not allow sending payloads as JSON using the `json` parameter of `requests.post`. This functionality is required for HyperLiquid and could be benefitial for other new exchange implementations, where requests to the info endpoint are POST requests with a JSON body.

#### Solution
- Added the `is_data_json` parameter to the `write()` method.
- When `is_data_json=True`, the payload is sent as JSON.
- The default behavior (using `data`) remains unchanged for backward compatibility.

### Checklist
- [x] Tested
- [x] Changelog updated
- [/] Tests run and pass (same errors as in the `bmoscon/cryptofeed/master` branch, unrelated to this PR)
- [/] Flake8 run and all errors/warnings resolved (same errors as in the `bmoscon/cryptofeed/master` branch, unrelated to this PR)
- [x ] Contributors file updated (optional)

### Related
Closes #1071
