### PR TITLE
fix(binance): add support for TRADIFI_PERPETUAL contract type

### DIFF
--- a/cryptofeed/exchanges/binance.py
+++ b/cryptofeed/exchanges/binance.py
@@ -63,7 +63,7 @@ class Binance(Feed, BinanceRestMixin):
 
             expiration = None
             stype = SPOT
-            if symbol.get('contractType') == 'PERPETUAL':
+            if symbol.get('contractType') in ('PERPETUAL', 'TRADIFI_PERPETUAL'):
                 stype = PERPETUAL
             elif symbol.get('contractType') in ('CURRENT_QUARTER', 'NEXT_QUARTER'):
                 stype = FUTURES


### PR DESCRIPTION
Binance introduced TradeFi futures contracts (e.g., XAUUSDT, XAGUSDT) with a new contractType value "TRADIFI_PERPETUAL". These contracts were not being recognized, causing UnsupportedSymbol errors when subscribing to symbols like XAG-USDT-PERP.

This change adds TRADIFI_PERPETUAL to the list of recognized perpetual contract types in the symbol parsing logic.

Reference: https://www.binance.com/en/support/announcement/detail/ecf7318c0d434c339e80878588e700d0

### Description of code - what bug does this fix / what feature does this add?

- [ ] - Tested
- [ ] - Changelog updated
- [ ] - Tests run and pass
- [ ] - Flake8 run and all errors/warnings resolved
- [ ] - Contributors file updated (optional)
