### PR TITLE
fix: use asyncio.run() in teardown_module to avoid event loop errors (closes #1099)

### DIFF
--- a/tests/integration/rest/test_okx.py
+++ b/tests/integration/rest/test_okx.py
@@ -15,11 +15,7 @@ o = OKX()
 
 
 def teardown_module(module):
-    try:
-        loop = asyncio.get_running_loop()
-    except RuntimeError:
-        loop = asyncio.new_event_loop()
-    loop.run_until_complete(o.shutdown())
+    asyncio.run(o.shutdown())
 
 
 class TestOKXRest:


### PR DESCRIPTION
## What
The `teardown_module` function in `tests/integration/rest/test_okx.py` uses a problematic pattern for event loop management. It calls `asyncio.get_running_loop()` and falls back to `asyncio.new_event_loop()`, but the newly created loop is never set as the current event loop. This causes `RuntimeError: There is no current event loop in thread 'MainThread'` errors in Python 3.10+ where `asyncio.get_event_loop()` no longer implicitly creates a new event loop.

## Fix
Replace the manual event loop handling with `asyncio.run()`, which properly creates a new event loop, sets it as the current loop, runs the coroutine, and cleans up afterward. This is the recommended pattern for running async code from synchronous contexts in Python 3.7+.

Closes #1099